### PR TITLE
Story 14.11: Game Result Verification

### DIFF
--- a/PROJECT_ACTIONS.md
+++ b/PROJECT_ACTIONS.md
@@ -102,6 +102,8 @@ This document lists all user-facing actions available in the **PlayWithMe** appl
 - [ ] **Cancel Game**: Tap "Cancel Game" (Creator/Admin).
 - [ ] **Navigate to Record Results**: Tap "Record Results" (after game started).
 - [ ] **Navigate to View Result**: Tap "View Result" (completed game).
+- [ ] **Confirm Result**: Tap "Confirm" (during verification).
+- [ ] **Dispute/Edit Result**: Tap "Edit / Dispute" (during verification).
 
 ### Record Results Screen (`RecordResultsPage`)
 - [ ] **Assign Teams**: Drag/Drop or Select players for Team A/B.
@@ -109,7 +111,7 @@ This document lists all user-facing actions available in the **PlayWithMe** appl
 
 ### Score Entry Screen (`ScoreEntryPage`)
 - [ ] **Enter Score**: Input scores for sets.
-- [ ] **Save Result**: Tap "Finish Game" -> Triggers ELO calc.
+- [ ] **Save Result**: Tap "Finish Game" -> Moves game to `Verification` state.
 
 ### Game History Screen (`GameHistoryScreen`)
 - [ ] **View Completed Games**: Scroll list of globally completed games (or user specific).

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -42,6 +42,9 @@ class GameModel with _$GameModel {
     GameTeams? teams,
     // Game result (for completed games with entered scores)
     GameResult? result,
+    // Verification fields
+    String? resultSubmittedBy,
+    @Default([]) List<String> confirmedBy,
     // ELO calculation flag (set to false when result is saved, true after Python function processes)
     @Default(false) bool eloCalculated,
     // Timestamp when the game result was entered and completed
@@ -617,6 +620,8 @@ enum GameStatus {
   scheduled,
   @JsonValue('in_progress')
   inProgress,
+  @JsonValue('verification')
+  verification,
   @JsonValue('completed')
   completed,
   @JsonValue('cancelled')

--- a/lib/core/data/models/game_model.freezed.dart
+++ b/lib/core/data/models/game_model.freezed.dart
@@ -61,6 +61,9 @@ mixin _$GameModel {
   GameTeams? get teams =>
       throw _privateConstructorUsedError; // Game result (for completed games with entered scores)
   GameResult? get result =>
+      throw _privateConstructorUsedError; // Verification fields
+  String? get resultSubmittedBy => throw _privateConstructorUsedError;
+  List<String> get confirmedBy =>
       throw _privateConstructorUsedError; // ELO calculation flag (set to false when result is saved, true after Python function processes)
   bool get eloCalculated =>
       throw _privateConstructorUsedError; // Timestamp when the game result was entered and completed
@@ -114,6 +117,8 @@ abstract class $GameModelCopyWith<$Res> {
     String? winnerId,
     GameTeams? teams,
     GameResult? result,
+    String? resultSubmittedBy,
+    List<String> confirmedBy,
     bool eloCalculated,
     @TimestampConverter() DateTime? completedAt,
     bool weatherDependent,
@@ -169,6 +174,8 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
     Object? winnerId = freezed,
     Object? teams = freezed,
     Object? result = freezed,
+    Object? resultSubmittedBy = freezed,
+    Object? confirmedBy = null,
     Object? eloCalculated = null,
     Object? completedAt = freezed,
     Object? weatherDependent = null,
@@ -292,6 +299,14 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
                 ? _value.result
                 : result // ignore: cast_nullable_to_non_nullable
                       as GameResult?,
+            resultSubmittedBy: freezed == resultSubmittedBy
+                ? _value.resultSubmittedBy
+                : resultSubmittedBy // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            confirmedBy: null == confirmedBy
+                ? _value.confirmedBy
+                : confirmedBy // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
             eloCalculated: null == eloCalculated
                 ? _value.eloCalculated
                 : eloCalculated // ignore: cast_nullable_to_non_nullable
@@ -391,6 +406,8 @@ abstract class _$$GameModelImplCopyWith<$Res>
     String? winnerId,
     GameTeams? teams,
     GameResult? result,
+    String? resultSubmittedBy,
+    List<String> confirmedBy,
     bool eloCalculated,
     @TimestampConverter() DateTime? completedAt,
     bool weatherDependent,
@@ -448,6 +465,8 @@ class __$$GameModelImplCopyWithImpl<$Res>
     Object? winnerId = freezed,
     Object? teams = freezed,
     Object? result = freezed,
+    Object? resultSubmittedBy = freezed,
+    Object? confirmedBy = null,
     Object? eloCalculated = null,
     Object? completedAt = freezed,
     Object? weatherDependent = null,
@@ -571,6 +590,14 @@ class __$$GameModelImplCopyWithImpl<$Res>
             ? _value.result
             : result // ignore: cast_nullable_to_non_nullable
                   as GameResult?,
+        resultSubmittedBy: freezed == resultSubmittedBy
+            ? _value.resultSubmittedBy
+            : resultSubmittedBy // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        confirmedBy: null == confirmedBy
+            ? _value._confirmedBy
+            : confirmedBy // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
         eloCalculated: null == eloCalculated
             ? _value.eloCalculated
             : eloCalculated // ignore: cast_nullable_to_non_nullable
@@ -625,6 +652,8 @@ class _$GameModelImpl extends _GameModel {
     this.winnerId,
     this.teams,
     this.result,
+    this.resultSubmittedBy,
+    final List<String> confirmedBy = const [],
     this.eloCalculated = false,
     @TimestampConverter() this.completedAt,
     this.weatherDependent = true,
@@ -633,6 +662,7 @@ class _$GameModelImpl extends _GameModel {
        _waitlistIds = waitlistIds,
        _equipment = equipment,
        _scores = scores,
+       _confirmedBy = confirmedBy,
        super._();
 
   factory _$GameModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -742,6 +772,18 @@ class _$GameModelImpl extends _GameModel {
   // Game result (for completed games with entered scores)
   @override
   final GameResult? result;
+  // Verification fields
+  @override
+  final String? resultSubmittedBy;
+  final List<String> _confirmedBy;
+  @override
+  @JsonKey()
+  List<String> get confirmedBy {
+    if (_confirmedBy is EqualUnmodifiableListView) return _confirmedBy;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_confirmedBy);
+  }
+
   // ELO calculation flag (set to false when result is saved, true after Python function processes)
   @override
   @JsonKey()
@@ -759,7 +801,7 @@ class _$GameModelImpl extends _GameModel {
 
   @override
   String toString() {
-    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, eloCalculated: $eloCalculated, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes)';
+    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes)';
   }
 
   @override
@@ -822,6 +864,12 @@ class _$GameModelImpl extends _GameModel {
                 other.winnerId == winnerId) &&
             (identical(other.teams, teams) || other.teams == teams) &&
             (identical(other.result, result) || other.result == result) &&
+            (identical(other.resultSubmittedBy, resultSubmittedBy) ||
+                other.resultSubmittedBy == resultSubmittedBy) &&
+            const DeepCollectionEquality().equals(
+              other._confirmedBy,
+              _confirmedBy,
+            ) &&
             (identical(other.eloCalculated, eloCalculated) ||
                 other.eloCalculated == eloCalculated) &&
             (identical(other.completedAt, completedAt) ||
@@ -865,6 +913,8 @@ class _$GameModelImpl extends _GameModel {
     winnerId,
     teams,
     result,
+    resultSubmittedBy,
+    const DeepCollectionEquality().hash(_confirmedBy),
     eloCalculated,
     completedAt,
     weatherDependent,
@@ -916,6 +966,8 @@ abstract class _GameModel extends GameModel {
     final String? winnerId,
     final GameTeams? teams,
     final GameResult? result,
+    final String? resultSubmittedBy,
+    final List<String> confirmedBy,
     final bool eloCalculated,
     @TimestampConverter() final DateTime? completedAt,
     final bool weatherDependent,
@@ -988,7 +1040,11 @@ abstract class _GameModel extends GameModel {
   @override
   GameTeams? get teams; // Game result (for completed games with entered scores)
   @override
-  GameResult? get result; // ELO calculation flag (set to false when result is saved, true after Python function processes)
+  GameResult? get result; // Verification fields
+  @override
+  String? get resultSubmittedBy;
+  @override
+  List<String> get confirmedBy; // ELO calculation flag (set to false when result is saved, true after Python function processes)
   @override
   bool get eloCalculated; // Timestamp when the game result was entered and completed
   @override

--- a/lib/core/data/models/game_model.g.dart
+++ b/lib/core/data/models/game_model.g.dart
@@ -60,6 +60,12 @@ _$GameModelImpl _$$GameModelImplFromJson(
   result: json['result'] == null
       ? null
       : GameResult.fromJson(json['result'] as Map<String, dynamic>),
+  resultSubmittedBy: json['resultSubmittedBy'] as String?,
+  confirmedBy:
+      (json['confirmedBy'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
   eloCalculated: json['eloCalculated'] as bool? ?? false,
   completedAt: const TimestampConverter().fromJson(json['completedAt']),
   weatherDependent: json['weatherDependent'] as bool? ?? true,
@@ -97,6 +103,8 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
       'winnerId': instance.winnerId,
       'teams': instance.teams,
       'result': instance.result,
+      'resultSubmittedBy': instance.resultSubmittedBy,
+      'confirmedBy': instance.confirmedBy,
       'eloCalculated': instance.eloCalculated,
       'completedAt': const TimestampConverter().toJson(instance.completedAt),
       'weatherDependent': instance.weatherDependent,
@@ -106,6 +114,7 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
 const _$GameStatusEnumMap = {
   GameStatus.scheduled: 'scheduled',
   GameStatus.inProgress: 'in_progress',
+  GameStatus.verification: 'verification',
   GameStatus.completed: 'completed',
   GameStatus.cancelled: 'cancelled',
 };

--- a/lib/core/domain/repositories/game_repository.dart
+++ b/lib/core/domain/repositories/game_repository.dart
@@ -90,6 +90,10 @@ abstract class GameRepository {
     required GameResult result,
   });
 
+  /// Confirm game result
+  /// Adds user to confirmedBy list. If confirmed, status changes to completed.
+  Future<void> confirmGameResult(String gameId, String userId);
+
   /// Update game scores
   Future<void> updateScores(String gameId, List<GameScore> scores);
 

--- a/lib/features/games/presentation/bloc/game_details/game_details_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_details/game_details_bloc.dart
@@ -17,6 +17,7 @@ class GameDetailsBloc extends Bloc<GameDetailsEvent, GameDetailsState> {
     on<JoinGameDetails>(_onJoinGameDetails);
     on<LeaveGameDetails>(_onLeaveGameDetails);
     on<MarkGameCompleted>(_onMarkGameCompleted);
+    on<ConfirmGameResult>(_onConfirmGameResult);
   }
 
   Future<void> _onLoadGameDetails(
@@ -133,6 +134,29 @@ class GameDetailsBloc extends Bloc<GameDetailsEvent, GameDetailsState> {
       emit(GameDetailsError(
         message: 'Failed to mark game as completed: ${e.toString()}',
         errorCode: 'MARK_COMPLETED_ERROR',
+      ));
+    }
+  }
+
+  Future<void> _onConfirmGameResult(
+    ConfirmGameResult event,
+    Emitter<GameDetailsState> emit,
+  ) async {
+    try {
+      if (state is GameDetailsLoaded) {
+        final currentGame = (state as GameDetailsLoaded).game;
+        emit(GameDetailsOperationInProgress(
+          game: currentGame,
+          operation: 'confirm_result',
+        ));
+      }
+
+      await _gameRepository.confirmGameResult(event.gameId, event.userId);
+      // Stream updates state
+    } catch (e) {
+      emit(GameDetailsError(
+        message: 'Failed to confirm result: ${e.toString()}',
+        errorCode: 'CONFIRM_RESULT_ERROR',
       ));
     }
   }

--- a/lib/features/games/presentation/bloc/game_details/game_details_event.dart
+++ b/lib/features/games/presentation/bloc/game_details/game_details_event.dart
@@ -60,3 +60,16 @@ class MarkGameCompleted extends GameDetailsEvent {
   @override
   List<Object?> get props => [gameId, userId];
 }
+
+class ConfirmGameResult extends GameDetailsEvent {
+  final String gameId;
+  final String userId;
+
+  const ConfirmGameResult({
+    required this.gameId,
+    required this.userId,
+  });
+
+  @override
+  List<Object?> get props => [gameId, userId];
+}

--- a/test/unit/core/data/repositories/mock_game_repository.dart
+++ b/test/unit/core/data/repositories/mock_game_repository.dart
@@ -430,6 +430,38 @@ class MockGameRepository implements GameRepository {
   }
 
   @override
+  Future<void> confirmGameResult(String gameId, String userId) async {
+    final game = _games[gameId];
+    if (game == null) throw Exception('Game not found');
+
+    if (game.status != GameStatus.verification) {
+      throw Exception('Game is not in verification state');
+    }
+
+    if (game.resultSubmittedBy == userId) {
+      throw Exception('You cannot confirm your own result');
+    }
+
+    if (game.confirmedBy.contains(userId)) {
+      throw Exception('You have already confirmed this result');
+    }
+
+    final updatedConfirmedBy = [...game.confirmedBy, userId];
+    final newStatus = GameStatus.completed;
+
+    final updatedGame = game.copyWith(
+      confirmedBy: updatedConfirmedBy,
+      status: newStatus,
+      eloCalculated: false,
+      updatedAt: DateTime.now(),
+    );
+
+    _games[gameId] = updatedGame;
+    _emitGames();
+    _emitGameUpdate(gameId);
+  }
+
+  @override
   Future<void> updateScores(String gameId, List<GameScore> scores) async {
     final game = _games[gameId];
     if (game == null) throw Exception('Game not found');

--- a/test/widget/features/games/presentation/pages/game_details_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_page_test.dart
@@ -357,10 +357,9 @@ void main() {
       expect(find.text('Past Test Game'), findsOneWidget);
 
       // Since the test user IS playing the past game (test-uid-123 in playerIds),
-      // the "I'm Out" button shows. The user can't actually leave since status is
-      // completed, but the button renders based on isPlaying check.
-      // Non-playing users would see "Game has ended" message instead.
-      expect(find.text('I\'m Out'), findsOneWidget);
+      // previously the "I'm Out" button showed. Now with Verification flow,
+      // RSVP buttons are hidden for completed games.
+      expect(find.text('I\'m Out'), findsNothing);
     });
 
     testWidgets('scrolls to reveal all game details', (tester) async {

--- a/test/widget/features/games/presentation/pages/game_details_verification_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_verification_test.dart
@@ -1,0 +1,107 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/games/presentation/pages/game_details_page.dart';
+
+import '../../../../../unit/core/data/repositories/mock_game_repository.dart';
+
+class MockAuthenticationBloc extends MockBloc<AuthenticationEvent, AuthenticationState>
+    implements AuthenticationBloc {}
+
+void main() {
+  late MockGameRepository mockGameRepository;
+  late MockAuthenticationBloc mockAuthBloc;
+  final sl = GetIt.instance;
+
+  const submitterId = 'user-1';
+  const verifierId = 'user-2';
+  
+  final verificationGame = TestGameData.testGame.copyWith(
+    id: 'verify-game-1',
+    status: GameStatus.verification,
+    playerIds: [submitterId, verifierId],
+    resultSubmittedBy: submitterId,
+    result: const GameResult(
+      games: [], // Empty for test, not validated by UI
+      overallWinner: 'teamA',
+    ),
+  );
+
+  setUp(() {
+    mockGameRepository = MockGameRepository();
+    mockAuthBloc = MockAuthenticationBloc();
+    
+    if (sl.isRegistered<GameRepository>()) {
+      sl.unregister<GameRepository>();
+    }
+    sl.registerSingleton<GameRepository>(mockGameRepository);
+  });
+
+  tearDown(() {
+    sl.reset();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<AuthenticationBloc>.value(
+        value: mockAuthBloc,
+        child: GameDetailsPage(gameId: verificationGame.id),
+      ),
+    );
+  }
+
+  testWidgets('GameDetailsPage shows "Result Submitted" for submitter', (tester) async {
+    mockGameRepository.addGame(verificationGame);
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: submitterId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Result Submitted'), findsOneWidget);
+    expect(find.text('Confirm'), findsNothing);
+    expect(find.text('Edit / Dispute'), findsOneWidget);
+  });
+
+  testWidgets('GameDetailsPage shows "Verification Pending" and Confirm button for verifier', (tester) async {
+    mockGameRepository.addGame(verificationGame);
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: verifierId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Result Verification Pending'), findsOneWidget);
+    expect(find.text('Confirm'), findsOneWidget);
+    expect(find.text('Edit / Dispute'), findsOneWidget);
+  });
+
+  testWidgets('GameDetailsPage shows "Confirmed" for user who already confirmed', (tester) async {
+    final confirmedGame = verificationGame.copyWith(
+      confirmedBy: [verifierId],
+    );
+    mockGameRepository.addGame(confirmedGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: verifierId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.text('Confirm'), findsNothing);
+    expect(find.text('Edit / Dispute'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Implementation Details
- Implemented **Peer Verification** flow for game results.
- Added `GameStatus.verification`.
- Updated `GameModel` with `resultSubmittedBy` and `confirmedBy`.
- Updated `GameDetailsPage` to show:
  - 'Verification Pending' banner.
  - 'Confirm' button for other players.
  - 'Edit / Dispute' button for all players.
- Updated `GameRepository` to handle atomic confirmations.

## Flow
1. Any player submits score -> Game enters `verification` state.
2. Other players see 'Confirm' button.
3. If one other player confirms -> Game becomes `completed` -> ELO triggers.
4. If edit is needed, any player can edit -> Reset to `verification` state.

## Testing
- ✅ Unit tests for `GameDetailsBloc` confirmation flow.
- ✅ Widget tests for verification UI states.

Closes #243