### PR TITLE
Story 14.7: Add Game History Page

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -87,6 +87,24 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "games",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "playerIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "completedAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/getCompletedGames.ts
+++ b/functions/src/getCompletedGames.ts
@@ -1,0 +1,277 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Request interface for getCompletedGames Cloud Function
+ */
+export interface GetCompletedGamesRequest {
+  groupId?: string; // Optional - null/undefined means all groups
+  userId?: string; // Optional - filter by player participation
+  startDate?: string; // ISO date string
+  endDate?: string; // ISO date string
+  limit?: number; // Number of games to return (default: 20)
+  lastGameId?: string; // For pagination - ID of last game from previous page
+}
+
+/**
+ * Completed game data returned by the function
+ */
+export interface CompletedGameData {
+  id: string;
+  title: string;
+  description?: string;
+  groupId: string;
+  createdBy: string;
+  createdAt: FirebaseFirestore.Timestamp;
+  scheduledAt: FirebaseFirestore.Timestamp;
+  completedAt?: FirebaseFirestore.Timestamp;
+  location: {
+    name: string;
+    address?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+  status: string;
+  playerIds: string[];
+  teams?: {
+    teamAPlayerIds: string[];
+    teamBPlayerIds: string[];
+  };
+  result?: {
+    games: Array<{
+      setNumber: number;
+      teamAScore: number;
+      teamBScore: number;
+      winner: string;
+    }>;
+    overallWinner: string;
+  };
+  eloCalculated: boolean;
+}
+
+/**
+ * Response interface for getCompletedGames Cloud Function
+ */
+export interface GetCompletedGamesResponse {
+  games: CompletedGameData[];
+  hasMore: boolean;
+}
+
+/**
+ * Handler function for getting completed games (exported for testing)
+ *
+ * Security:
+ * - Validates user authentication
+ * - For groupId queries: Verifies user is a member of the group
+ * - For cross-group queries: Only returns games the user participated in
+ * - Returns only completed games with pagination support
+ * - Uses Admin SDK to bypass Firestore security rules
+ *
+ * @param data - Request data with optional filters
+ * @param context - Firebase Functions context with auth information
+ * @returns Promise resolving to GetCompletedGamesResponse
+ */
+export async function getCompletedGamesHandler(
+  data: GetCompletedGamesRequest,
+  context: functions.https.CallableContext
+): Promise<GetCompletedGamesResponse> {
+  // Validate authentication
+  if (!context.auth) {
+    functions.logger.warn("Unauthenticated request to getCompletedGames");
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "User must be authenticated to view game history"
+    );
+  }
+
+  const currentUserId = context.auth.uid;
+  const {groupId, userId, startDate, endDate, limit = 20, lastGameId} = data;
+
+  functions.logger.info("Fetching completed games", {
+    currentUserId,
+    groupId,
+    userId,
+    startDate,
+    endDate,
+    limit,
+    lastGameId,
+  });
+
+  const db = admin.firestore();
+
+  try {
+    // If groupId is specified, verify user is a member
+    if (groupId) {
+      const groupDoc = await db.collection("groups").doc(groupId).get();
+
+      if (!groupDoc.exists) {
+        functions.logger.warn("Group not found", {
+          currentUserId,
+          groupId,
+        });
+        throw new functions.https.HttpsError(
+          "not-found",
+          "Group not found"
+        );
+      }
+
+      const groupData = groupDoc.data();
+      if (!groupData) {
+        throw new functions.https.HttpsError(
+          "internal",
+          "Failed to read group data"
+        );
+      }
+
+      const memberIds = groupData.memberIds || [];
+      if (!memberIds.includes(currentUserId)) {
+        functions.logger.warn("User not a member of group", {
+          currentUserId,
+          groupId,
+        });
+        throw new functions.https.HttpsError(
+          "permission-denied",
+          "You must be a member of this group to view its game history"
+        );
+      }
+    }
+
+    // Build query
+    let query: FirebaseFirestore.Query = db.collection("games");
+
+    // Filter by status (completed games only)
+    query = query.where("status", "==", "completed");
+
+    // Filter by groupId if specified
+    if (groupId) {
+      query = query.where("groupId", "==", groupId);
+    }
+
+    // For cross-group queries, filter by user participation
+    // This is a security measure - users can only see games they played in
+    if (!groupId || userId) {
+      const filterUserId = userId || currentUserId;
+      query = query.where("playerIds", "array-contains", filterUserId);
+    }
+
+    // Filter by date range
+    if (startDate) {
+      const start = admin.firestore.Timestamp.fromDate(new Date(startDate));
+      query = query.where("completedAt", ">=", start);
+    }
+    if (endDate) {
+      const end = admin.firestore.Timestamp.fromDate(new Date(endDate));
+      query = query.where("completedAt", "<=", end);
+    }
+
+    // Order by completedAt (most recent first)
+    query = query.orderBy("completedAt", "desc");
+
+    // Handle pagination
+    if (lastGameId) {
+      const lastGameDoc = await db.collection("games").doc(lastGameId).get();
+      if (lastGameDoc.exists) {
+        query = query.startAfter(lastGameDoc);
+      }
+    }
+
+    // Fetch limit + 1 to check if there are more results
+    query = query.limit(limit + 1);
+
+    const gamesSnapshot = await query.get();
+
+    const hasMore = gamesSnapshot.docs.length > limit;
+    const gameDocs = hasMore ?
+      gamesSnapshot.docs.slice(0, limit) :
+      gamesSnapshot.docs;
+
+    const games: CompletedGameData[] = [];
+
+    for (const doc of gameDocs) {
+      if (doc.exists) {
+        const gameData = doc.data();
+
+        games.push({
+          id: doc.id,
+          title: gameData.title,
+          description: gameData.description,
+          groupId: gameData.groupId,
+          createdBy: gameData.createdBy,
+          createdAt: gameData.createdAt,
+          scheduledAt: gameData.scheduledAt,
+          completedAt: gameData.completedAt,
+          location: gameData.location,
+          status: gameData.status,
+          playerIds: gameData.playerIds || [],
+          teams: gameData.teams,
+          result: gameData.result,
+          eloCalculated: gameData.eloCalculated ?? false,
+        });
+      }
+    }
+
+    functions.logger.info("Completed games fetched successfully", {
+      currentUserId,
+      groupId,
+      userId,
+      gamesCount: games.length,
+      hasMore,
+    });
+
+    return {games, hasMore};
+  } catch (error) {
+    // Re-throw HttpsError as-is
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    // Log and wrap unexpected errors
+    functions.logger.error("Error fetching completed games", {
+      currentUserId,
+      groupId,
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to fetch completed games"
+    );
+  }
+}
+
+/**
+ * Cloud Function to securely fetch completed games with pagination.
+ *
+ * This function allows users to retrieve their game history with flexible filtering:
+ * - By group: Returns completed games for a specific group (requires membership)
+ * - Cross-group: Returns all completed games the user participated in (any group)
+ * - By date range: Filter games by completion date
+ * - By player: Filter to specific player's games
+ *
+ * Security:
+ * - Requires authentication
+ * - For group-specific queries: Validates user is a member
+ * - For cross-group queries: Automatically filters to user's own games only
+ * - Uses Admin SDK to bypass security rules (centralized permission check)
+ *
+ * Pagination:
+ * - Returns up to `limit` games (default: 20)
+ * - Provides `hasMore` flag to indicate if more results exist
+ * - Use `lastGameId` to fetch next page
+ *
+ * Usage from Flutter:
+ * ```dart
+ * final callable = FirebaseFunctions.instance.httpsCallable('getCompletedGames');
+ * final result = await callable.call({
+ *   'groupId': 'group-123', // optional
+ *   'userId': 'user-456',   // optional
+ *   'limit': 20,
+ *   'lastGameId': 'game-789' // for pagination
+ * });
+ * ```
+ */
+export const getCompletedGames = functions.https.onCall(
+  getCompletedGamesHandler
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,6 +17,7 @@ export {getUsersByIds} from "./getUsersByIds";
 export {leaveGroup} from "./leaveGroup";
 export {inviteToGroup} from "./inviteToGroup"; // Story 11.16
 export {getGamesForGroup} from "./getGamesForGroup"; // Story 3.5
+export {getCompletedGames} from "./getCompletedGames"; // Story 14.7
 
 // Export friendship functions (callable functions)
 export {

--- a/lib/core/domain/repositories/game_repository.dart
+++ b/lib/core/domain/repositories/game_repository.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 import '../../data/models/game_model.dart';
 
 abstract class GameRepository {
@@ -131,4 +133,34 @@ abstract class GameRepository {
 
   /// Get game statistics
   Future<Map<String, dynamic>> getGameStats(String gameId);
+
+  /// Get completed games for a group with pagination (Story 14.7)
+  /// Returns a stream of completed games with pagination support
+  /// [groupId] - Optional group to fetch games for (null = all groups)
+  /// [limit] - Number of games per page (default: 20)
+  /// [userId] - Optional user ID to filter games (null = all games)
+  /// [startDate] - Optional start date filter
+  /// [endDate] - Optional end date filter
+  /// [lastDocument] - Last document from previous page (for pagination)
+  Stream<GameHistoryPage> getCompletedGames({
+    String? groupId,
+    int limit = 20,
+    String? userId,
+    DateTime? startDate,
+    DateTime? endDate,
+    DocumentSnapshot? lastDocument,
+  });
+}
+
+/// Container for paginated game history results
+class GameHistoryPage {
+  final List<GameModel> games;
+  final DocumentSnapshot? lastDocument;
+  final bool hasMore;
+
+  const GameHistoryPage({
+    required this.games,
+    this.lastDocument,
+    required this.hasMore,
+  });
 }

--- a/lib/features/games/presentation/bloc/game_history/game_history_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_history/game_history_bloc.dart
@@ -1,0 +1,167 @@
+// BLoC for managing game history with pagination and filters (Story 14.7)
+
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/domain/repositories/game_repository.dart';
+import 'game_history_event.dart';
+import 'game_history_state.dart';
+
+class GameHistoryBloc extends Bloc<GameHistoryEvent, GameHistoryState> {
+  final GameRepository _gameRepository;
+
+  DocumentSnapshot? _lastDocument;
+  String? _currentGroupId; // null means all groups
+  String? _currentUserId;
+  GameHistoryFilter _currentFilter = GameHistoryFilter.all;
+  DateTime? _startDate;
+  DateTime? _endDate;
+
+  GameHistoryBloc({
+    required GameRepository gameRepository,
+  })  : _gameRepository = gameRepository,
+        super(const GameHistoryState.initial()) {
+    on<GameHistoryLoadEvent>(_onLoad);
+    on<GameHistoryLoadMoreEvent>(_onLoadMore);
+    on<GameHistoryRefreshEvent>(_onRefresh);
+    on<GameHistoryFilterChangedEvent>(_onFilterChanged);
+    on<GameHistoryDateRangeChangedEvent>(_onDateRangeChanged);
+  }
+
+  Future<void> _onLoad(
+    GameHistoryLoadEvent event,
+    Emitter<GameHistoryState> emit,
+  ) async {
+    emit(const GameHistoryState.loading());
+
+    _currentGroupId = event.groupId;
+    _currentUserId = event.userId;
+    _currentFilter = event.filter;
+    _startDate = event.startDate;
+    _endDate = event.endDate;
+    _lastDocument = null; // Reset pagination
+
+    try {
+      final page = await _gameRepository
+          .getCompletedGames(
+            groupId: event.groupId,
+            userId: event.filter == GameHistoryFilter.myGames
+                ? event.userId
+                : null,
+            startDate: event.startDate,
+            endDate: event.endDate,
+            lastDocument: null,
+          )
+          .first;
+
+      _lastDocument = page.lastDocument;
+      emit(GameHistoryState.loaded(
+        games: page.games,
+        hasMore: page.hasMore,
+        currentFilter: _currentFilter,
+        startDate: _startDate,
+        endDate: _endDate,
+      ));
+    } catch (e) {
+      emit(GameHistoryState.error(
+        message: 'Failed to load games: $e',
+        lastFilter: _currentFilter,
+      ));
+    }
+  }
+
+  Future<void> _onLoadMore(
+    GameHistoryLoadMoreEvent event,
+    Emitter<GameHistoryState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! GameHistoryLoaded) return;
+    if (!currentState.hasMore || currentState.isLoadingMore) return;
+
+    // Emit loading more state
+    emit(currentState.copyWith(isLoadingMore: true));
+
+    try {
+      final page = await _gameRepository
+          .getCompletedGames(
+            groupId: _currentGroupId,
+            userId: _currentFilter == GameHistoryFilter.myGames
+                ? _currentUserId
+                : null,
+            startDate: _startDate,
+            endDate: _endDate,
+            lastDocument: _lastDocument,
+          )
+          .first;
+
+      _lastDocument = page.lastDocument;
+
+      emit(GameHistoryState.loaded(
+        games: [...currentState.games, ...page.games],
+        hasMore: page.hasMore,
+        currentFilter: _currentFilter,
+        startDate: _startDate,
+        endDate: _endDate,
+        isLoadingMore: false,
+      ));
+    } catch (e) {
+      emit(currentState.copyWith(isLoadingMore: false));
+      // Don't emit error, just stop loading more
+    }
+  }
+
+  Future<void> _onRefresh(
+    GameHistoryRefreshEvent event,
+    Emitter<GameHistoryState> emit,
+  ) async {
+    if (_currentUserId == null) return;
+
+    // Reload with current filters
+    add(GameHistoryEvent.load(
+      groupId: _currentGroupId,
+      userId: _currentUserId!,
+      filter: _currentFilter,
+      startDate: _startDate,
+      endDate: _endDate,
+    ));
+  }
+
+  Future<void> _onFilterChanged(
+    GameHistoryFilterChangedEvent event,
+    Emitter<GameHistoryState> emit,
+  ) async {
+    if (_currentUserId == null) return;
+
+    _currentFilter = event.filter;
+
+    // Reload with new filter
+    add(GameHistoryEvent.load(
+      groupId: _currentGroupId,
+      userId: _currentUserId!,
+      filter: event.filter,
+      startDate: _startDate,
+      endDate: _endDate,
+    ));
+  }
+
+  Future<void> _onDateRangeChanged(
+    GameHistoryDateRangeChangedEvent event,
+    Emitter<GameHistoryState> emit,
+  ) async {
+    if (_currentUserId == null) return;
+
+    _startDate = event.startDate;
+    _endDate = event.endDate;
+
+    // Reload with new date range
+    add(GameHistoryEvent.load(
+      groupId: _currentGroupId,
+      userId: _currentUserId!,
+      filter: _currentFilter,
+      startDate: event.startDate,
+      endDate: event.endDate,
+    ));
+  }
+}

--- a/lib/features/games/presentation/bloc/game_history/game_history_event.dart
+++ b/lib/features/games/presentation/bloc/game_history/game_history_event.dart
@@ -1,0 +1,36 @@
+// Events for game history page (Story 14.7)
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'game_history_state.dart';
+
+part 'game_history_event.freezed.dart';
+
+@freezed
+class GameHistoryEvent with _$GameHistoryEvent {
+  /// Load initial game history
+  const factory GameHistoryEvent.load({
+    String? groupId,
+    required String userId,
+    @Default(GameHistoryFilter.all) GameHistoryFilter filter,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) = GameHistoryLoadEvent;
+
+  /// Load more games (pagination)
+  const factory GameHistoryEvent.loadMore() = GameHistoryLoadMoreEvent;
+
+  /// Refresh game history (pull-to-refresh)
+  const factory GameHistoryEvent.refresh() = GameHistoryRefreshEvent;
+
+  /// Apply filter
+  const factory GameHistoryEvent.filterChanged({
+    required GameHistoryFilter filter,
+  }) = GameHistoryFilterChangedEvent;
+
+  /// Apply date range filter
+  const factory GameHistoryEvent.dateRangeChanged({
+    DateTime? startDate,
+    DateTime? endDate,
+  }) = GameHistoryDateRangeChangedEvent;
+}

--- a/lib/features/games/presentation/bloc/game_history/game_history_event.freezed.dart
+++ b/lib/features/games/presentation/bloc/game_history/game_history_event.freezed.dart
@@ -1,0 +1,1069 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'game_history_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$GameHistoryEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GameHistoryEventCopyWith<$Res> {
+  factory $GameHistoryEventCopyWith(
+    GameHistoryEvent value,
+    $Res Function(GameHistoryEvent) then,
+  ) = _$GameHistoryEventCopyWithImpl<$Res, GameHistoryEvent>;
+}
+
+/// @nodoc
+class _$GameHistoryEventCopyWithImpl<$Res, $Val extends GameHistoryEvent>
+    implements $GameHistoryEventCopyWith<$Res> {
+  _$GameHistoryEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$GameHistoryLoadEventImplCopyWith<$Res> {
+  factory _$$GameHistoryLoadEventImplCopyWith(
+    _$GameHistoryLoadEventImpl value,
+    $Res Function(_$GameHistoryLoadEventImpl) then,
+  ) = __$$GameHistoryLoadEventImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({
+    String? groupId,
+    String userId,
+    GameHistoryFilter filter,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+}
+
+/// @nodoc
+class __$$GameHistoryLoadEventImplCopyWithImpl<$Res>
+    extends _$GameHistoryEventCopyWithImpl<$Res, _$GameHistoryLoadEventImpl>
+    implements _$$GameHistoryLoadEventImplCopyWith<$Res> {
+  __$$GameHistoryLoadEventImplCopyWithImpl(
+    _$GameHistoryLoadEventImpl _value,
+    $Res Function(_$GameHistoryLoadEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? groupId = freezed,
+    Object? userId = null,
+    Object? filter = null,
+    Object? startDate = freezed,
+    Object? endDate = freezed,
+  }) {
+    return _then(
+      _$GameHistoryLoadEventImpl(
+        groupId: freezed == groupId
+            ? _value.groupId
+            : groupId // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        userId: null == userId
+            ? _value.userId
+            : userId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        filter: null == filter
+            ? _value.filter
+            : filter // ignore: cast_nullable_to_non_nullable
+                  as GameHistoryFilter,
+        startDate: freezed == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        endDate: freezed == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$GameHistoryLoadEventImpl implements GameHistoryLoadEvent {
+  const _$GameHistoryLoadEventImpl({
+    this.groupId,
+    required this.userId,
+    this.filter = GameHistoryFilter.all,
+    this.startDate,
+    this.endDate,
+  });
+
+  @override
+  final String? groupId;
+  @override
+  final String userId;
+  @override
+  @JsonKey()
+  final GameHistoryFilter filter;
+  @override
+  final DateTime? startDate;
+  @override
+  final DateTime? endDate;
+
+  @override
+  String toString() {
+    return 'GameHistoryEvent.load(groupId: $groupId, userId: $userId, filter: $filter, startDate: $startDate, endDate: $endDate)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryLoadEventImpl &&
+            (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, groupId, userId, filter, startDate, endDate);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameHistoryLoadEventImplCopyWith<_$GameHistoryLoadEventImpl>
+  get copyWith =>
+      __$$GameHistoryLoadEventImplCopyWithImpl<_$GameHistoryLoadEventImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) {
+    return load(groupId, userId, filter, startDate, endDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) {
+    return load?.call(groupId, userId, filter, startDate, endDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (load != null) {
+      return load(groupId, userId, filter, startDate, endDate);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) {
+    return load(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) {
+    return load?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (load != null) {
+      return load(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryLoadEvent implements GameHistoryEvent {
+  const factory GameHistoryLoadEvent({
+    final String? groupId,
+    required final String userId,
+    final GameHistoryFilter filter,
+    final DateTime? startDate,
+    final DateTime? endDate,
+  }) = _$GameHistoryLoadEventImpl;
+
+  String? get groupId;
+  String get userId;
+  GameHistoryFilter get filter;
+  DateTime? get startDate;
+  DateTime? get endDate;
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameHistoryLoadEventImplCopyWith<_$GameHistoryLoadEventImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryLoadMoreEventImplCopyWith<$Res> {
+  factory _$$GameHistoryLoadMoreEventImplCopyWith(
+    _$GameHistoryLoadMoreEventImpl value,
+    $Res Function(_$GameHistoryLoadMoreEventImpl) then,
+  ) = __$$GameHistoryLoadMoreEventImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$GameHistoryLoadMoreEventImplCopyWithImpl<$Res>
+    extends _$GameHistoryEventCopyWithImpl<$Res, _$GameHistoryLoadMoreEventImpl>
+    implements _$$GameHistoryLoadMoreEventImplCopyWith<$Res> {
+  __$$GameHistoryLoadMoreEventImplCopyWithImpl(
+    _$GameHistoryLoadMoreEventImpl _value,
+    $Res Function(_$GameHistoryLoadMoreEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$GameHistoryLoadMoreEventImpl implements GameHistoryLoadMoreEvent {
+  const _$GameHistoryLoadMoreEventImpl();
+
+  @override
+  String toString() {
+    return 'GameHistoryEvent.loadMore()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryLoadMoreEventImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) {
+    return loadMore();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) {
+    return loadMore?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (loadMore != null) {
+      return loadMore();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) {
+    return loadMore(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) {
+    return loadMore?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (loadMore != null) {
+      return loadMore(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryLoadMoreEvent implements GameHistoryEvent {
+  const factory GameHistoryLoadMoreEvent() = _$GameHistoryLoadMoreEventImpl;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryRefreshEventImplCopyWith<$Res> {
+  factory _$$GameHistoryRefreshEventImplCopyWith(
+    _$GameHistoryRefreshEventImpl value,
+    $Res Function(_$GameHistoryRefreshEventImpl) then,
+  ) = __$$GameHistoryRefreshEventImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$GameHistoryRefreshEventImplCopyWithImpl<$Res>
+    extends _$GameHistoryEventCopyWithImpl<$Res, _$GameHistoryRefreshEventImpl>
+    implements _$$GameHistoryRefreshEventImplCopyWith<$Res> {
+  __$$GameHistoryRefreshEventImplCopyWithImpl(
+    _$GameHistoryRefreshEventImpl _value,
+    $Res Function(_$GameHistoryRefreshEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$GameHistoryRefreshEventImpl implements GameHistoryRefreshEvent {
+  const _$GameHistoryRefreshEventImpl();
+
+  @override
+  String toString() {
+    return 'GameHistoryEvent.refresh()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryRefreshEventImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) {
+    return refresh();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) {
+    return refresh?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) {
+    return refresh(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) {
+    return refresh?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryRefreshEvent implements GameHistoryEvent {
+  const factory GameHistoryRefreshEvent() = _$GameHistoryRefreshEventImpl;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryFilterChangedEventImplCopyWith<$Res> {
+  factory _$$GameHistoryFilterChangedEventImplCopyWith(
+    _$GameHistoryFilterChangedEventImpl value,
+    $Res Function(_$GameHistoryFilterChangedEventImpl) then,
+  ) = __$$GameHistoryFilterChangedEventImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({GameHistoryFilter filter});
+}
+
+/// @nodoc
+class __$$GameHistoryFilterChangedEventImplCopyWithImpl<$Res>
+    extends
+        _$GameHistoryEventCopyWithImpl<
+          $Res,
+          _$GameHistoryFilterChangedEventImpl
+        >
+    implements _$$GameHistoryFilterChangedEventImplCopyWith<$Res> {
+  __$$GameHistoryFilterChangedEventImplCopyWithImpl(
+    _$GameHistoryFilterChangedEventImpl _value,
+    $Res Function(_$GameHistoryFilterChangedEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? filter = null}) {
+    return _then(
+      _$GameHistoryFilterChangedEventImpl(
+        filter: null == filter
+            ? _value.filter
+            : filter // ignore: cast_nullable_to_non_nullable
+                  as GameHistoryFilter,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$GameHistoryFilterChangedEventImpl
+    implements GameHistoryFilterChangedEvent {
+  const _$GameHistoryFilterChangedEventImpl({required this.filter});
+
+  @override
+  final GameHistoryFilter filter;
+
+  @override
+  String toString() {
+    return 'GameHistoryEvent.filterChanged(filter: $filter)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryFilterChangedEventImpl &&
+            (identical(other.filter, filter) || other.filter == filter));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, filter);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameHistoryFilterChangedEventImplCopyWith<
+    _$GameHistoryFilterChangedEventImpl
+  >
+  get copyWith =>
+      __$$GameHistoryFilterChangedEventImplCopyWithImpl<
+        _$GameHistoryFilterChangedEventImpl
+      >(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) {
+    return filterChanged(filter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) {
+    return filterChanged?.call(filter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (filterChanged != null) {
+      return filterChanged(filter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) {
+    return filterChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) {
+    return filterChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (filterChanged != null) {
+      return filterChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryFilterChangedEvent implements GameHistoryEvent {
+  const factory GameHistoryFilterChangedEvent({
+    required final GameHistoryFilter filter,
+  }) = _$GameHistoryFilterChangedEventImpl;
+
+  GameHistoryFilter get filter;
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameHistoryFilterChangedEventImplCopyWith<
+    _$GameHistoryFilterChangedEventImpl
+  >
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryDateRangeChangedEventImplCopyWith<$Res> {
+  factory _$$GameHistoryDateRangeChangedEventImplCopyWith(
+    _$GameHistoryDateRangeChangedEventImpl value,
+    $Res Function(_$GameHistoryDateRangeChangedEventImpl) then,
+  ) = __$$GameHistoryDateRangeChangedEventImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DateTime? startDate, DateTime? endDate});
+}
+
+/// @nodoc
+class __$$GameHistoryDateRangeChangedEventImplCopyWithImpl<$Res>
+    extends
+        _$GameHistoryEventCopyWithImpl<
+          $Res,
+          _$GameHistoryDateRangeChangedEventImpl
+        >
+    implements _$$GameHistoryDateRangeChangedEventImplCopyWith<$Res> {
+  __$$GameHistoryDateRangeChangedEventImplCopyWithImpl(
+    _$GameHistoryDateRangeChangedEventImpl _value,
+    $Res Function(_$GameHistoryDateRangeChangedEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? startDate = freezed, Object? endDate = freezed}) {
+    return _then(
+      _$GameHistoryDateRangeChangedEventImpl(
+        startDate: freezed == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        endDate: freezed == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$GameHistoryDateRangeChangedEventImpl
+    implements GameHistoryDateRangeChangedEvent {
+  const _$GameHistoryDateRangeChangedEventImpl({this.startDate, this.endDate});
+
+  @override
+  final DateTime? startDate;
+  @override
+  final DateTime? endDate;
+
+  @override
+  String toString() {
+    return 'GameHistoryEvent.dateRangeChanged(startDate: $startDate, endDate: $endDate)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryDateRangeChangedEventImpl &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, startDate, endDate);
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameHistoryDateRangeChangedEventImplCopyWith<
+    _$GameHistoryDateRangeChangedEventImpl
+  >
+  get copyWith =>
+      __$$GameHistoryDateRangeChangedEventImplCopyWithImpl<
+        _$GameHistoryDateRangeChangedEventImpl
+      >(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )
+    load,
+    required TResult Function() loadMore,
+    required TResult Function() refresh,
+    required TResult Function(GameHistoryFilter filter) filterChanged,
+    required TResult Function(DateTime? startDate, DateTime? endDate)
+    dateRangeChanged,
+  }) {
+    return dateRangeChanged(startDate, endDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult? Function()? loadMore,
+    TResult? Function()? refresh,
+    TResult? Function(GameHistoryFilter filter)? filterChanged,
+    TResult? Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+  }) {
+    return dateRangeChanged?.call(startDate, endDate);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+      String? groupId,
+      String userId,
+      GameHistoryFilter filter,
+      DateTime? startDate,
+      DateTime? endDate,
+    )?
+    load,
+    TResult Function()? loadMore,
+    TResult Function()? refresh,
+    TResult Function(GameHistoryFilter filter)? filterChanged,
+    TResult Function(DateTime? startDate, DateTime? endDate)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (dateRangeChanged != null) {
+      return dateRangeChanged(startDate, endDate);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryLoadEvent value) load,
+    required TResult Function(GameHistoryLoadMoreEvent value) loadMore,
+    required TResult Function(GameHistoryRefreshEvent value) refresh,
+    required TResult Function(GameHistoryFilterChangedEvent value)
+    filterChanged,
+    required TResult Function(GameHistoryDateRangeChangedEvent value)
+    dateRangeChanged,
+  }) {
+    return dateRangeChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryLoadEvent value)? load,
+    TResult? Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult? Function(GameHistoryRefreshEvent value)? refresh,
+    TResult? Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult? Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+  }) {
+    return dateRangeChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryLoadEvent value)? load,
+    TResult Function(GameHistoryLoadMoreEvent value)? loadMore,
+    TResult Function(GameHistoryRefreshEvent value)? refresh,
+    TResult Function(GameHistoryFilterChangedEvent value)? filterChanged,
+    TResult Function(GameHistoryDateRangeChangedEvent value)? dateRangeChanged,
+    required TResult orElse(),
+  }) {
+    if (dateRangeChanged != null) {
+      return dateRangeChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryDateRangeChangedEvent implements GameHistoryEvent {
+  const factory GameHistoryDateRangeChangedEvent({
+    final DateTime? startDate,
+    final DateTime? endDate,
+  }) = _$GameHistoryDateRangeChangedEventImpl;
+
+  DateTime? get startDate;
+  DateTime? get endDate;
+
+  /// Create a copy of GameHistoryEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameHistoryDateRangeChangedEventImplCopyWith<
+    _$GameHistoryDateRangeChangedEventImpl
+  >
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/features/games/presentation/bloc/game_history/game_history_state.dart
+++ b/lib/features/games/presentation/bloc/game_history/game_history_state.dart
@@ -1,0 +1,33 @@
+// Manages state for game history page with pagination (Story 14.7)
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../../core/data/models/game_model.dart';
+
+part 'game_history_state.freezed.dart';
+
+enum GameHistoryFilter {
+  all,     // All group games
+  myGames, // Only games user played in
+}
+
+@freezed
+class GameHistoryState with _$GameHistoryState {
+  const factory GameHistoryState.initial() = GameHistoryInitial;
+
+  const factory GameHistoryState.loading() = GameHistoryLoading;
+
+  const factory GameHistoryState.loaded({
+    required List<GameModel> games,
+    required bool hasMore,
+    required GameHistoryFilter currentFilter,
+    DateTime? startDate,
+    DateTime? endDate,
+    @Default(false) bool isLoadingMore,
+  }) = GameHistoryLoaded;
+
+  const factory GameHistoryState.error({
+    required String message,
+    GameHistoryFilter? lastFilter,
+  }) = GameHistoryError;
+}

--- a/lib/features/games/presentation/bloc/game_history/game_history_state.freezed.dart
+++ b/lib/features/games/presentation/bloc/game_history/game_history_state.freezed.dart
@@ -1,0 +1,882 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'game_history_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$GameHistoryState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )
+    loaded,
+    required TResult Function(String message, GameHistoryFilter? lastFilter)
+    error,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult? Function(String message, GameHistoryFilter? lastFilter)? error,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult Function(String message, GameHistoryFilter? lastFilter)? error,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryInitial value) initial,
+    required TResult Function(GameHistoryLoading value) loading,
+    required TResult Function(GameHistoryLoaded value) loaded,
+    required TResult Function(GameHistoryError value) error,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryInitial value)? initial,
+    TResult? Function(GameHistoryLoading value)? loading,
+    TResult? Function(GameHistoryLoaded value)? loaded,
+    TResult? Function(GameHistoryError value)? error,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryInitial value)? initial,
+    TResult Function(GameHistoryLoading value)? loading,
+    TResult Function(GameHistoryLoaded value)? loaded,
+    TResult Function(GameHistoryError value)? error,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GameHistoryStateCopyWith<$Res> {
+  factory $GameHistoryStateCopyWith(
+    GameHistoryState value,
+    $Res Function(GameHistoryState) then,
+  ) = _$GameHistoryStateCopyWithImpl<$Res, GameHistoryState>;
+}
+
+/// @nodoc
+class _$GameHistoryStateCopyWithImpl<$Res, $Val extends GameHistoryState>
+    implements $GameHistoryStateCopyWith<$Res> {
+  _$GameHistoryStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$GameHistoryInitialImplCopyWith<$Res> {
+  factory _$$GameHistoryInitialImplCopyWith(
+    _$GameHistoryInitialImpl value,
+    $Res Function(_$GameHistoryInitialImpl) then,
+  ) = __$$GameHistoryInitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$GameHistoryInitialImplCopyWithImpl<$Res>
+    extends _$GameHistoryStateCopyWithImpl<$Res, _$GameHistoryInitialImpl>
+    implements _$$GameHistoryInitialImplCopyWith<$Res> {
+  __$$GameHistoryInitialImplCopyWithImpl(
+    _$GameHistoryInitialImpl _value,
+    $Res Function(_$GameHistoryInitialImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$GameHistoryInitialImpl implements GameHistoryInitial {
+  const _$GameHistoryInitialImpl();
+
+  @override
+  String toString() {
+    return 'GameHistoryState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$GameHistoryInitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )
+    loaded,
+    required TResult Function(String message, GameHistoryFilter? lastFilter)
+    error,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult? Function(String message, GameHistoryFilter? lastFilter)? error,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult Function(String message, GameHistoryFilter? lastFilter)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryInitial value) initial,
+    required TResult Function(GameHistoryLoading value) loading,
+    required TResult Function(GameHistoryLoaded value) loaded,
+    required TResult Function(GameHistoryError value) error,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryInitial value)? initial,
+    TResult? Function(GameHistoryLoading value)? loading,
+    TResult? Function(GameHistoryLoaded value)? loaded,
+    TResult? Function(GameHistoryError value)? error,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryInitial value)? initial,
+    TResult Function(GameHistoryLoading value)? loading,
+    TResult Function(GameHistoryLoaded value)? loaded,
+    TResult Function(GameHistoryError value)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryInitial implements GameHistoryState {
+  const factory GameHistoryInitial() = _$GameHistoryInitialImpl;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryLoadingImplCopyWith<$Res> {
+  factory _$$GameHistoryLoadingImplCopyWith(
+    _$GameHistoryLoadingImpl value,
+    $Res Function(_$GameHistoryLoadingImpl) then,
+  ) = __$$GameHistoryLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$GameHistoryLoadingImplCopyWithImpl<$Res>
+    extends _$GameHistoryStateCopyWithImpl<$Res, _$GameHistoryLoadingImpl>
+    implements _$$GameHistoryLoadingImplCopyWith<$Res> {
+  __$$GameHistoryLoadingImplCopyWithImpl(
+    _$GameHistoryLoadingImpl _value,
+    $Res Function(_$GameHistoryLoadingImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$GameHistoryLoadingImpl implements GameHistoryLoading {
+  const _$GameHistoryLoadingImpl();
+
+  @override
+  String toString() {
+    return 'GameHistoryState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$GameHistoryLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )
+    loaded,
+    required TResult Function(String message, GameHistoryFilter? lastFilter)
+    error,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult? Function(String message, GameHistoryFilter? lastFilter)? error,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult Function(String message, GameHistoryFilter? lastFilter)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryInitial value) initial,
+    required TResult Function(GameHistoryLoading value) loading,
+    required TResult Function(GameHistoryLoaded value) loaded,
+    required TResult Function(GameHistoryError value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryInitial value)? initial,
+    TResult? Function(GameHistoryLoading value)? loading,
+    TResult? Function(GameHistoryLoaded value)? loaded,
+    TResult? Function(GameHistoryError value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryInitial value)? initial,
+    TResult Function(GameHistoryLoading value)? loading,
+    TResult Function(GameHistoryLoaded value)? loaded,
+    TResult Function(GameHistoryError value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryLoading implements GameHistoryState {
+  const factory GameHistoryLoading() = _$GameHistoryLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryLoadedImplCopyWith<$Res> {
+  factory _$$GameHistoryLoadedImplCopyWith(
+    _$GameHistoryLoadedImpl value,
+    $Res Function(_$GameHistoryLoadedImpl) then,
+  ) = __$$GameHistoryLoadedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({
+    List<GameModel> games,
+    bool hasMore,
+    GameHistoryFilter currentFilter,
+    DateTime? startDate,
+    DateTime? endDate,
+    bool isLoadingMore,
+  });
+}
+
+/// @nodoc
+class __$$GameHistoryLoadedImplCopyWithImpl<$Res>
+    extends _$GameHistoryStateCopyWithImpl<$Res, _$GameHistoryLoadedImpl>
+    implements _$$GameHistoryLoadedImplCopyWith<$Res> {
+  __$$GameHistoryLoadedImplCopyWithImpl(
+    _$GameHistoryLoadedImpl _value,
+    $Res Function(_$GameHistoryLoadedImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? games = null,
+    Object? hasMore = null,
+    Object? currentFilter = null,
+    Object? startDate = freezed,
+    Object? endDate = freezed,
+    Object? isLoadingMore = null,
+  }) {
+    return _then(
+      _$GameHistoryLoadedImpl(
+        games: null == games
+            ? _value._games
+            : games // ignore: cast_nullable_to_non_nullable
+                  as List<GameModel>,
+        hasMore: null == hasMore
+            ? _value.hasMore
+            : hasMore // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        currentFilter: null == currentFilter
+            ? _value.currentFilter
+            : currentFilter // ignore: cast_nullable_to_non_nullable
+                  as GameHistoryFilter,
+        startDate: freezed == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        endDate: freezed == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        isLoadingMore: null == isLoadingMore
+            ? _value.isLoadingMore
+            : isLoadingMore // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$GameHistoryLoadedImpl implements GameHistoryLoaded {
+  const _$GameHistoryLoadedImpl({
+    required final List<GameModel> games,
+    required this.hasMore,
+    required this.currentFilter,
+    this.startDate,
+    this.endDate,
+    this.isLoadingMore = false,
+  }) : _games = games;
+
+  final List<GameModel> _games;
+  @override
+  List<GameModel> get games {
+    if (_games is EqualUnmodifiableListView) return _games;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_games);
+  }
+
+  @override
+  final bool hasMore;
+  @override
+  final GameHistoryFilter currentFilter;
+  @override
+  final DateTime? startDate;
+  @override
+  final DateTime? endDate;
+  @override
+  @JsonKey()
+  final bool isLoadingMore;
+
+  @override
+  String toString() {
+    return 'GameHistoryState.loaded(games: $games, hasMore: $hasMore, currentFilter: $currentFilter, startDate: $startDate, endDate: $endDate, isLoadingMore: $isLoadingMore)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryLoadedImpl &&
+            const DeepCollectionEquality().equals(other._games, _games) &&
+            (identical(other.hasMore, hasMore) || other.hasMore == hasMore) &&
+            (identical(other.currentFilter, currentFilter) ||
+                other.currentFilter == currentFilter) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate) &&
+            (identical(other.isLoadingMore, isLoadingMore) ||
+                other.isLoadingMore == isLoadingMore));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_games),
+    hasMore,
+    currentFilter,
+    startDate,
+    endDate,
+    isLoadingMore,
+  );
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameHistoryLoadedImplCopyWith<_$GameHistoryLoadedImpl> get copyWith =>
+      __$$GameHistoryLoadedImplCopyWithImpl<_$GameHistoryLoadedImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )
+    loaded,
+    required TResult Function(String message, GameHistoryFilter? lastFilter)
+    error,
+  }) {
+    return loaded(
+      games,
+      hasMore,
+      currentFilter,
+      startDate,
+      endDate,
+      isLoadingMore,
+    );
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult? Function(String message, GameHistoryFilter? lastFilter)? error,
+  }) {
+    return loaded?.call(
+      games,
+      hasMore,
+      currentFilter,
+      startDate,
+      endDate,
+      isLoadingMore,
+    );
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult Function(String message, GameHistoryFilter? lastFilter)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(
+        games,
+        hasMore,
+        currentFilter,
+        startDate,
+        endDate,
+        isLoadingMore,
+      );
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryInitial value) initial,
+    required TResult Function(GameHistoryLoading value) loading,
+    required TResult Function(GameHistoryLoaded value) loaded,
+    required TResult Function(GameHistoryError value) error,
+  }) {
+    return loaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryInitial value)? initial,
+    TResult? Function(GameHistoryLoading value)? loading,
+    TResult? Function(GameHistoryLoaded value)? loaded,
+    TResult? Function(GameHistoryError value)? error,
+  }) {
+    return loaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryInitial value)? initial,
+    TResult Function(GameHistoryLoading value)? loading,
+    TResult Function(GameHistoryLoaded value)? loaded,
+    TResult Function(GameHistoryError value)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryLoaded implements GameHistoryState {
+  const factory GameHistoryLoaded({
+    required final List<GameModel> games,
+    required final bool hasMore,
+    required final GameHistoryFilter currentFilter,
+    final DateTime? startDate,
+    final DateTime? endDate,
+    final bool isLoadingMore,
+  }) = _$GameHistoryLoadedImpl;
+
+  List<GameModel> get games;
+  bool get hasMore;
+  GameHistoryFilter get currentFilter;
+  DateTime? get startDate;
+  DateTime? get endDate;
+  bool get isLoadingMore;
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameHistoryLoadedImplCopyWith<_$GameHistoryLoadedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GameHistoryErrorImplCopyWith<$Res> {
+  factory _$$GameHistoryErrorImplCopyWith(
+    _$GameHistoryErrorImpl value,
+    $Res Function(_$GameHistoryErrorImpl) then,
+  ) = __$$GameHistoryErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message, GameHistoryFilter? lastFilter});
+}
+
+/// @nodoc
+class __$$GameHistoryErrorImplCopyWithImpl<$Res>
+    extends _$GameHistoryStateCopyWithImpl<$Res, _$GameHistoryErrorImpl>
+    implements _$$GameHistoryErrorImplCopyWith<$Res> {
+  __$$GameHistoryErrorImplCopyWithImpl(
+    _$GameHistoryErrorImpl _value,
+    $Res Function(_$GameHistoryErrorImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? message = null, Object? lastFilter = freezed}) {
+    return _then(
+      _$GameHistoryErrorImpl(
+        message: null == message
+            ? _value.message
+            : message // ignore: cast_nullable_to_non_nullable
+                  as String,
+        lastFilter: freezed == lastFilter
+            ? _value.lastFilter
+            : lastFilter // ignore: cast_nullable_to_non_nullable
+                  as GameHistoryFilter?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$GameHistoryErrorImpl implements GameHistoryError {
+  const _$GameHistoryErrorImpl({required this.message, this.lastFilter});
+
+  @override
+  final String message;
+  @override
+  final GameHistoryFilter? lastFilter;
+
+  @override
+  String toString() {
+    return 'GameHistoryState.error(message: $message, lastFilter: $lastFilter)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameHistoryErrorImpl &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.lastFilter, lastFilter) ||
+                other.lastFilter == lastFilter));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message, lastFilter);
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameHistoryErrorImplCopyWith<_$GameHistoryErrorImpl> get copyWith =>
+      __$$GameHistoryErrorImplCopyWithImpl<_$GameHistoryErrorImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )
+    loaded,
+    required TResult Function(String message, GameHistoryFilter? lastFilter)
+    error,
+  }) {
+    return error(message, lastFilter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult? Function(String message, GameHistoryFilter? lastFilter)? error,
+  }) {
+    return error?.call(message, lastFilter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(
+      List<GameModel> games,
+      bool hasMore,
+      GameHistoryFilter currentFilter,
+      DateTime? startDate,
+      DateTime? endDate,
+      bool isLoadingMore,
+    )?
+    loaded,
+    TResult Function(String message, GameHistoryFilter? lastFilter)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(message, lastFilter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameHistoryInitial value) initial,
+    required TResult Function(GameHistoryLoading value) loading,
+    required TResult Function(GameHistoryLoaded value) loaded,
+    required TResult Function(GameHistoryError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameHistoryInitial value)? initial,
+    TResult? Function(GameHistoryLoading value)? loading,
+    TResult? Function(GameHistoryLoaded value)? loaded,
+    TResult? Function(GameHistoryError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameHistoryInitial value)? initial,
+    TResult Function(GameHistoryLoading value)? loading,
+    TResult Function(GameHistoryLoaded value)? loaded,
+    TResult Function(GameHistoryError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameHistoryError implements GameHistoryState {
+  const factory GameHistoryError({
+    required final String message,
+    final GameHistoryFilter? lastFilter,
+  }) = _$GameHistoryErrorImpl;
+
+  String get message;
+  GameHistoryFilter? get lastFilter;
+
+  /// Create a copy of GameHistoryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameHistoryErrorImplCopyWith<_$GameHistoryErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/games/presentation/pages/game_history_screen.dart
+++ b/lib/features/games/presentation/pages/game_history_screen.dart
@@ -1,0 +1,323 @@
+// Game History Screen with pagination and filters (Story 14.7)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/domain/repositories/game_repository.dart';
+import '../bloc/game_history/game_history_bloc.dart';
+import '../bloc/game_history/game_history_event.dart';
+import '../bloc/game_history/game_history_state.dart';
+import '../widgets/game_history_card.dart';
+import 'game_details_page.dart';
+
+class GameHistoryScreen extends StatefulWidget {
+  final String? groupId;
+  final String userId;
+
+  const GameHistoryScreen({
+    super.key,
+    this.groupId,
+    required this.userId,
+  });
+
+  @override
+  State<GameHistoryScreen> createState() => _GameHistoryScreenState();
+}
+
+class _GameHistoryScreenState extends State<GameHistoryScreen> {
+  late final ScrollController _scrollController;
+  GameHistoryFilter _selectedFilter = GameHistoryFilter.all;
+  DateTime? _startDate;
+  DateTime? _endDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController()..addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_isBottom) {
+      context.read<GameHistoryBloc>().add(const GameHistoryEvent.loadMore());
+    }
+  }
+
+  bool get _isBottom {
+    if (!_scrollController.hasClients) return false;
+    final maxScroll = _scrollController.position.maxScrollExtent;
+    final currentScroll = _scrollController.offset;
+    return currentScroll >= (maxScroll * 0.9);
+  }
+
+  Future<void> _onRefresh() async {
+    context.read<GameHistoryBloc>().add(const GameHistoryEvent.refresh());
+    // Wait a bit for the stream to update
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  void _showFilterDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Filter Games'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            RadioListTile<GameHistoryFilter>(
+              title: const Text('All Games'),
+              value: GameHistoryFilter.all,
+              groupValue: _selectedFilter,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedFilter = value);
+                  Navigator.pop(context);
+                  _applyFilter(value);
+                }
+              },
+            ),
+            RadioListTile<GameHistoryFilter>(
+              title: const Text('My Games Only'),
+              value: GameHistoryFilter.myGames,
+              groupValue: _selectedFilter,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedFilter = value);
+                  Navigator.pop(context);
+                  _applyFilter(value);
+                }
+              },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _applyFilter(GameHistoryFilter filter) {
+    context.read<GameHistoryBloc>().add(
+          GameHistoryEvent.filterChanged(filter: filter),
+        );
+  }
+
+  Future<void> _showDateRangePicker() async {
+    final DateTimeRange? picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now(),
+      initialDateRange: _startDate != null && _endDate != null
+          ? DateTimeRange(start: _startDate!, end: _endDate!)
+          : null,
+    );
+
+    if (picked != null) {
+      setState(() {
+        _startDate = picked.start;
+        _endDate = picked.end;
+      });
+      context.read<GameHistoryBloc>().add(
+            GameHistoryEvent.dateRangeChanged(
+              startDate: picked.start,
+              endDate: picked.end,
+            ),
+          );
+    }
+  }
+
+  void _clearDateRange() {
+    setState(() {
+      _startDate = null;
+      _endDate = null;
+    });
+    context.read<GameHistoryBloc>().add(
+          const GameHistoryEvent.dateRangeChanged(
+            startDate: null,
+            endDate: null,
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Game History'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list),
+            onPressed: _showFilterDialog,
+            tooltip: 'Filter',
+          ),
+          IconButton(
+            icon: const Icon(Icons.date_range),
+            onPressed: _showDateRangePicker,
+            tooltip: 'Date Range',
+          ),
+        ],
+      ),
+      body: BlocProvider(
+        create: (context) => GameHistoryBloc(
+          gameRepository: context.read<GameRepository>(),
+        )..add(GameHistoryEvent.load(
+            groupId: widget.groupId,
+            userId: widget.userId,
+          )),
+        child: BlocBuilder<GameHistoryBloc, GameHistoryState>(
+          builder: (context, state) {
+            return state.when(
+              initial: () => const Center(
+                child: Text('Select filters to view game history'),
+              ),
+              loading: () => const Center(
+                child: CircularProgressIndicator(),
+              ),
+              loaded: (games, hasMore, filter, startDate, endDate,
+                  isLoadingMore) {
+                return Column(
+                  children: [
+                    // Active filters display
+                    if (startDate != null || filter != GameHistoryFilter.all)
+                      _buildActiveFiltersBar(filter, startDate, endDate),
+
+                    // Games list
+                    Expanded(
+                      child: games.isEmpty
+                          ? _buildEmptyState()
+                          : RefreshIndicator(
+                              onRefresh: _onRefresh,
+                              child: ListView.builder(
+                                controller: _scrollController,
+                                itemCount: games.length + (hasMore ? 1 : 0),
+                                itemBuilder: (context, index) {
+                                  if (index >= games.length) {
+                                    return const Center(
+                                      child: Padding(
+                                        padding: EdgeInsets.all(16),
+                                        child: CircularProgressIndicator(),
+                                      ),
+                                    );
+                                  }
+
+                                  final game = games[index];
+                                  return GameHistoryCard(
+                                    game: game,
+                                    onTap: () => _navigateToGameDetail(game.id),
+                                  );
+                                },
+                              ),
+                            ),
+                    ),
+                  ],
+                );
+              },
+              error: (message, lastFilter) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error_outline, size: 48),
+                    const SizedBox(height: 16),
+                    Text(message),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        context.read<GameHistoryBloc>().add(
+                              GameHistoryEvent.load(
+                                groupId: widget.groupId,
+                                userId: widget.userId,
+                                filter:
+                                    lastFilter ?? GameHistoryFilter.all,
+                              ),
+                            );
+                      },
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActiveFiltersBar(
+    GameHistoryFilter filter,
+    DateTime? startDate,
+    DateTime? endDate,
+  ) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: Theme.of(context).colorScheme.surfaceVariant,
+      child: Row(
+        children: [
+          const Text('Active filters: '),
+          const SizedBox(width: 8),
+          if (filter == GameHistoryFilter.myGames)
+            Chip(
+              label: const Text('My Games'),
+              onDeleted: () => _applyFilter(GameHistoryFilter.all),
+            ),
+          if (startDate != null) ...[
+            const SizedBox(width: 8),
+            Chip(
+              label: Text(
+                '${startDate.month}/${startDate.day} - ${endDate?.month}/${endDate?.day}',
+              ),
+              onDeleted: _clearDateRange,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.history,
+            size: 64,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No completed games yet',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Games will appear here after they are completed',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _navigateToGameDetail(String gameId) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => GameDetailsPage(
+          gameId: gameId,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/games/presentation/widgets/game_history_card.dart
+++ b/lib/features/games/presentation/widgets/game_history_card.dart
@@ -1,0 +1,215 @@
+// Widget displaying a game in history list (Story 14.7)
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/data/models/game_model.dart';
+
+class GameHistoryCard extends StatelessWidget {
+  final GameModel game;
+  final VoidCallback onTap;
+
+  const GameHistoryCard({
+    super.key,
+    required this.game,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat('MMM d, y');
+    final timeFormat = DateFormat('h:mm a');
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Date and location header
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    game.completedAt != null
+                        ? dateFormat.format(game.completedAt!)
+                        : dateFormat.format(game.scheduledAt),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  if (game.completedAt != null)
+                    Text(
+                      timeFormat.format(game.completedAt!),
+                      style: theme.textTheme.bodySmall,
+                    ),
+                ],
+              ),
+              if (game.location.name != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  game.location.name!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+
+              // Teams and scores
+              if (game.teams != null && game.result != null)
+                _buildTeamsAndScores(context)
+              else
+                Text(
+                  'No scores recorded',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontStyle: FontStyle.italic,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+
+              // ELO changes indicator
+              if (game.eloCalculated) ...[
+                const SizedBox(height: 8),
+                const Divider(),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.trending_up,
+                      size: 16,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      'ELO Updated',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTeamsAndScores(BuildContext context) {
+    final theme = Theme.of(context);
+    final teams = game.teams!;
+    final result = game.result!;
+    final winnerTeam = result.overallWinner;
+
+    // Count total games won by each team
+    int teamAWins = result.games.where((g) => g.winner == 'teamA').length;
+    int teamBWins = result.games.where((g) => g.winner == 'teamB').length;
+
+    return Row(
+      children: [
+        // Team A
+        Expanded(
+          child: _buildTeamSection(
+            context,
+            'Team A',
+            teams.teamAPlayerIds.length,
+            teamAWins,
+            winnerTeam == 'teamA',
+          ),
+        ),
+        const SizedBox(width: 16),
+        // VS indicator
+        Text(
+          'VS',
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(width: 16),
+        // Team B
+        Expanded(
+          child: _buildTeamSection(
+            context,
+            'Team B',
+            teams.teamBPlayerIds.length,
+            teamBWins,
+            winnerTeam == 'teamB',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTeamSection(
+    BuildContext context,
+    String teamName,
+    int playerCount,
+    int gamesWon,
+    bool isWinner,
+  ) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isWinner
+            ? theme.colorScheme.primaryContainer.withOpacity(0.3)
+            : theme.colorScheme.surfaceVariant.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(8),
+        border: isWinner
+            ? Border.all(color: theme.colorScheme.primary, width: 2)
+            : null,
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                teamName,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: isWinner ? FontWeight.bold : FontWeight.normal,
+                ),
+              ),
+              if (isWinner) ...[
+                const SizedBox(width: 4),
+                Icon(
+                  Icons.emoji_events,
+                  size: 16,
+                  color: theme.colorScheme.primary,
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$playerCount ${playerCount == 1 ? 'player' : 'players'}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            gamesWon.toString(),
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: isWinner ? theme.colorScheme.primary : null,
+            ),
+          ),
+          Text(
+            'games won',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -18,6 +18,9 @@ import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_event.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/player_stats_section.dart';
+import 'package:play_with_me/features/games/presentation/pages/game_history_screen.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_history/game_history_bloc.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 
 /// Profile page displaying user information and account details
 class ProfilePage extends StatelessWidget {
@@ -116,6 +119,21 @@ class _ProfileContent extends StatelessWidget {
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const NotificationSettingsPage(),
+                ),
+              );
+            },
+            onGameHistory: () {
+              final gameRepository = sl<GameRepository>();
+
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (newContext) => RepositoryProvider.value(
+                    value: gameRepository,
+                    child: GameHistoryScreen(
+                      userId: state.user.uid,
+                      groupId: null, // null = all groups
+                    ),
+                  ),
                 ),
               );
             },

--- a/lib/features/profile/presentation/widgets/profile_actions.dart
+++ b/lib/features/profile/presentation/widgets/profile_actions.dart
@@ -7,11 +7,13 @@ class ProfileActions extends StatelessWidget {
     required this.onEditProfile,
     required this.onSignOut,
     this.onNotificationSettings,
+    this.onGameHistory,
   });
 
   final VoidCallback onEditProfile;
   final VoidCallback onSignOut;
   final VoidCallback? onNotificationSettings;
+  final VoidCallback? onGameHistory;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +37,16 @@ class ProfileActions extends StatelessWidget {
               icon: const Icon(Icons.notifications_outlined),
               label: const Text('Notification Settings'),
             ),
+
+          // Game History button
+          if (onGameHistory != null) ...[
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: onGameHistory,
+              icon: const Icon(Icons.history),
+              label: const Text('Game History'),
+            ),
+          ],
           const SizedBox(height: 24),
 
           // Sign Out button

--- a/test/unit/features/games/presentation/bloc/game_history/game_history_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/game_history/game_history_bloc_test.dart
@@ -1,0 +1,151 @@
+// Tests for GameHistoryBloc (Story 14.7)
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_history/game_history_bloc.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_history/game_history_event.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_history/game_history_state.dart';
+
+import '../../../../../../unit/core/data/repositories/mock_game_repository.dart';
+
+void main() {
+  late MockGameRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockGameRepository();
+  });
+
+  tearDown(() {
+    mockRepository.dispose();
+  });
+
+  group('GameHistoryBloc', () {
+    final testGame1 = GameModel(
+      id: 'game1',
+      title: 'Game 1',
+      groupId: 'group1',
+      createdBy: 'user1',
+      createdAt: DateTime(2024, 1, 1),
+      scheduledAt: DateTime(2024, 1, 5),
+      location: const GameLocation(name: 'Test Location', latitude: 0, longitude: 0),
+      status: GameStatus.completed,
+      completedAt: DateTime(2024, 1, 5, 14, 0),
+      playerIds: ['user1', 'user2'],
+    );
+
+    final testGame2 = GameModel(
+      id: 'game2',
+      title: 'Game 2',
+      groupId: 'group1',
+      createdBy: 'user1',
+      createdAt: DateTime(2024, 1, 2),
+      scheduledAt: DateTime(2024, 1, 6),
+      location: const GameLocation(name: 'Test Location 2', latitude: 0, longitude: 0),
+      status: GameStatus.completed,
+      completedAt: DateTime(2024, 1, 6, 14, 0),
+      playerIds: ['user2', 'user3'],
+    );
+
+    blocTest<GameHistoryBloc, GameHistoryState>(
+      'emits [loading, loaded] when games are loaded successfully',
+      build: () {
+        mockRepository.addGame(testGame1);
+        mockRepository.addGame(testGame2);
+        return GameHistoryBloc(gameRepository: mockRepository);
+      },
+      act: (bloc) => bloc.add(const GameHistoryEvent.load(
+        groupId: 'group1',
+        userId: 'user1',
+      )),
+      expect: () => [
+        const GameHistoryState.loading(),
+        isA<GameHistoryLoaded>()
+            .having((s) => s.games.length, 'games length', 2)
+            .having((s) => s.currentFilter, 'filter', GameHistoryFilter.all),
+      ],
+    );
+
+    blocTest<GameHistoryBloc, GameHistoryState>(
+      'filters games by user when myGames filter is applied',
+      build: () {
+        mockRepository.addGame(testGame1);
+        mockRepository.addGame(testGame2);
+        return GameHistoryBloc(gameRepository: mockRepository);
+      },
+      act: (bloc) => bloc.add(const GameHistoryEvent.load(
+        groupId: 'group1',
+        userId: 'user1',
+        filter: GameHistoryFilter.myGames,
+      )),
+      expect: () => [
+        const GameHistoryState.loading(),
+        isA<GameHistoryLoaded>()
+            .having((s) => s.games.length, 'games length', 1)
+            .having((s) => s.games.first.id, 'game id', 'game1'),
+      ],
+    );
+
+    blocTest<GameHistoryBloc, GameHistoryState>(
+      'emits empty list when no completed games exist',
+      build: () => GameHistoryBloc(gameRepository: mockRepository),
+      act: (bloc) => bloc.add(const GameHistoryEvent.load(
+        groupId: 'group1',
+        userId: 'user1',
+      )),
+      expect: () => [
+        const GameHistoryState.loading(),
+        isA<GameHistoryLoaded>().having((s) => s.games, 'games', isEmpty),
+      ],
+    );
+
+    blocTest<GameHistoryBloc, GameHistoryState>(
+      'changes filter when filterChanged event is added',
+      build: () {
+        mockRepository.addGame(testGame1);
+        mockRepository.addGame(testGame2);
+        return GameHistoryBloc(gameRepository: mockRepository);
+      },
+      act: (bloc) async {
+        bloc.add(const GameHistoryEvent.load(
+          groupId: 'group1',
+          userId: 'user1',
+        ));
+        await Future.delayed(const Duration(milliseconds: 100));
+        bloc.add(const GameHistoryEvent.filterChanged(
+          filter: GameHistoryFilter.myGames,
+        ));
+      },
+      skip: 2, // Skip initial loading and loaded states
+      expect: () => [
+        const GameHistoryState.loading(),
+        isA<GameHistoryLoaded>()
+            .having((s) => s.games.length, 'games length', 1)
+            .having((s) => s.currentFilter, 'filter', GameHistoryFilter.myGames),
+      ],
+    );
+
+    blocTest<GameHistoryBloc, GameHistoryState>(
+      'reloads games when refresh event is added',
+      build: () {
+        mockRepository.addGame(testGame1);
+        return GameHistoryBloc(gameRepository: mockRepository);
+      },
+      act: (bloc) async {
+        bloc.add(const GameHistoryEvent.load(
+          groupId: 'group1',
+          userId: 'user1',
+        ));
+        await Future.delayed(const Duration(milliseconds: 100));
+        // Add another game
+        mockRepository.addGame(testGame2);
+        bloc.add(const GameHistoryEvent.refresh());
+      },
+      skip: 2,
+      expect: () => [
+        const GameHistoryState.loading(),
+        isA<GameHistoryLoaded>().having((s) => s.games.length, 'games length', 2),
+      ],
+    );
+  });
+}

--- a/test/widget/features/games/presentation/widgets/game_history_card_test.dart
+++ b/test/widget/features/games/presentation/widgets/game_history_card_test.dart
@@ -1,0 +1,140 @@
+// Widget tests for GameHistoryCard (Story 14.7)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/features/games/presentation/widgets/game_history_card.dart';
+
+void main() {
+  group('GameHistoryCard', () {
+    final testGame = GameModel(
+      id: 'test-game',
+      title: 'Test Game',
+      groupId: 'test-group',
+      createdBy: 'user1',
+      createdAt: DateTime(2024, 1, 1),
+      scheduledAt: DateTime(2024, 1, 5, 14, 0),
+      location: const GameLocation(
+        latitude: 40.7128,
+        longitude: -74.0060,
+        name: 'Central Park',
+      ),
+      status: GameStatus.completed,
+      completedAt: DateTime(2024, 1, 5, 16, 30),
+      playerIds: ['user1', 'user2'],
+      teams: const GameTeams(
+        teamAPlayerIds: ['user1'],
+        teamBPlayerIds: ['user2'],
+      ),
+      result: const GameResult(
+        games: [],
+        overallWinner: 'teamA',
+      ),
+      eloCalculated: true,
+    );
+
+    testWidgets('displays game date and location', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: testGame,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Jan 5, 2024'), findsOneWidget);
+      expect(find.text('Central Park'), findsOneWidget);
+    });
+
+    testWidgets('displays team scores when available', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: testGame,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Team A'), findsOneWidget);
+      expect(find.text('Team B'), findsOneWidget);
+      expect(find.text('0'), findsWidgets); // No game scores in test data
+    });
+
+    testWidgets('shows winner indicator for winning team', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: testGame,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.emoji_events), findsOneWidget);
+    });
+
+    testWidgets('shows ELO updated indicator when calculated', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: testGame,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('ELO Updated'), findsOneWidget);
+      expect(find.byIcon(Icons.trending_up), findsOneWidget);
+    });
+
+    testWidgets('shows message when no scores recorded', (tester) async {
+      final gameWithoutScores = testGame.copyWith(
+        teams: null,
+        result: null,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: gameWithoutScores,
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('No scores recorded'), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GameHistoryCard(
+              game: testGame,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(GameHistoryCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the Game History page with pagination, filtering, and pull-to-refresh functionality for displaying completed games.

### Features Implemented

**Repository Layer:**
- ✅ Added `getCompletedGames()` method to GameRepository with pagination support
- ✅ Created `GameHistoryPage` model for paginated results with DocumentSnapshot cursor
- ✅ Implemented Firestore query with filters (groupId, userId, date range) and pagination
- ✅ Sorting by completedAt (most recent first)

**BLoC Layer:**
- ✅ Created `GameHistoryState` with freezed (initial, loading, loaded, error)
- ✅ Created `GameHistoryEvent` with freezed (load, loadMore, refresh, filterChanged, dateRangeChanged)
- ✅ Implemented `GameHistoryBloc` with:
  - Pagination logic using DocumentSnapshot cursor
  - Filter management (all games vs my games)
  - Date range filtering
  - Pull-to-refresh support

**UI Layer:**
- ✅ Created `GameHistoryCard` widget displaying:
  - Game date, time, location
  - Team compositions and scores
  - Winner indicator with trophy icon
  - ELO updated badge
  - "No scores recorded" fallback
- ✅ Created `GameHistoryScreen` with:
  - AppBar with filter and date range buttons
  - Pull-to-refresh functionality
  - Infinite scroll pagination (loads more at 90% scroll)
  - Filter dialog (All Games / My Games Only)
  - Date range picker
  - Active filters display bar with removable chips
  - Empty state UI
  - Error state with retry button
  - Navigation to game details on tap

**Testing:**
- ✅ Created 5 BLoC unit tests (all passing)
- ✅ Created 6 widget tests (all passing)
- ✅ Added `getCompletedGames()` to MockGameRepository
- ✅ Full test suite: 878 tests passing, 7 skipped (no regressions)

### Technical Decisions

1. **Pagination Strategy:** Uses Firestore DocumentSnapshot-based cursor pagination with limit+1 pattern for hasMore detection
2. **Stream Handling:** Uses `.first` instead of maintaining long-lived subscriptions to avoid BLoC lifecycle issues
3. **Filter State:** Tracks filter state in BLoC to support filter changes without losing pagination context
4. **Score Display:** Calculates team wins from `IndividualGame.winner` field

### Files Modified

**New Files:**
- `lib/features/games/presentation/bloc/game_history/` (BLoC + freezed files)
- `lib/features/games/presentation/pages/game_history_screen.dart`
- `lib/features/games/presentation/widgets/game_history_card.dart`
- `test/unit/features/games/presentation/bloc/game_history/game_history_bloc_test.dart`
- `test/widget/features/games/presentation/widgets/game_history_card_test.dart`

**Modified Files:**
- `lib/core/domain/repositories/game_repository.dart` (added getCompletedGames)
- `lib/core/data/repositories/firestore_game_repository.dart` (implemented getCompletedGames)
- `test/unit/core/data/repositories/mock_game_repository.dart` (added getCompletedGames)

### Checklist

- [x] All tests pass (878 tests, 7 skipped - same as baseline)
- [x] No secrets or Firebase configs committed
- [x] Code follows BLoC with Repository Pattern
- [x] Comprehensive test coverage (11 new tests)
- [x] Follows conventional commit format
- [x] No warnings or errors in flutter analyze

Closes #240