### PR TITLE
Story 11.19: Add Friend Request Button for Non-Friend Group Members

### DIFF
--- a/functions/src/friendships.ts
+++ b/functions/src/friendships.ts
@@ -103,6 +103,16 @@ interface BatchCheckFriendshipResponse {
   };
 }
 
+interface BatchCheckFriendRequestStatusRequest {
+  userIds: string[]; // List of user IDs to check request status with
+}
+
+interface BatchCheckFriendRequestStatusResponse {
+  requestStatuses: {
+    [userId: string]: "none" | "sentByMe" | "receivedFromThem";
+  };
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -219,6 +229,29 @@ export async function sendFriendRequestHandler(
   }
 
   try {
+    // Rate limiting: Check recent requests from this user
+    // Story 11.19: Prevent spam by limiting to 10 requests per hour
+    const db = admin.firestore();
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+    const recentRequests = await db
+      .collection("friendships")
+      .where("initiatorId", "==", currentUserId)
+      .where("createdAt", ">", oneHourAgo)
+      .where("status", "==", "pending")
+      .get();
+
+    if (recentRequests.size >= 10) {
+      functions.logger.warn("Rate limit exceeded for friend requests", {
+        userId: currentUserId,
+        recentRequestCount: recentRequests.size,
+      });
+      throw new functions.https.HttpsError(
+        "resource-exhausted",
+        "You have sent too many friend requests recently. Please try again later."
+      );
+    }
+
     // Check if target user exists
     const targetExists = await userExists(targetUserId);
     if (!targetExists) {
@@ -294,7 +327,6 @@ export async function sendFriendRequestHandler(
     }
 
     // Create new friendship document
-    const db = admin.firestore();
     const friendshipRef = await db.collection("friendships").add({
       initiatorId: currentUserId,
       recipientId: targetUserId,
@@ -1581,4 +1613,166 @@ export async function batchCheckFriendshipHandler(
  */
 export const batchCheckFriendship = functions.https.onCall(
   batchCheckFriendshipHandler
+);
+
+// ============================================================================
+// Story 11.19: Batch Friend Request Status Checking
+// ============================================================================
+
+/**
+ * Cloud Function handler for batch checking friend request statuses
+ * Story 11.19: Performance optimization for group member friendship indicators
+ *
+ * This function optimizes friend request status checking when viewing multiple
+ * group members. Instead of N individual queries (2N Firestore reads), it
+ * performs 2 batch queries to check all pending requests at once.
+ *
+ * Performance:
+ * - Before: N individual checks = 2N Firestore reads
+ * - After: 2 batch queries = 2 Firestore reads
+ * - Savings: (2N-2)/2N reduction (e.g., 90% for 10 users)
+ *
+ * @param data - Request containing array of user IDs to check
+ * @param context - Firebase callable context with auth info
+ * @returns Map of userId -> request status (none/sentByMe/receivedFromThem)
+ */
+export async function batchCheckFriendRequestStatusHandler(
+  data: BatchCheckFriendRequestStatusRequest,
+  context: functions.https.CallableContext
+): Promise<BatchCheckFriendRequestStatusResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to check friend request statuses"
+    );
+  }
+
+  const currentUserId = context.auth.uid;
+
+  // 2. Validate input
+  if (!data || !Array.isArray(data.userIds)) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "userIds must be an array"
+    );
+  }
+
+  if (data.userIds.length === 0) {
+    return {requestStatuses: {}};
+  }
+
+  if (data.userIds.length > 100) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Maximum 100 users can be checked at once"
+    );
+  }
+
+  try {
+    functions.logger.info("Batch checking friend request statuses", {
+      userId: currentUserId,
+      count: data.userIds.length,
+    });
+
+    const db = admin.firestore();
+    const requestStatuses: {
+      [key: string]: "none" | "sentByMe" | "receivedFromThem";
+    } = {};
+
+    // Initialize all users with "none" status
+    for (const userId of data.userIds) {
+      requestStatuses[userId] = "none";
+    }
+
+    // 3. Query 1: Check for requests sent by current user (where they are initiator)
+    // Using 'in' query to batch check multiple recipients
+    // Firestore 'in' limited to 10 items, so batch in chunks
+    for (let i = 0; i < data.userIds.length; i += 10) {
+      const userIdBatch = data.userIds.slice(i, i + 10);
+
+      const sentRequests = await db
+        .collection("friendships")
+        .where("initiatorId", "==", currentUserId)
+        .where("recipientId", "in", userIdBatch)
+        .where("status", "==", "pending")
+        .get();
+
+      sentRequests.docs.forEach((doc) => {
+        const docData = doc.data();
+        const recipientId = docData.recipientId;
+        requestStatuses[recipientId] = "sentByMe";
+      });
+    }
+
+    // 4. Query 2: Check for requests received by current user (where they are recipient)
+    for (let i = 0; i < data.userIds.length; i += 10) {
+      const userIdBatch = data.userIds.slice(i, i + 10);
+
+      const receivedRequests = await db
+        .collection("friendships")
+        .where("initiatorId", "in", userIdBatch)
+        .where("recipientId", "==", currentUserId)
+        .where("status", "==", "pending")
+        .get();
+
+      receivedRequests.docs.forEach((doc) => {
+        const docData = doc.data();
+        const initiatorId = docData.initiatorId;
+        // Only set if not already marked as sentByMe
+        // (shouldn't happen, but just in case)
+        if (requestStatuses[initiatorId] === "none") {
+          requestStatuses[initiatorId] = "receivedFromThem";
+        }
+      });
+    }
+
+    const sentCount = Object.values(requestStatuses).filter(
+      (s) => s === "sentByMe"
+    ).length;
+    const receivedCount = Object.values(requestStatuses).filter(
+      (s) => s === "receivedFromThem"
+    ).length;
+
+    functions.logger.info("Batch friend request status check complete", {
+      userId: currentUserId,
+      totalChecked: data.userIds.length,
+      sentByMe: sentCount,
+      receivedFromThem: receivedCount,
+      none: data.userIds.length - sentCount - receivedCount,
+    });
+
+    return {requestStatuses};
+  } catch (error) {
+    // Re-throw HttpsErrors as-is
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("Error in batch friend request status check", {
+      userId: currentUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to check friend request statuses"
+    );
+  }
+}
+
+/**
+ * Cloud Function: Batch check friend request statuses for multiple users
+ * Story 11.19: Performance optimization for group member lists
+ *
+ * Use this when:
+ * - Displaying group members with friendship indicators
+ * - Showing friend request status for multiple users
+ * - Any UI that needs to show pending request status for N users
+ *
+ * Performance: O(N/10) Firestore reads (due to 'in' query limit of 10)
+ * Still much better than 2N individual reads
+ */
+export const batchCheckFriendRequestStatus = functions.https.onCall(
+  batchCheckFriendRequestStatusHandler
 );

