### PR TITLE
Story 1.4-cleanup: Remove User ID Display from Profile Section

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_info_card.dart
+++ b/lib/features/profile/presentation/widgets/profile_info_card.dart
@@ -113,19 +113,7 @@ class ProfileInfoCard extends StatelessWidget {
                 label: l10n.lastActive,
                 value: dateFormat.format(user.lastSignInAt!),
               ),
-              const Divider(height: 24),
             ],
-
-            // User ID
-            _InfoRow(
-              icon: Icons.fingerprint,
-              label: l10n.userId,
-              value: '${user.uid.substring(0, 8)}...',
-              valueStyle: theme.textTheme.bodyMedium?.copyWith(
-                fontFamily: 'monospace',
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
           ],
         ),
       ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -44,8 +44,6 @@
   "regular": "Normal",
   "memberSince": "Mitglied Seit",
   "lastActive": "Zuletzt Aktiv",
-  "userId": "Benutzer-ID",
-  "accountSettings": "Kontoeinstellungen",
   "signOutConfirm": "Möchten Sie sich wirklich abmelden?",
   "pleaseLogIn": "Bitte melden Sie sich an, um Ihr Profil zu sehen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -220,16 +220,6 @@
     "description": "Last active label"
   },
 
-  "userId": "User ID",
-  "@userId": {
-    "description": "User ID label"
-  },
-
-  "accountSettings": "Account Settings",
-  "@accountSettings": {
-    "description": "Account settings button text"
-  },
-
   "signOutConfirm": "Are you sure you want to sign out?",
   "@signOutConfirm": {
     "description": "Sign out confirmation message"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -44,8 +44,6 @@
   "regular": "Regular",
   "memberSince": "Miembro Desde",
   "lastActive": "Última Actividad",
-  "userId": "ID de Usuario",
-  "accountSettings": "Configuración de Cuenta",
   "signOutConfirm": "¿Estás seguro de que quieres cerrar sesión?",
   "pleaseLogIn": "Por favor inicia sesión para ver tu perfil"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -44,8 +44,6 @@
   "regular": "Régulier",
   "memberSince": "Membre Depuis",
   "lastActive": "Dernière Activité",
-  "userId": "ID Utilisateur",
-  "accountSettings": "Paramètres du Compte",
   "signOutConfirm": "Êtes-vous sûr de vouloir vous déconnecter ?",
   "pleaseLogIn": "Veuillez vous connecter pour voir votre profil"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -44,8 +44,6 @@
   "regular": "Normale",
   "memberSince": "Membro Dal",
   "lastActive": "Ultima Attività",
-  "userId": "ID Utente",
-  "accountSettings": "Impostazioni Account",
   "signOutConfirm": "Sei sicuro di voler disconnetterti?",
   "pleaseLogIn": "Effettua l'accesso per visualizzare il tuo profilo"
 }

--- a/test/unit/features/profile/presentation/widgets/profile_info_card_test.dart
+++ b/test/unit/features/profile/presentation/widgets/profile_info_card_test.dart
@@ -132,37 +132,6 @@ void main() {
       expect(find.text('Oct 12, 2024'), findsOneWidget);
     });
 
-    testWidgets('displays truncated user ID', (tester) async {
-      final testUser = UserEntity(
-        uid: 'test-uid-123456789',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        photoUrl: null,
-        isEmailVerified: true,
-        createdAt: DateTime(2024, 1, 1),
-        lastSignInAt: DateTime(2024, 10, 1),
-        isAnonymous: false,
-      );
-
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: const [Locale('en')],
-          home: Scaffold(
-            body: ProfileInfoCard(user: testUser),
-          ),
-        ),
-      );
-
-      expect(find.text('User ID'), findsOneWidget);
-      expect(find.text('test-uid...'), findsOneWidget);
-    });
-
     testWidgets('omits member since when createdAt is null', (tester) async {
       final testUser = UserEntity(
         uid: 'test-uid-123',


### PR DESCRIPTION
## Story 1.4-cleanup: Remove User ID Display from Profile Section

Closes #133

### 📋 Summary

Removed the User ID field from the profile information card for security and privacy reasons. Exposing internal user IDs provides no practical value to end users and could be used in enumeration attacks.

### ✅ Changes Made

**Source Code:**
- Removed User ID `_InfoRow` widget from `ProfileInfoCard` 
- Removed associated divider before User ID field
- Profile now displays: Account Type, Member Since, and Last Active (when available)

**Tests:**
- Removed "displays truncated user ID" test case from `profile_info_card_test.dart`
- All other profile widget tests continue to pass (7/7 tests passing)
- Overall test suite: **304 passing, 5 skipped, 0 failures** ✅

**Translations:**
- Removed `userId` translation key from all ARB files (en, es, fr, de, it)
- Cleaned up duplicate `accountSettings` entries found in ARB files

### 🧪 Testing Results

**Before (main branch):**
- ProfileInfoCard tests: 8 passing (including User ID test)
- Total unit tests: 305 passing

**After (feature branch):**
- ProfileInfoCard tests: 7 passing (User ID test removed as expected)
- Total unit tests: 304 passing ✅
- **All tests pass with 0 failures**

**Code Quality:**
- ✅ `flutter analyze` - No new warnings or errors (230 pre-existing info-level warnings in test files)
- ✅ All changes follow project conventions
- ✅ No regressions in other tests

### 🔒 Security Impact

This change improves security by:
- Not exposing internal user IDs to end users
- Reducing the attack surface for enumeration attacks
- Removing implementation details about the authentication system

### 📸 Before & After

**Before:**
- Account Type
- Member Since  
- Last Active
- **User ID** (test-uid...)

**After:**
- Account Type
- Member Since
- Last Active

### 📚 Related

- Story: #133
- Branch: `feature/story-1.4-cleanup-remove-user-id-display`
- Commit: a541d79

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>