### PR TITLE
Story 11.16: Validate Group Invitations via Social Graph

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,6 +15,7 @@ export {acceptInvitation} from "./acceptInvitation";
 export {declineInvitation} from "./declineInvitation";
 export {getUsersByIds} from "./getUsersByIds";
 export {leaveGroup} from "./leaveGroup";
+export {inviteToGroup} from "./inviteToGroup"; // Story 11.16
 
 // Export friendship functions (callable functions)
 export {

--- a/functions/src/inviteToGroup.ts
+++ b/functions/src/inviteToGroup.ts
@@ -1,0 +1,341 @@
+// Cloud Function for inviting users to groups with social graph validation
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import {checkFriendship} from "./friendships";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface InviteToGroupRequest {
+  groupId: string;
+  invitedUserId: string;
+}
+
+interface InviteToGroupResponse {
+  success: boolean;
+  invitationId: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Check if a user exists in Firestore
+ */
+async function userExists(userId: string): Promise<boolean> {
+  const db = admin.firestore();
+  const userDoc = await db.collection("users").doc(userId).get();
+  return userDoc.exists;
+}
+
+/**
+ * Get user profile data (minimal fields needed)
+ */
+async function getUserProfile(userId: string): Promise<{
+  displayName: string;
+  email: string;
+} | null> {
+  const db = admin.firestore();
+  const userDoc = await db.collection("users").doc(userId).get();
+
+  if (!userDoc.exists) {
+    return null;
+  }
+
+  const userData = userDoc.data()!;
+  return {
+    displayName: userData.displayName || userData.email,
+    email: userData.email,
+  };
+}
+
+/**
+ * Check if group exists and get group data
+ */
+async function getGroupData(groupId: string): Promise<{
+  name: string;
+  createdBy: string;
+  memberIds: string[];
+} | null> {
+  const db = admin.firestore();
+  const groupDoc = await db.collection("groups").doc(groupId).get();
+
+  if (!groupDoc.exists) {
+    return null;
+  }
+
+  const groupData = groupDoc.data()!;
+  return {
+    name: groupData.name,
+    createdBy: groupData.createdBy,
+    memberIds: groupData.memberIds || [],
+  };
+}
+
+/**
+ * Check if user already has a pending invitation for this group
+ */
+async function hasPendingInvitation(
+  userId: string,
+  groupId: string
+): Promise<boolean> {
+  const db = admin.firestore();
+  const invitationsSnapshot = await db
+    .collection("users")
+    .doc(userId)
+    .collection("invitations")
+    .where("groupId", "==", groupId)
+    .where("status", "==", "pending")
+    .limit(1)
+    .get();
+
+  return !invitationsSnapshot.empty;
+}
+
+// Note: Member check is done inline in the handler by accessing groupData.members
+// Keeping this helper for potential future use
+// async function isGroupMember(userId: string, groupId: string): Promise<boolean> {
+//   const groupData = await getGroupData(groupId);
+//   if (!groupData) {
+//     return false;
+//   }
+//   return groupData.members.includes(userId);
+// }
+
+// ============================================================================
+// Cloud Function: Invite to Group
+// ============================================================================
+
+/**
+ * Handler for inviting a user to a group
+ * Story 11.16: Validates friendship via social graph before allowing invitation
+ *
+ * This function enforces the architectural boundary:
+ * Groups layer → Social Graph API (checkFriendship)
+ *
+ * Security validations:
+ * 1. Authenticated user check
+ * 2. Input parameter validation
+ * 3. Group existence check
+ * 4. Group membership check (inviter must be a member)
+ * 5. Friendship validation (inviter and invitee must be friends)
+ * 6. Duplicate invitation check
+ * 7. Self-invitation check
+ */
+export async function inviteToGroupHandler(
+  data: InviteToGroupRequest,
+  context: functions.https.CallableContext
+): Promise<InviteToGroupResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    functions.logger.warn("Unauthenticated inviteToGroup attempt");
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to invite users to groups"
+    );
+  }
+
+  const inviterId = context.auth.uid;
+
+  // 2. Validate input parameters
+  if (!data || typeof data.groupId !== "string") {
+    functions.logger.warn("Missing or invalid groupId", {
+      inviterId,
+    });
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'groupId' is required and must be a string"
+    );
+  }
+
+  if (!data || typeof data.invitedUserId !== "string") {
+    functions.logger.warn("Missing or invalid invitedUserId", {
+      inviterId,
+    });
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'invitedUserId' is required and must be a string"
+    );
+  }
+
+  const {groupId, invitedUserId} = data;
+
+  functions.logger.info("Inviting user to group", {
+    inviterId,
+    invitedUserId,
+    groupId,
+  });
+
+  // 7. Cannot invite yourself
+  if (inviterId === invitedUserId) {
+    functions.logger.warn("Attempt to invite self to group", {
+      inviterId,
+      groupId,
+    });
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "You cannot invite yourself to a group"
+    );
+  }
+
+  try {
+    // 3. Check if group exists
+    const groupData = await getGroupData(groupId);
+    if (!groupData) {
+      functions.logger.warn("Group not found", {
+        inviterId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The group you're trying to invite to doesn't exist"
+      );
+    }
+
+    // 4. Check if inviter is a member of the group
+    if (!groupData.memberIds.includes(inviterId)) {
+      functions.logger.warn("Non-member attempting to invite to group", {
+        inviterId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You must be a member of the group to invite others"
+      );
+    }
+
+    // Check if invitee exists
+    const inviteeExists = await userExists(invitedUserId);
+    if (!inviteeExists) {
+      functions.logger.warn("Invitee user not found", {
+        inviterId,
+        invitedUserId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The user you're trying to invite doesn't exist"
+      );
+    }
+
+    // 5. STORY 11.16: Validate friendship using social graph API
+    // This is the key enforcement of the architectural boundary:
+    // Groups layer queries the social graph via checkFriendship helper
+    const areFriends = await checkFriendship(inviterId, invitedUserId);
+
+    if (!areFriends) {
+      functions.logger.warn("Attempt to invite non-friend to group", {
+        inviterId,
+        invitedUserId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You can only invite friends to groups"
+      );
+    }
+
+    functions.logger.debug("Friendship validated", {
+      inviterId,
+      invitedUserId,
+      groupId,
+    });
+
+    // 6. Check if user is already a member
+    if (groupData.memberIds.includes(invitedUserId)) {
+      functions.logger.warn("User already a member of group", {
+        inviterId,
+        invitedUserId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "This user is already a member of the group"
+      );
+    }
+
+    // Check if there's already a pending invitation
+    const hasPending = await hasPendingInvitation(invitedUserId, groupId);
+    if (hasPending) {
+      functions.logger.warn("Pending invitation already exists", {
+        inviterId,
+        invitedUserId,
+        groupId,
+      });
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "This user already has a pending invitation to this group"
+      );
+    }
+
+    // Get user profiles for denormalized data
+    const inviterProfile = await getUserProfile(inviterId);
+    const inviteeProfile = await getUserProfile(invitedUserId);
+
+    if (!inviterProfile || !inviteeProfile) {
+      functions.logger.error("Failed to retrieve user profiles", {
+        inviterId,
+        invitedUserId,
+        hasInviter: !!inviterProfile,
+        hasInvitee: !!inviteeProfile,
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        "Failed to retrieve user profiles"
+      );
+    }
+
+    // Create invitation document
+    const db = admin.firestore();
+    const invitationRef = await db
+      .collection("users")
+      .doc(invitedUserId)
+      .collection("invitations")
+      .add({
+        groupId,
+        groupName: groupData.name,
+        invitedUserId,
+        invitedBy: inviterId,
+        inviterName: inviterProfile.displayName,
+        status: "pending",
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    functions.logger.info("Group invitation created successfully", {
+      inviterId,
+      invitedUserId,
+      groupId,
+      invitationId: invitationRef.id,
+    });
+
+    return {
+      success: true,
+      invitationId: invitationRef.id,
+    };
+  } catch (error) {
+    // Re-throw HttpsError
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("Error inviting user to group", {
+      inviterId,
+      invitedUserId,
+      groupId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to send group invitation"
+    );
+  }
+}
+
+/**
+ * Cloud Function to invite a user to a group
+ * Story 11.16: Enforces that only confirmed friends can be invited to groups
+ */
+export const inviteToGroup = functions.https.onCall(inviteToGroupHandler);

--- a/functions/test/unit/inviteToGroup.test.ts
+++ b/functions/test/unit/inviteToGroup.test.ts
@@ -1,0 +1,384 @@
+// Unit tests for inviteToGroup Cloud Function
+// Story 11.16: Validate Group Invitations via Social Graph
+
+import * as admin from "firebase-admin";
+import {inviteToGroupHandler} from "../../src/inviteToGroup";
+import * as friendships from "../../src/friendships";
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// Mock friendships module
+jest.mock("../../src/friendships", () => ({
+  checkFriendship: jest.fn(),
+}));
+
+// Mock firebase-functions with logger
+jest.mock("firebase-functions", () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "HttpsError";
+      }
+    },
+    onCall: jest.fn((handler) => handler),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  firestore: {
+    FieldValue: {
+      serverTimestamp: jest.fn(() => "TIMESTAMP"),
+    },
+  },
+}));
+
+// Import functions to access logger
+const functions = require("firebase-functions");
+
+describe("inviteToGroup Cloud Function", () => {
+  let mockDb: any;
+  let mockGroupDoc: any;
+  let mockUserDoc: any;
+  let mockInvitationsCollection: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mock Firestore
+    mockInvitationsCollection = {
+      add: jest.fn().mockImplementation((data) => {
+        // Return a promise that resolves to a reference with id
+        return Promise.resolve({id: "invitation123"});
+      }),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({empty: true}),
+    };
+
+    mockUserDoc = {
+      exists: true,
+      data: () => ({
+        displayName: "Test User",
+        email: "test@example.com",
+      }),
+    };
+
+    mockGroupDoc = {
+      exists: true,
+      data: () => ({
+        name: "Test Group",
+        createdBy: "inviter123",
+        memberIds: ["inviter123", "member456"],
+      }),
+    };
+
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "users") {
+          return {
+            doc: jest.fn((userId: string) => {
+              if (userId === "invitee123" || userId === "inviter123") {
+                return {
+                  get: jest.fn().mockResolvedValue(mockUserDoc),
+                  collection: jest.fn(() => mockInvitationsCollection),
+                };
+              }
+              return {
+                get: jest.fn().mockResolvedValue({exists: false}),
+              };
+            }),
+          };
+        }
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+            })),
+          };
+        }
+        return {};
+      }),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  describe("Authentication and Input Validation", () => {
+    it("should throw unauthenticated error if user is not logged in", async () => {
+      const data = {groupId: "group123", invitedUserId: "user123"};
+      const context = {auth: null};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("You must be logged in to invite users to groups");
+    });
+
+    it("should throw invalid-argument error if groupId is missing", async () => {
+      const data = {invitedUserId: "user123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("Parameter 'groupId' is required and must be a string");
+    });
+
+    it("should throw invalid-argument error if invitedUserId is missing", async () => {
+      const data = {groupId: "group123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow(
+        "Parameter 'invitedUserId' is required and must be a string"
+      );
+    });
+
+    it("should throw invalid-argument error if trying to invite self", async () => {
+      const data = {groupId: "group123", invitedUserId: "inviter123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("You cannot invite yourself to a group");
+    });
+  });
+
+  describe("Group and User Validation", () => {
+    it("should throw not-found error if group doesn't exist", async () => {
+      mockGroupDoc.exists = false;
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow(
+        "The group you're trying to invite to doesn't exist"
+      );
+    });
+
+    it("should throw permission-denied if inviter is not a group member", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Test Group",
+        createdBy: "owner123",
+        memberIds: ["owner123", "otherMember456"],
+      });
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("You must be a member of the group to invite others");
+    });
+
+    it("should throw not-found error if invitee doesn't exist", async () => {
+      mockDb.collection = jest.fn((collectionName: string) => {
+        if (collectionName === "users") {
+          return {
+            doc: jest.fn((userId: string) => {
+              if (userId === "inviter123") {
+                return {
+                  get: jest.fn().mockResolvedValue(mockUserDoc),
+                  collection: jest.fn(() => mockInvitationsCollection),
+                };
+              }
+              // invitee doesn't exist
+              return {
+                get: jest.fn().mockResolvedValue({exists: false}),
+              };
+            }),
+          };
+        }
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+            })),
+          };
+        }
+        return {};
+      });
+
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("The user you're trying to invite doesn't exist");
+    });
+  });
+
+  describe("Friendship Validation (Story 11.16)", () => {
+    it("should throw permission-denied if users are not friends", async () => {
+      // Mock checkFriendship to return false
+      (friendships.checkFriendship as jest.Mock).mockResolvedValue(false);
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("You can only invite friends to groups");
+
+      // Verify checkFriendship was called with correct parameters
+      expect(friendships.checkFriendship).toHaveBeenCalledWith(
+        "inviter123",
+        "invitee123"
+      );
+    });
+
+    it("should proceed with invitation if users are friends", async () => {
+      // Mock checkFriendship to return true
+      (friendships.checkFriendship as jest.Mock).mockResolvedValue(true);
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      const result = await inviteToGroupHandler(data as any, context as any);
+
+      expect(result).toEqual({
+        success: true,
+        invitationId: "invitation123",
+      });
+
+      // Verify checkFriendship was called
+      expect(friendships.checkFriendship).toHaveBeenCalledWith(
+        "inviter123",
+        "invitee123"
+      );
+    });
+  });
+
+  describe("Duplicate and Existing Member Checks", () => {
+    beforeEach(() => {
+      // Mock friendship check to pass
+      (friendships.checkFriendship as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("should throw already-exists if user is already a member", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Test Group",
+        createdBy: "owner123",
+        memberIds: ["inviter123", "invitee123"],
+      });
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("This user is already a member of the group");
+    });
+
+    it("should throw already-exists if pending invitation exists", async () => {
+      mockInvitationsCollection.get.mockResolvedValue({
+        empty: false,
+      });
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow(
+        "This user already has a pending invitation to this group"
+      );
+    });
+  });
+
+  describe("Successful Invitation Creation", () => {
+    beforeEach(() => {
+      // Mock friendship check to pass
+      (friendships.checkFriendship as jest.Mock).mockResolvedValue(true);
+      // Mock no pending invitations
+      mockInvitationsCollection.get.mockResolvedValue({empty: true});
+    });
+
+    it("should create invitation when all validations pass", async () => {
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      const result = await inviteToGroupHandler(data as any, context as any);
+
+      expect(result).toEqual({
+        success: true,
+        invitationId: "invitation123",
+      });
+
+      // Verify invitation was created with correct data
+      expect(mockInvitationsCollection.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupId: "group123",
+          groupName: "Test Group",
+          invitedUserId: "invitee123",
+          invitedBy: "inviter123",
+          inviterName: "Test User",
+          status: "pending",
+        })
+      );
+    });
+
+    it("should log successful invitation creation", async () => {
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await inviteToGroupHandler(data as any, context as any);
+
+      expect(functions.logger.info).toHaveBeenCalledWith(
+        "Group invitation created successfully",
+        expect.objectContaining({
+          inviterId: "inviter123",
+          invitedUserId: "invitee123",
+          groupId: "group123",
+          invitationId: "invitation123",
+        })
+      );
+    });
+  });
+
+  describe("Error Handling", () => {
+    beforeEach(() => {
+      (friendships.checkFriendship as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("should throw internal error if invitation creation fails", async () => {
+      mockInvitationsCollection.add.mockRejectedValue(
+        new Error("Firestore error")
+      );
+
+      const data = {groupId: "group123", invitedUserId: "invitee123"};
+      const context = {auth: {uid: "inviter123"}};
+
+      await expect(
+        inviteToGroupHandler(data as any, context as any)
+      ).rejects.toThrow("Failed to send group invitation");
+
+      expect(functions.logger.error).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements server-side validation to enforce that only confirmed friends can be invited to groups, closing a critical security gap in the group invitation flow.

## Changes

### Cloud Functions
- ✅ **Created `inviteToGroup` Cloud Function** with comprehensive validation:
  - Authentication check
  - Group existence and membership verification
  - **Friendship validation using `checkFriendship` helper** (Story 11.6)
  - Duplicate invitation prevention
  - Clear, user-friendly error messages
- ✅ **Refactored `searchUserByEmail`** to use `checkFriendship` helper instead of direct friendship queries
- ✅ **Enhanced `acceptInvitation`** with group existence validation and debug logging
- ✅ **Enforces architectural boundary**: Groups layer → Social Graph API (no direct friendship collection access)

### Flutter (Mobile App)
- ✅ **Updated `InvitationRepository.sendInvitation()`** to call `inviteToGroup` Cloud Function instead of direct Firestore writes
- ✅ **Enhanced error handling** with user-friendly messages for all error codes:
  - `permission-denied`: "You can only invite friends to groups"
  - `not-found`: "User or group not found"
  - `already-exists`: "Invitation already exists or user is already a member"
  - `invalid-argument`: "Invalid invitation parameters"

### Bug Fixes
- 🐛 **Fixed critical field name mismatch** in `inviteToGroup`: `members` → `memberIds`
  - This was preventing all group invitations from being sent
  - Updated all tests to use correct field name
- 🐛 **Added group existence validation** in `acceptInvitation`
  - Prevents accepting invitations for deleted groups
  - Provides clear error message when group no longer exists

### Tests
- ✅ **Cloud Function unit tests**: 112/112 tests passing
- ✅ **Flutter unit tests**: All tests passing (755+ tests)
- ✅ **Zero linter warnings**: `flutter analyze` passed
- ✅ Added comprehensive test coverage for new functionality
- ✅ Fixed all existing tests to match implementation

### Security
- ✅ **Server-side enforcement**: Prevents bypassing UI validation by calling Firestore directly
- ✅ **Uses cached friendIds**: O(1) friendship lookup performance (Story 11.6)
- ✅ **No secrets committed**: Reviewed pre-commit security checklist

### Deployment
- ✅ **Deployed to all environments**:
  - Dev (playwithme-dev)
  - Staging (playwithme-stg)
  - Production (playwithme-prod)
- ✅ **Manually tested**: Full flow working end-to-end

## Architecture Impact
This implementation completes the layered architecture design:

```
Users → My Community (Social Graph) → Groups → Games
        ↑                              ↓
        └──── checkFriendship API ─────┘
```

**Benefits:**
- Groups layer remains decoupled from friendship storage implementation
- Can evolve social graph independently (followers, blocking, etc.)
- Centralized friendship validation logic
- Scalable with cached lookups

## Test Plan
- [x] Unit tests for Cloud Function validation logic
- [x] Unit tests for Flutter repository error handling
- [x] All existing tests passing
- [x] Manual testing: Invite friends to groups (should succeed)
- [x] Manual testing: Attempt to invite non-friends (should fail with clear error)
- [x] Manual testing: Accept invitation (group appears in list)

## Breaking Changes
⚠️ **Invitation flow now requires Cloud Function**:
- Previous: Direct Firestore writes
- New: Must call `inviteToGroup` Cloud Function
- **Migration**: Already deployed to all environments

## Related Issues
- Closes #204 (Story 11.16)
- Depends on Story 11.6 (checkFriendship helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>