--- a/integration_test/batch_friend_request_status_test.dart
+++ b/integration_test/batch_friend_request_status_test.dart
@@ -1,0 +1,346 @@
+// Integration test for batch friend request status checking
+// Tests real Firestore interactions using Firebase Emulator for Story 11.19
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/firebase_emulator_helper.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await FirebaseEmulatorHelper.initialize();
+  });
+
+  setUp(() async {
+    await FirebaseEmulatorHelper.clearFirestore();
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  tearDown(() async {
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  group('Batch Friend Request Status - Story 11.19', () {
+    test(
+      'Should return correct statuses for multiple users (mix of none, sentByMe, receivedFromThem)',
+      () async {
+        // 1. Create test users
+        final currentUser = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'current@test.com',
+          password: 'password123',
+          displayName: 'Current User',
+        );
+
+        final userNoRequest = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'no-request@test.com',
+          password: 'password123',
+          displayName: 'No Request User',
+        );
+
+        final userSentToMe = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'sent-to-me@test.com',
+          password: 'password123',
+          displayName: 'Sent To Me User',
+        );
+
+        final userISentTo = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'i-sent-to@test.com',
+          password: 'password123',
+          displayName: 'I Sent To User',
+        );
+
+        // 2. Sign in as currentUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'current@test.com',
+          password: 'password123',
+        );
+
+        // 3. Send friend request to userISentTo
+        final sendRequestCallable =
+            FirebaseFunctions.instance.httpsCallable('sendFriendRequest');
+        await sendRequestCallable.call({'targetUserId': userISentTo.uid});
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // 4. Sign in as userSentToMe and send request to currentUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'sent-to-me@test.com',
+          password: 'password123',
+        );
+        await sendRequestCallable.call({'targetUserId': currentUser.uid});
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // 5. Sign back in as currentUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'current@test.com',
+          password: 'password123',
+        );
+
+        // 6. Call batchCheckFriendRequestStatus
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+        final result = await batchCheckCallable.call({
+          'userIds': [
+            userNoRequest.uid,
+            userSentToMe.uid,
+            userISentTo.uid,
+          ],
+        });
+
+        expect(result.data, isNotNull);
+        expect(result.data['requestStatuses'], isNotNull);
+
+        final statuses =
+            Map<String, dynamic>.from(result.data['requestStatuses'] as Map);
+
+        // 7. Verify each status
+        expect(statuses[userNoRequest.uid], equals('none'));
+        expect(statuses[userSentToMe.uid], equals('receivedFromThem'));
+        expect(statuses[userISentTo.uid], equals('sentByMe'));
+      },
+    );
+
+    test(
+      'Should return empty map for empty userIds list',
+      () async {
+        // 1. Create and sign in as test user
+        await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'test@test.com',
+          password: 'password123',
+          displayName: 'Test User',
+        );
+
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'test@test.com',
+          password: 'password123',
+        );
+
+        // 2. Call batchCheckFriendRequestStatus with empty list
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+        final result = await batchCheckCallable.call({
+          'userIds': [],
+        });
+
+        expect(result.data, isNotNull);
+        expect(result.data['requestStatuses'], isNotNull);
+
+        final statuses =
+            Map<String, dynamic>.from(result.data['requestStatuses'] as Map);
+        expect(statuses.isEmpty, isTrue);
+      },
+    );
+
+    test(
+      'Should handle large batch of users (50 users)',
+      () async {
+        // 1. Create current user
+        final currentUser = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'current@test.com',
+          password: 'password123',
+          displayName: 'Current User',
+        );
+
+        // 2. Create 50 test users
+        final List<String> userIds = [];
+        for (int i = 0; i < 50; i++) {
+          final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+            email: 'user$i@test.com',
+            password: 'password123',
+            displayName: 'User $i',
+          );
+          userIds.add(user.uid);
+        }
+
+        // 3. Sign in as currentUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'current@test.com',
+          password: 'password123',
+        );
+
+        // 4. Send requests to first 10 users
+        final sendRequestCallable =
+            FirebaseFunctions.instance.httpsCallable('sendFriendRequest');
+        for (int i = 0; i < 10; i++) {
+          await sendRequestCallable.call({'targetUserId': userIds[i]});
+        }
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // 5. Call batchCheckFriendRequestStatus
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+        final result = await batchCheckCallable.call({
+          'userIds': userIds,
+        });
+
+        expect(result.data, isNotNull);
+        expect(result.data['requestStatuses'], isNotNull);
+
+        final statuses =
+            Map<String, dynamic>.from(result.data['requestStatuses'] as Map);
+
+        // 6. Verify all 50 users have status
+        expect(statuses.length, equals(50));
+
+        // 7. Verify first 10 are sentByMe
+        for (int i = 0; i < 10; i++) {
+          expect(statuses[userIds[i]], equals('sentByMe'));
+        }
+
+        // 8. Verify remaining are none
+        for (int i = 10; i < 50; i++) {
+          expect(statuses[userIds[i]], equals('none'));
+        }
+      },
+    );
+
+    test(
+      'Should reject more than 100 users',
+      () async {
+        // 1. Create and sign in as test user
+        await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'test@test.com',
+          password: 'password123',
+          displayName: 'Test User',
+        );
+
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'test@test.com',
+          password: 'password123',
+        );
+
+        // 2. Create list of 101 fake user IDs
+        final List<String> userIds =
+            List.generate(101, (i) => 'fake-user-id-$i');
+
+        // 3. Call batchCheckFriendRequestStatus should fail
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+
+        expect(
+          () => batchCheckCallable.call({'userIds': userIds}),
+          throwsA(
+            isA<FirebaseFunctionsException>().having(
+              (e) => e.code,
+              'code',
+              'invalid-argument',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'Should require authentication',
+      () async {
+        // 1. Ensure signed out
+        await FirebaseEmulatorHelper.signOut();
+
+        // 2. Try to call batchCheckFriendRequestStatus without auth
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+
+        expect(
+          () => batchCheckCallable.call({
+            'userIds': ['fake-user-id'],
+          }),
+          throwsA(
+            isA<FirebaseFunctionsException>().having(
+              (e) => e.code,
+              'code',
+              'unauthenticated',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'Should handle mix of friends and non-friends correctly',
+      () async {
+        // 1. Create test users
+        final currentUser = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'current@test.com',
+          password: 'password123',
+          displayName: 'Current User',
+        );
+
+        final friendUser = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'friend@test.com',
+          password: 'password123',
+          displayName: 'Friend User',
+        );
+
+        final pendingUser = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'pending@test.com',
+          password: 'password123',
+          displayName: 'Pending User',
+        );
+
+        // 2. Create accepted friendship with friendUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'current@test.com',
+          password: 'password123',
+        );
+
+        final sendRequestCallable =
+            FirebaseFunctions.instance.httpsCallable('sendFriendRequest');
+        final requestResult =
+            await sendRequestCallable.call({'targetUserId': friendUser.uid});
+        final friendshipId = requestResult.data['friendshipId'];
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // Accept the friend request
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'friend@test.com',
+          password: 'password123',
+        );
+
+        final acceptCallable =
+            FirebaseFunctions.instance.httpsCallable('acceptFriendRequest');
+        await acceptCallable.call({'friendshipId': friendshipId});
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // 3. Send pending request to pendingUser
+        await FirebaseEmulatorHelper.signOut();
+        await FirebaseEmulatorHelper.signIn(
+          email: 'current@test.com',
+          password: 'password123',
+        );
+
+        await sendRequestCallable.call({'targetUserId': pendingUser.uid});
+        await FirebaseEmulatorHelper.waitForFirestore();
+
+        // 4. Call batchCheckFriendRequestStatus
+        // Note: friendUser should NOT appear in request statuses because they're already friends
+        final batchCheckCallable = FirebaseFunctions.instance
+            .httpsCallable('batchCheckFriendRequestStatus');
+        final result = await batchCheckCallable.call({
+          'userIds': [
+            friendUser.uid,
+            pendingUser.uid,
+          ],
+        });
+
+        final statuses =
+            Map<String, dynamic>.from(result.data['requestStatuses'] as Map);
+
+        // 5. Verify: friendUser shows 'none' (they're friends, not pending)
+        // and pendingUser shows 'sentByMe'
+        expect(statuses[friendUser.uid], equals('none'));
+        expect(statuses[pendingUser.uid], equals('sentByMe'));
+      },
+    );
+  });
+}

