### PR TITLE
Story 14.14: Democratize Game Result Entry

### DIFF
--- a/docs/epic-14/story-14.14/README.md
+++ b/docs/epic-14/story-14.14/README.md
@@ -1,0 +1,33 @@
+# Story 14.14: Democratize Game Result Entry
+
+## Overview
+This story implements the "Democratized Result Entry" pattern, allowing any participant of a game to enter scores once the game is finished, removing the dependency on the Game Creator.
+
+## Key Changes
+
+### 1. UI Logic (GameDetailsPage)
+The "Enter Results" button is now visible to **all participants** (and the creator) if:
+- The game status is `completed` OR `in_progress`.
+- OR The game's scheduled time is in the past.
+- AND The game does not yet have a result recorded.
+- AND The game is not cancelled or in verification state.
+
+This logic is encapsulated in `GameModel.canUserEnterResults(userId)`.
+
+### 2. Repository Permissions (FirestoreGameRepository)
+The permission checks in `saveGameResult` and `updateGameTeams` have been relaxed:
+- **Old:** `if (!isCreator) throw ...`
+- **New:** `if (!isPlayer && !isCreator) throw ...`
+
+### 3. Implicit Completion
+The system no longer requires an explicit "Mark as Completed" step by the creator before results can be entered. If a participant enters results for a scheduled game, the game status implicitly transitions to `verification` (via Story 14.11 flow).
+
+## Security & Validation
+- Only verified participants (in `playerIds`) can submit results.
+- Cancelled games cannot have results entered.
+- Verification status blocks re-entry until resolved (or edited).
+
+## Testing
+- **Widget Tests:** `game_details_result_entry_test.dart` verifies button visibility for various user roles and game states.
+- **Integration Tests:** `game_result_persistence_test.dart` verifies the end-to-end flow of a participant saving data.
+- **Unit Tests:** BLoC tests updated to ensure state transitions allow non-completed games to proceed to result entry.

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -218,6 +218,27 @@ class GameModel with _$GameModel {
            status == GameStatus.scheduled;
   }
 
+  /// Check if user can enter/record results for the game
+  /// Allows participants (or creator) to enter results if the game is ready
+  /// (completed, in-progress, or past scheduled time)
+  bool canUserEnterResults(String userId) {
+    final isParticipant = isPlayer(userId) || isCreator(userId);
+    final hasExistingResult = result != null;
+    final isCancelled = status == GameStatus.cancelled;
+    final isVerification = status == GameStatus.verification;
+    
+    final isReady = status == GameStatus.completed || 
+                    status == GameStatus.inProgress || 
+                    isPast || 
+                    isCreator(userId);
+
+    return isParticipant && 
+           !isCancelled && 
+           !isVerification && 
+           !hasExistingResult && 
+           isReady;
+  }
+
   /// Validation methods
 
   /// Validate game timing

--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -392,14 +392,14 @@ class FirestoreGameRepository implements GameRepository {
         throw Exception('Game not found');
       }
 
