### PR TITLE
Story 3.8: Notify Group Members When Game is Created

### DIFF
--- a/functions/test/unit/onGameCreated.test.ts
+++ b/functions/test/unit/onGameCreated.test.ts
@@ -148,17 +148,23 @@ describe("onGameCreated Cloud Function", () => {
 
   describe("Notification sending", () => {
     it("should send notification to all group members except creator", async () => {
+      const mockScheduledAt = {
+        toDate: () => new Date("2025-12-01T14:00:00Z"),
+      };
+
       const snapshot = {
         data: () => ({
           title: "Beach Volleyball",
           createdBy: "creator123",
           groupId: "group123",
+          scheduledAt: mockScheduledAt,
+          location: {name: "Sunset Beach"},
         }),
         id: "game123",
       };
 
       const context = {
-        params: {groupId: "group123", gameId: "game123"},
+        params: {gameId: "game123"},
       };
 
       await onGameCreatedHandler(snapshot, context);
@@ -168,9 +174,9 @@ describe("onGameCreated Cloud Function", () => {
 
       const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
       expect(callArgs.tokens).toEqual(["token1", "token2", "token3"]);
-      expect(callArgs.notification.title).toBe("New Game in Test Group");
-      expect(callArgs.notification.body).toContain("Creator User created a new game");
-      expect(callArgs.notification.body).toContain("Beach Volleyball");
+      expect(callArgs.notification.title).toBe("New Game: Beach Volleyball");
+      expect(callArgs.notification.body).toContain("Creator User created a game");
+      expect(callArgs.notification.body).toContain("Sunset Beach");
       expect(callArgs.data.type).toBe("game_created");
       expect(callArgs.data.gameId).toBe("game123");
     });
@@ -199,19 +205,21 @@ describe("onGameCreated Cloud Function", () => {
       const snapshot = {
         data: () => ({
           createdBy: "creator123",
+          groupId: "group123",
           // No title
         }),
         id: "game123",
       };
 
       const context = {
-        params: {groupId: "group123", gameId: "game123"},
+        params: {gameId: "game123"},
       };
 
       await onGameCreatedHandler(snapshot, context);
 
       const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
-      expect(callArgs.notification.body).toBe("Creator User created a new game");
+      expect(callArgs.notification.title).toBe("New Game: Game");
+      expect(callArgs.notification.body).toContain("Creator User created a game at TBD");
     });
   });
 
@@ -260,12 +268,13 @@ describe("onGameCreated Cloud Function", () => {
       const snapshot = {
         data: () => ({
           createdBy: "creator123",
+          groupId: "group123",
         }),
         id: "game123",
       };
 
       const context = {
-        params: {groupId: "group123", gameId: "game123"},
+        params: {gameId: "game123"},
       };
 
       await onGameCreatedHandler(snapshot, context);
@@ -396,18 +405,19 @@ describe("onGameCreated Cloud Function", () => {
       const snapshot = {
         data: () => ({
           createdBy: "nonexistent",
+          groupId: "group123",
         }),
         id: "game123",
       };
 
       const context = {
-        params: {groupId: "group123", gameId: "game123"},
+        params: {gameId: "game123"},
       };
 
       await onGameCreatedHandler(snapshot, context);
 
       const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
-      expect(callArgs.notification.body).toContain("Someone created a new game");
+      expect(callArgs.notification.body).toContain("Someone created a game at TBD");
     });
   });
 


### PR DESCRIPTION
## Summary
Implements Story 3.8: Notify Group Members When Game is Created

This PR adds push notifications to all group members (except the creator) when a new game is created.

## Changes Made

### Cloud Function Updates
- Fixed trigger path from `groups/{groupId}/games/{gameId}` to `games/{gameId}` to match the actual Firestore structure
- Changed groupId retrieval from `context.params.groupId` to `game.groupId` (from document data)
- Added date formatting to notification body using `Intl.DateTimeFormatOptions`
- Added location formatting to notification body
- Improved creator name resolution with fallback chain: firstName+lastName → displayName → email → "Someone"
- Updated notification title format to "New Game: {GameTitle}"
- Updated notification body to "{CreatorName} created a game on {Date} at {Location}"

### Test Updates
- Updated all 13 existing unit tests to match new implementation
- Fixed test context structure to use `{gameId}` instead of `{groupId, gameId}`
- Added `scheduledAt`, `location`, and `groupId` fields to test game data
- Updated expected notification messages to match new format
- All tests passing (166 tests across 10 test suites)

## Testing

### Unit Tests
✅ All 13 onGameCreated tests passing
✅ Full test suite: 166 tests passed across 10 test suites

### Manual Testing
✅ Created game from iOS simulator → Android emulator received notification
✅ Notification displays correct format with date and location
✅ Creator does not receive notification (as expected)

### Deployment
✅ Deployed to dev environment
✅ Deployed to staging environment  
✅ Deployed to production environment

## Notification Format

**Title:** "New Game: Beach Volleyball"  
**Body:** "John Doe created a game on Dec 4, 2:00 PM at Sunset Beach"

## Closes

Closes #223