--- a/lib/core/domain/repositories/friend_repository.dart
+++ b/lib/core/domain/repositories/friend_repository.dart
@@ -47,6 +47,22 @@ abstract class FriendRepository {
   /// Maximum 100 users can be checked at once
   /// Throws [FriendshipException] on error
   Future<Map<String, bool>> batchCheckFriendship(List<String> userIds);
+
+  /// Check if there's a pending friend request between two users
+  /// Returns the status of any pending request
+  /// Throws [FriendshipException] on error
+  Future<FriendRequestStatus> getFriendRequestStatus(
+    String currentUserId,
+    String targetUserId,
+  );
+
+  /// Batch check friend request status for multiple users
+  /// Returns map of userId → FriendRequestStatus
+  /// Maximum 100 users can be checked at once
+  /// Throws [FriendshipException] on error
+  Future<Map<String, FriendRequestStatus>> batchCheckFriendRequestStatus(
+    List<String> userIds,
+  );
 }
 
 /// Type of friend request to filter by
@@ -56,6 +72,18 @@ enum FriendRequestType {
 
   /// Requests received by current user
   received,
+}
+
+/// Status of a friend request between two users
+enum FriendRequestStatus {
+  /// No request exists
+  none,
+
+  /// Current user sent a request to target user
+  sentByMe,
+
+  /// Target user sent a request to current user
+  receivedFromThem,
 }
 
 /// Custom exception for friendship-related errors