-      // Check if user has permission (creator only for now)
-      if (!currentGame.isCreator(userId)) {
-        throw Exception('Only the game creator can update teams');
+      // Check if user has permission (participant or creator)
+      if (!currentGame.isPlayer(userId) && !currentGame.isCreator(userId)) {
+        throw Exception('Only participants can update teams');
       }
 
-      // Check if game is completed
-      if (currentGame.status != GameStatus.completed) {
-        throw Exception('Can only assign teams to completed games');
+      // Check if game is active
+      if (currentGame.status == GameStatus.cancelled) {
+        throw Exception('Cannot update teams for a cancelled game');
       }
 
       // Validate teams
@@ -435,14 +435,14 @@ class FirestoreGameRepository implements GameRepository {
         throw Exception('Game not found');
       }
 
-      // Check if user has permission (creator only for now)
-      if (!currentGame.isCreator(userId)) {
-        throw Exception('Only the game creator can update game result');
+      // Check if user has permission (participant or creator)
+      if (!currentGame.isPlayer(userId) && !currentGame.isCreator(userId)) {
+        throw Exception('Only participants can update game result');
       }
 
-      // Check if game is completed
-      if (currentGame.status != GameStatus.completed) {
-        throw Exception('Can only add result to completed games');
+      // Check if game is active
+      if (currentGame.status == GameStatus.cancelled) {
+        throw Exception('Cannot update result of a cancelled game');
       }
 
       // Check if teams are assigned
@@ -503,14 +503,14 @@ class FirestoreGameRepository implements GameRepository {
 
         final currentGame = GameModel.fromFirestore(snapshot);
 
-        // Check if user has permission (creator only for now)
-        if (!currentGame.isCreator(userId)) {
-          throw Exception('Only the game creator can save game result');
+        // Check if user has permission (participant or creator)
+        if (!currentGame.isPlayer(userId) && !currentGame.isCreator(userId)) {
+          throw Exception('Only participants can save game result');
         }
 
-        // Check if game is completed
-        if (currentGame.status != GameStatus.completed) {
-          throw Exception('Can only save result to completed games');
+        // Check if game is active
+        if (currentGame.status == GameStatus.cancelled) {
+          throw Exception('Cannot save result to a cancelled game');
         }
 
         // Validate teams

--- a/lib/features/games/presentation/bloc/record_results/record_results_bloc.dart
+++ b/lib/features/games/presentation/bloc/record_results/record_results_bloc.dart
@@ -34,8 +34,8 @@ class RecordResultsBloc extends Bloc<RecordResultsEvent, RecordResultsState> {
         return;
       }
 
-      if (game.status != GameStatus.completed) {
-        emit(const RecordResultsError(message: 'Game must be completed before assigning teams'));
+      if (game.status == GameStatus.cancelled) {
+        emit(const RecordResultsError(message: 'Cannot record results for a cancelled game'));
         return;
       }
 

--- a/lib/features/games/presentation/bloc/score_entry/score_entry_bloc.dart
+++ b/lib/features/games/presentation/bloc/score_entry/score_entry_bloc.dart
@@ -33,8 +33,8 @@ class ScoreEntryBloc extends Bloc<ScoreEntryEvent, ScoreEntryState> {
       }
 
       // Validate game state
-      if (game.status != GameStatus.completed) {
-        emit(const ScoreEntryError(message: 'Game must be completed before entering scores'));
+      if (game.status == GameStatus.cancelled) {
+        emit(const ScoreEntryError(message: 'Cannot enter scores for a cancelled game'));
         return;
       }
 

--- a/test/unit/features/games/presentation/bloc/record_results/record_results_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/record_results/record_results_bloc_test.dart
@@ -58,7 +58,7 @@ void main() {
       );
 
       blocTest<RecordResultsBloc, RecordResultsState>(
-        'emits [loading, error] when game is not completed',
+        'emits [loading, loaded] when game is scheduled (implicitly completing)',
         build: () {
           mockGameRepository.addGame(TestGameData.testGame); // scheduled game
           return RecordResultsBloc(gameRepository: mockGameRepository);
@@ -66,7 +66,7 @@ void main() {
         act: (bloc) => bloc.add(const LoadGameForResults(gameId: 'test-game-123')),
         expect: () => [
           const RecordResultsLoading(),
-          const RecordResultsError(message: 'Game must be completed before assigning teams'),
+          isA<RecordResultsLoaded>(),
         ],
       );
 

--- a/test/unit/features/games/presentation/bloc/score_entry/score_entry_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/score_entry/score_entry_bloc_test.dart
@@ -102,15 +102,19 @@ void main() {
       );
 
       blocTest<ScoreEntryBloc, ScoreEntryState>(
-        'emits error when game not completed',
+        'emits loaded when game is scheduled (implicitly completing)',
         build: () {
-          mockGameRepository.addGame(TestGameData.testGame); // scheduled game
+          final scheduledGame = TestGameData.testGame.copyWith(
+            status: GameStatus.scheduled,
+            teams: const GameTeams(teamAPlayerIds: ['p1'], teamBPlayerIds: ['p2']),
+          );
+          mockGameRepository.addGame(scheduledGame); // scheduled game
           return ScoreEntryBloc(gameRepository: mockGameRepository);
         },
         act: (bloc) => bloc.add(const LoadGameForScoreEntry(gameId: 'test-game-123')),
         expect: () => [
           const ScoreEntryLoading(),
-          const ScoreEntryError(message: 'Game must be completed before entering scores'),
+          isA<ScoreEntryLoaded>(),
         ],
       );
 

--- a/test/widget/features/games/presentation/pages/game_details_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_page_test.dart
@@ -360,6 +360,10 @@ void main() {
       // previously the "I'm Out" button showed. Now with Verification flow,
       // RSVP buttons are hidden for completed games.
       expect(find.text('I\'m Out'), findsNothing);
+      
+      // With Democratized Entry (Story 14.14), participants can enter results
+      // for past/completed games if no result exists yet.
+      expect(find.text('Enter Results'), findsOneWidget);
     });
 
     testWidgets('scrolls to reveal all game details', (tester) async {

--- a/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
@@ -1,0 +1,161 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/games/presentation/pages/game_details_page.dart';
+import 'package:play_with_me/features/games/presentation/pages/record_results_page.dart';
+
+import '../../../../../unit/core/data/repositories/mock_game_repository.dart';
+
+class MockAuthenticationBloc extends MockBloc<AuthenticationEvent, AuthenticationState>
+    implements AuthenticationBloc {}
+
+void main() {
+  late MockGameRepository mockGameRepository;
+  late MockAuthenticationBloc mockAuthBloc;
+  final sl = GetIt.instance;
+
+  const creatorId = 'user-creator';
+  const participantId = 'user-participant';
+  const outsiderId = 'user-outsider';
+  
+  final baseGame = TestGameData.testGame.copyWith(
+    id: 'game-1',
+    createdBy: creatorId,
+    playerIds: [creatorId, participantId],
+    status: GameStatus.scheduled,
+    result: null,
+  );
+
+  setUp(() {
+    mockGameRepository = MockGameRepository();
+    mockAuthBloc = MockAuthenticationBloc();
+    
+    if (sl.isRegistered<GameRepository>()) {
+      sl.unregister<GameRepository>();
+    }
+    sl.registerSingleton<GameRepository>(mockGameRepository);
+  });
+
+  tearDown(() {
+    sl.reset();
+  });
+
+  Widget createWidgetUnderTest(String gameId) {
+    return MaterialApp(
+      home: BlocProvider<AuthenticationBloc>.value(
+        value: mockAuthBloc,
+        child: GameDetailsPage(gameId: gameId),
+      ),
+    );
+  }
+
+  testWidgets('Participant sees "Enter Results" button when game is past', (tester) async {
+    final pastGame = baseGame.copyWith(
+      scheduledAt: DateTime.now().subtract(const Duration(hours: 2)),
+    );
+    mockGameRepository.addGame(pastGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: participantId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(pastGame.id));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter Results'), findsOneWidget);
+  });
+
+  testWidgets('Participant does NOT see "Enter Results" button when game is future', (tester) async {
+    final futureGame = baseGame.copyWith(
+      scheduledAt: DateTime.now().add(const Duration(hours: 2)),
+    );
+    mockGameRepository.addGame(futureGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: participantId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(futureGame.id));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter Results'), findsNothing);
+  });
+
+  testWidgets('Creator sees "Enter Results" button even when game is future', (tester) async {
+    final futureGame = baseGame.copyWith(
+      scheduledAt: DateTime.now().add(const Duration(hours: 2)),
+    );
+    mockGameRepository.addGame(futureGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: creatorId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(futureGame.id));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter Results'), findsOneWidget);
+  });
+
+  testWidgets('Participant sees "Enter Results" button when game is in progress', (tester) async {
+    final inProgressGame = baseGame.copyWith(
+      status: GameStatus.inProgress,
+      // Ensure scheduledAt is future to prove status overrides time check
+      scheduledAt: DateTime.now().add(const Duration(hours: 1)),
+    );
+    mockGameRepository.addGame(inProgressGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: participantId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(inProgressGame.id));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter Results'), findsOneWidget);
+  });
+
+  testWidgets('Outsider does NOT see "Enter Results" button even when game is past', (tester) async {
+    final pastGame = baseGame.copyWith(
+      scheduledAt: DateTime.now().subtract(const Duration(hours: 2)),
+    );
+    mockGameRepository.addGame(pastGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: outsiderId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(pastGame.id));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter Results'), findsNothing);
+  });
+
+  testWidgets('"Enter Results" button navigates to RecordResultsPage', (tester) async {
+    final pastGame = baseGame.copyWith(
+      scheduledAt: DateTime.now().subtract(const Duration(hours: 2)),
+    );
+    mockGameRepository.addGame(pastGame);
+    
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(UserEntity(uid: participantId, email: '', isEmailVerified: true, isAnonymous: false)),
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest(pastGame.id));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Enter Results'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RecordResultsPage), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Implementation Details
- Updated `GameDetailsPage` logic to show 'Enter Results' button to **all participants** if the game is completed or past its scheduled time.
- Updated `FirestoreGameRepository` to remove creator-only restriction for `saveGameResult` and `updateGameTeams`.
- Updated `FirestoreGameRepository` to allow saving results for non-completed (e.g. scheduled) games, which implicitly moves them to `verification` status.
- Added comprehensive widget tests for button visibility logic.
- Updated integration tests to verify participant result entry flow.

## Testing
- ✅ Unit/Widget tests: `test/widget/features/games/presentation/pages/game_details_result_entry_test.dart`
- ✅ Integration tests: `integration_test/game_result_persistence_test.dart`

Closes #265