--- a/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
+++ b/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
@@ -1,0 +1,219 @@
+// Widget for displaying group member with friendship status and add friend button
+import 'package:flutter/material.dart';
+import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
+
+/// Displays a group member with their friendship status and action buttons
+class MemberListItemWithFriendship extends StatelessWidget {
+  final UserModel user;
+  final bool isAdmin;
+  final bool isCreator;
+  final bool isCurrentUser;
+  final String currentUserId;
+  final bool isFriend;
+  final FriendRequestStatus requestStatus;
+  final VoidCallback? onRefresh;
+  final Function(String targetUserId)? onSendFriendRequest;
+
+  const MemberListItemWithFriendship({
+    super.key,
+    required this.user,
+    required this.isAdmin,
+    required this.isCreator,
+    required this.isCurrentUser,
+    required this.currentUserId,
+    required this.isFriend,
+    required this.requestStatus,
+    this.onRefresh,
+    this.onSendFriendRequest,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundImage:
+            user.photoUrl != null ? NetworkImage(user.photoUrl!) : null,
+        child: user.photoUrl == null
+            ? Text(
+                _getInitials(user.displayName ?? user.email),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              )
+            : null,
+      ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              user.displayName ?? user.email,
+              style: const TextStyle(fontWeight: FontWeight.w500),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (isCurrentUser) ...[
+            const SizedBox(width: 8),
+            Text(
+              '(You)',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.primary,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+          if (isAdmin) ...[
+            const SizedBox(width: 8),
+            Chip(
+              label: const Text(
+                'Admin',
+                style: TextStyle(fontSize: 12),
+              ),
+              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+              labelStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onPrimaryContainer,
+                fontWeight: FontWeight.bold,
+              ),
+              padding: EdgeInsets.zero,
+            ),
+          ],
+          if (isCreator) ...[
+            const SizedBox(width: 8),
+            Icon(
+              Icons.star,
+              size: 16,
+              color: Colors.amber[700],
+            ),
+          ],
+        ],
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (user.displayName != null) Text(user.email),
+          if (!isCurrentUser) _buildFriendshipStatus(context),
+        ],
+      ),
+      trailing: !isCurrentUser ? _buildTrailingWidget(context) : null,
+    );
+  }
+
+  String _getInitials(String name) {
+    final parts = name.trim().split(' ');
+    if (parts.isEmpty) return '?';
+    if (parts.length == 1) {
+      return parts[0].substring(0, 1).toUpperCase();
+    }
+    return (parts[0].substring(0, 1) + parts[1].substring(0, 1)).toUpperCase();
+  }
+
+  Widget _buildFriendshipStatus(BuildContext context) {
+    if (isFriend) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.check_circle,
+            size: 16,
+            color: Colors.green[700],
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'Friend',
+            style: TextStyle(
+              color: Colors.green[700],
+              fontSize: 12,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (requestStatus == FriendRequestStatus.sentByMe) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.schedule,
+            size: 16,
+            color: Colors.orange[700],
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'Request Sent',
+            style: TextStyle(
+              color: Colors.orange[700],
+              fontSize: 12,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (requestStatus == FriendRequestStatus.receivedFromThem) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.person_add,
+            size: 16,
+            color: Colors.blue[700],
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'Wants to be friends',
+            style: TextStyle(
+              color: Colors.blue[700],
+              fontSize: 12,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Text(
+      'Not in Community',
+      style: TextStyle(
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+        fontSize: 12,
+      ),
+    );
+  }
+
+  Widget? _buildTrailingWidget(BuildContext context) {
+    if (isFriend) {
+      return null; // Already friends, no action needed
+    }
+
+    if (requestStatus == FriendRequestStatus.sentByMe) {
+      return Chip(
+        label: const Text('Pending'),
+        backgroundColor: Colors.orange.shade100,
+        labelStyle: TextStyle(
+          color: Colors.orange[900],
+          fontSize: 11,
+        ),
+      );
+    }
+
+    if (requestStatus == FriendRequestStatus.receivedFromThem) {
+      // Show accept/decline buttons for incoming requests
+      // Note: This is a simplified version - full implementation would
+      // require access to the friendshipId
+      return const SizedBox.shrink();
+    }
+
+    // Not in community - show add button
+    return IconButton(
+      icon: const Icon(Icons.person_add_outlined),
+      onPressed: () => _sendFriendRequest(context),
+      tooltip: 'Add to Community',
+      color: Theme.of(context).colorScheme.primary,
+      iconSize: 24,
+    );
+  }
+
+  void _sendFriendRequest(BuildContext context) {
+    if (onSendFriendRequest != null) {
+      onSendFriendRequest!(user.uid);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR implements the ability for users to send friend requests to group members who are not yet in their community, facilitating organic social network growth through shared group participation.

## Changes

### Cloud Functions (Backend)
- **Added `batchCheckFriendRequestStatus` Cloud Function** for efficient batch checking of friend request statuses
  - Optimizes from 2N individual Firestore reads to O(N/10) batch reads
  - Handles up to 100 users per request  
  - Returns status map: none, sentByMe, receivedFromThem
- **Implemented rate limiting** in sendFriendRequest Cloud Function
  - Limit: 10 friend requests per hour per user
  - Prevents spam and abuse
  - Returns resource-exhausted error when limit exceeded

### Repository Layer  
- **Added `FriendRequestStatus` enum** to track the status of friend requests (none, sentByMe, receivedFromThem)
- **Implemented `getFriendRequestStatus()` method** in FriendRepository to check pending friend requests between two users
- **Implemented `batchCheckFriendRequestStatus()` method** in FriendRepository using new Cloud Function
- **Added rate limit error handling** for resource-exhausted responses
- Leverages existing `batchCheckFriendship()` method from Story 11.17 for friendship checking

### UI Layer
- **Created `MemberListItemWithFriendship` widget** that displays:
  - Current user with "(You)" label
  - Friends with green checkmark (✓) and "Friend" label
  - Non-friends with "Not in Community" label and add button (➕)
  - Pending sent requests with "Request Sent" (⏳) indicator  
  - Pending received requests with "Wants to be friends" indicator
- **Enhanced GroupDetailsPage** to:
  - Load friendship status for all group members using batch checking
  - Load request status for non-friends using batch checking
  - Display loading indicators while checking friendships
  - Handle friend request sending with proper error handling via callbacks
  - Refresh friendship status after sending requests
  - Optimize queries: only check request status for non-friends

### Testing
- **Added 8 comprehensive unit tests** for `getFriendRequestStatus()` method
  - Tests cover all scenarios: sentByMe, receivedFromThem, none
  - Tests authentication, permission, and error handling
- **Added 6 integration tests** for batch friend request status checking
  - Tests mix of statuses (none, sentByMe, receivedFromThem)
  - Tests empty lists, large batches (50 users), limit validation (>100)
  - Tests authentication requirements
  - Tests interaction with friendships
- **All tests passing**: 125 Cloud Functions tests ✅, 774 Flutter tests ✅

## Performance Optimization

### Before (Individual Queries):
- Checking friendship: 1 Firestore read (using cached friendIds - O(1))
- Checking request status: 2N Firestore reads (2 queries per non-friend)
- **Total: 2N reads for group of N non-friend members**

### After (Batch Queries):
- Checking friendship: 1 Firestore read (using cached friendIds - O(1))
- Checking request status: O(N/10) Firestore reads (batched in chunks of 10)
- **Total: O(N/10) reads for group of N non-friend members**
- **Savings: ~90% reduction in Firestore reads**

## Architecture Alignment
This feature maintains the layered architecture:
- ✅ Groups **query** the social graph (via `batchCheckFriendship()`)
- ✅ Groups **call** social graph APIs (via `sendFriendRequest()` and `batchCheckFriendRequestStatus()`)
- ✅ Social graph remains **unaware** of groups
- ✅ No reverse dependencies created
- ✅ Friend requests work identically regardless of origin

## Security & Quality
- **Duplicate prevention**: Existing Cloud Function logic prevents duplicate requests
- **Rate limiting**: 10 requests per hour prevents spam and abuse
- **Authentication**: All Cloud Functions validate auth tokens
- **Input validation**: Parameter types and limits enforced
- **Error handling**: User-friendly error messages for all failure scenarios
- **Security checklist**: Verified - no secrets committed
- **Code quality**: 0 new errors, only pre-existing warnings in unrelated code

## Visual Design
- **Friend**: Green ✓ indicator + "Friend" label
- **Request Sent**: Orange ⏳ indicator + "Request Sent" label + "Pending" chip
- **Request Received**: Blue ➕ indicator + "Wants to be friends" label
- **Not in Community**: Grey text + ➕ add button
- Matches existing PlayWithMe design patterns

## Bug Fixes
- Fixed duplicate db variable declaration in Cloud Functions
- Fixed SnackBar floating behavior conflict with FAB
- Fixed provider error by using callback pattern instead of direct BLoC access
- Used Date instead of Timestamp.fromMillis for test compatibility

## Testing Checklist
- [x] All unit tests passing (46/46 in friend repository)
- [x] All Cloud Functions tests passing (125/125)
- [x] All Flutter tests passing (774/774)
- [x] Integration tests added and passing (6 new tests)
- [x] Flutter analyze: 0 new warnings
- [x] Security checklist verified
- [x] Manual testing: Feature works correctly in app
- [x] UI tested: No SnackBar or provider errors
- [x] Cloud Functions compile successfully

## Related Issues
Closes #206