### PR TITLE
Story 14.15: Notifications for Game Result Verification

### DIFF
--- a/docs/epic-14/story-14.15/README.md
+++ b/docs/epic-14/story-14.15/README.md
@@ -1,0 +1,188 @@
+# Story 14.15: Notifications for Game Result Verification
+
+## Overview
+
+This story implements push notifications to alert players when a game result has been submitted for verification, enabling timely confirmation and preventing games from getting stuck in pending verification state.
+
+## User Story
+
+As a player, I want to receive a notification when a game result is submitted, so that I can promptly review and confirm the score.
+
+## Context
+
+With the Verification Flow (Story 14.11), games require a second player to confirm the result before ELO is calculated. Without notifications, players might not know they need to take action, leaving games in a 'Verification Pending' state indefinitely.
+
+## Implementation
+
+### Cloud Function: `onGameResultSubmitted`
+
+**Location:** `functions/src/notifications.ts`
+
+**Trigger:** Firestore document update on `games/{gameId}`
+
+**Condition:** Triggers when game status changes to `verification`
+
+**Logic:**
+1. Detects status transition from any state to `verification`
+2. Retrieves submitter's name (firstName + lastName, displayName, email, or "Someone")
+3. Collects FCM tokens from all confirmed participants except the submitter
+4. Respects notification preferences:
+   - Global `gameResultSubmitted` preference
+   - Group-specific `gameResultSubmitted` preference
+   - Quiet hours settings
+5. Sends multicast FCM notification
+6. Cleans up invalid FCM tokens
+
+**Notification Content:**
+- **Title:** "Game Result Posted"
+- **Body:** "[Submitter Name] posted the score for [Game Title]. Please confirm the result."
+- **Data Payload:**
+  - `type`: "game_result_submitted"
+  - `groupId`: The group ID
+  - `gameId`: The game ID
+  - `submitterId`: User who submitted the result
+  - `submitterName`: Display name of submitter
+
+**Deep Linking:**
+The notification data includes `gameId` which the Flutter app uses to navigate directly to `GameDetailsPage`.
+
+## Testing
+
+### Unit Tests
+
+**Location:** `functions/test/unit/onGameResultSubmitted.test.ts`
+
+**Coverage:** 19 test cases covering:
+- Status transition detection (3 tests)
+- Notification sending (6 tests)
+- Notification preferences (2 tests)
+- Quiet hours (1 test)
+- Edge cases (4 tests)
+- Invalid token cleanup (2 tests)
+- Error handling (1 test)
+
+**Test Results:** ✅ All 19 tests passing
+
+### Key Test Scenarios
+
+1. **Status Transition Detection**
+   - ✅ Triggers when status changes to 'verification'
+   - ✅ Does not trigger if status was already 'verification'
+   - ✅ Does not trigger for other status changes
+
+2. **Notification Sending**
+   - ✅ Sends to all players except submitter
+   - ✅ Handles missing game title
+   - ✅ Uses correct name fallback order (firstName+lastName → displayName → email → "Someone")
+
+3. **Preferences & Privacy**
+   - ✅ Respects global `gameResultSubmitted` preference
+   - ✅ Respects group-specific preferences
+   - ✅ Honors quiet hours
+
+4. **Edge Cases**
+   - ✅ Handles games with no players
+   - ✅ Handles players without FCM tokens
+   - ✅ Handles games with only the submitter
+   - ✅ Handles missing submitter document
+
+5. **Token Management**
+   - ✅ Removes invalid FCM tokens
+   - ✅ Preserves valid tokens on non-token errors
+
+## Deployment
+
+The Cloud Function has been deployed to all environments:
+
+- ✅ `playwithme-dev`
+- ✅ `playwithme-stg`
+- ✅ `playwithme-prod`
+
+**Deployment Command:**
+```bash
+firebase use <project-id>
+firebase deploy --only functions:onGameResultSubmitted
+```
+
+## Idempotency
+
+The function is idempotent due to the status check:
+- Only triggers when transitioning **to** `verification`
+- Does not re-trigger if status remains `verification`
+- If a result is edited and re-submitted, the status transitions again (scheduled → verification), triggering a new notification
+
+This ensures players are notified of every meaningful update requiring verification, without duplicate notifications for the same submission.
+
+## Security & Privacy
+
+- ✅ Only notifies confirmed participants (players in `playerIds`)
+- ✅ Excludes the submitter from notifications
+- ✅ Respects user notification preferences at global and group levels
+- ✅ Honors quiet hours settings
+- ✅ Uses secure FCM token handling with automatic cleanup
+- ✅ Logs all actions for audit trail
+
+## Integration with Existing Features
+
+### Story 14.11: Game Result Verification Flow
+- Complements the verification UI by notifying players when action is required
+- Notification deep-links to the game details page where players can confirm results
+
+### Story 14.14: Democratize Game Result Entry
+- Works seamlessly with democratized result entry
+- Any participant can submit results, triggering notifications to all others
+
+### Notification Infrastructure
+- Reuses existing FCM infrastructure from `functions/src/notifications.ts`
+- Follows the same patterns as other game notifications (`onGameCreated`, `onPlayerJoinedGame`, etc.)
+- Integrates with notification preferences system
+
+## User Experience Flow
+
+1. **Player A** enters game results after the game ends
+2. Game status changes from `completed` to `verification`
+3. **Cloud Function** detects the status change
+4. **Notification sent** to all other players (B, C, D) except Player A
+5. **Players B, C, D** receive push notification: "Player A posted the score for Beach Volleyball. Please confirm the result."
+6. **Player taps notification** → Deep-links to Game Details Page
+7. **Player confirms** result → Game status changes to `completed`
+8. ELO calculation proceeds (Story 14.5)
+
+## Future Enhancements
+
+Potential improvements for future stories:
+- Add a "reminder" notification if result remains unconfirmed after 24 hours
+- Include score summary in notification body
+- Support notification customization (e.g., different tones for different game types)
+- Add notification batching for users in multiple games
+
+## Files Changed
+
+### Cloud Functions
+- `functions/src/notifications.ts` - Added `onGameResultSubmitted` function
+- `functions/src/index.ts` - Exported new function
+- `functions/test/unit/onGameResultSubmitted.test.ts` - Added comprehensive unit tests
+
+### Documentation
+- `docs/epic-14/story-14.15/README.md` - This file
+
+## Acceptance Criteria Status
+
+- ✅ **Trigger:** Function triggers when game enters `verification` state
+- ✅ **Audience:** Sends to all confirmed participants except the submitter
+- ✅ **Content:** Notification includes correct title and body with submitter name and game title
+- ✅ **Navigation:** Data payload includes `gameId` for deep-linking to GameDetailsPage
+- ✅ **Idempotency:** Only one notification per status transition to `verification`
+
+## Related Stories
+
+- **Story 14.11:** Game Result Verification Flow
+- **Story 14.14:** Democratize Game Result Entry
+- **Story 14.5:** ELO Rating Calculation
+- **Story 3.2:** Game Created Notifications (notification infrastructure foundation)
+
+---
+
+**Status:** ✅ Completed
+**Deployed:** Yes (all environments)
+**Tests:** 19/19 passing

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -55,4 +55,5 @@ export {
   onPlayerJoinedGame,
   onPlayerLeftGame,
   onWaitlistPromoted,
+  onGameResultSubmitted, // Story 14.15
 } from "./notifications";

--- a/functions/test/unit/onGameResultSubmitted.test.ts
+++ b/functions/test/unit/onGameResultSubmitted.test.ts
@@ -1,0 +1,906 @@
+// Unit tests for onGameResultSubmitted Cloud Function
+// Story 14.15: Notifications for Game Result Verification
+
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+          arrayRemove: jest.fn((...elements) => ({
+            _methodName: "FieldValue.arrayRemove",
+            _elements: elements,
+          })),
+        },
+      }
+    ),
+    messaging: jest.fn(() => ({
+      sendEachForMulticast: jest.fn(),
+    })),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  firestore: {
+    document: jest.fn(() => ({
+      onCreate: jest.fn((handler) => handler),
+      onUpdate: jest.fn((handler) => handler),
+      onDelete: jest.fn((handler) => handler),
+    })),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("onGameResultSubmitted Cloud Function", () => {
+  let mockDb: any;
+  let mockMessaging: any;
+  let mockSubmitterDoc: any;
+  let mockPlayer1Doc: any;
+  let mockPlayer2Doc: any;
+  let mockPlayer3Doc: any;
+
+  // Re-import to get fresh mocks
+  let onGameResultSubmittedHandler: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Setup mock messaging
+    mockMessaging = {
+      sendEachForMulticast: jest.fn().mockResolvedValue({
+        successCount: 3,
+        failureCount: 0,
+        responses: [{success: true}, {success: true}, {success: true}],
+      }),
+    };
+
+    // Setup mock player documents
+    mockPlayer1Doc = {
+      data: jest.fn().mockReturnValue({
+        displayName: "Player 1",
+        fcmTokens: ["token1"],
+        notificationPreferences: {
+          gameResultSubmitted: true,
+          quietHours: {enabled: false},
+        },
+      }),
+      exists: true,
+    };
+
+    mockPlayer2Doc = {
+      data: jest.fn().mockReturnValue({
+        displayName: "Player 2",
+        fcmTokens: ["token2"],
+        notificationPreferences: {
+          gameResultSubmitted: true,
+          quietHours: {enabled: false},
+        },
+      }),
+      exists: true,
+    };
+
+    mockPlayer3Doc = {
+      data: jest.fn().mockReturnValue({
+        displayName: "Player 3",
+        fcmTokens: ["token3"],
+        notificationPreferences: {
+          gameResultSubmitted: true,
+          quietHours: {enabled: false},
+        },
+      }),
+      exists: true,
+    };
+
+    // Setup mock submitter document
+    mockSubmitterDoc = {
+      data: jest.fn().mockReturnValue({
+        displayName: "Submitter User",
+        firstName: "Submitter",
+        lastName: "User",
+      }),
+      exists: true,
+    };
+
+    // Setup mock Firestore
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "users") {
+          return {
+            doc: jest.fn((userId: string) => ({
+              get: jest.fn().mockImplementation(() => {
+                if (userId === "submitter123") return Promise.resolve(mockSubmitterDoc);
+                if (userId === "player1") return Promise.resolve(mockPlayer1Doc);
+                if (userId === "player2") return Promise.resolve(mockPlayer2Doc);
+                if (userId === "player3") return Promise.resolve(mockPlayer3Doc);
+                return Promise.resolve({exists: false, data: () => null});
+              }),
+              update: jest.fn().mockResolvedValue({}),
+            })),
+          };
+        }
+        return {doc: jest.fn()};
+      }),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+    (admin.messaging as unknown as jest.Mock).mockReturnValue(mockMessaging);
+
+    // Dynamically import to get fresh instance with mocks
+    const notificationsModule = await import("../../src/notifications");
+    onGameResultSubmittedHandler = notificationsModule.onGameResultSubmitted;
+  });
+
+  describe("Status transition detection", () => {
+    it("should trigger when status changes to verification", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+          groupId: "group123",
+          title: "Beach Volleyball",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Beach Volleyball",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      // Verify messaging was called
+      expect(mockMessaging.sendEachForMulticast).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not trigger if status was already verification", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Beach Volleyball",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Beach Volleyball",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      // Should not send notification
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+
+    it("should not trigger if status changed to something other than verification", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "scheduled",
+          groupId: "group123",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "completed",
+          groupId: "group123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Notification sending", () => {
+    it("should send notification to all players except submitter", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Beach Volleyball Match",
+          playerIds: ["submitter123", "player1", "player2", "player3"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      expect(mockMessaging.sendEachForMulticast).toHaveBeenCalledTimes(1);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      // Should only have tokens for player1, player2, player3 (not submitter)
+      expect(callArgs.tokens).toEqual(["token1", "token2", "token3"]);
+      expect(callArgs.notification.title).toBe("Game Result Posted");
+      expect(callArgs.notification.body).toBe(
+        "Submitter User posted the score for Beach Volleyball Match. Please confirm the result."
+      );
+      expect(callArgs.data.type).toBe("game_result_submitted");
+      expect(callArgs.data.gameId).toBe("game123");
+      expect(callArgs.data.submitterId).toBe("submitter123");
+    });
+
+    it("should not notify submitter", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      // Should only have player1's token
+      expect(callArgs.tokens).toEqual(["token1"]);
+    });
+
+    it("should handle game without title gracefully", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          // No title
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.notification.body).toContain("the game");
+    });
+
+    it("should use displayName if firstName and lastName not available", async () => {
+      mockSubmitterDoc.data.mockReturnValue({
+        displayName: "John Doe",
+        // No firstName/lastName
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.notification.body).toContain("John Doe posted the score");
+    });
+
+    it("should use email if displayName not available", async () => {
+      mockSubmitterDoc.data.mockReturnValue({
+        email: "submitter@example.com",
+        // No firstName/lastName/displayName
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.notification.body).toContain("submitter@example.com posted the score");
+    });
+
+    it("should use 'Someone' if no name information available", async () => {
+      mockSubmitterDoc.data.mockReturnValue({
+        // No name/email
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.notification.body).toContain("Someone posted the score");
+    });
+  });
+
+  describe("Notification preferences", () => {
+    it("should respect user with gameResultSubmitted disabled globally", async () => {
+      mockPlayer1Doc.data.mockReturnValue({
+        displayName: "Player 1",
+        fcmTokens: ["token1"],
+        notificationPreferences: {
+          gameResultSubmitted: false, // Disabled globally
+        },
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      // Should only have player2's token (player1 disabled)
+      expect(callArgs.tokens).toEqual(["token2"]);
+    });
+
+    it("should respect group-specific notification preferences", async () => {
+      mockPlayer1Doc.data.mockReturnValue({
+        displayName: "Player 1",
+        fcmTokens: ["token1"],
+        notificationPreferences: {
+          gameResultSubmitted: true,
+          groupSpecific: {
+            group123: {
+              gameResultSubmitted: false, // Disabled for this specific group
+            },
+          },
+        },
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.tokens).toEqual(["token2"]);
+    });
+  });
+
+  describe("Quiet hours", () => {
+    it("should not send notification during quiet hours", async () => {
+      // Set quiet hours to always be active (mock time doesn't matter)
+      mockPlayer1Doc.data.mockReturnValue({
+        displayName: "Player 1",
+        fcmTokens: ["token1"],
+        notificationPreferences: {
+          gameResultSubmitted: true,
+          quietHours: {
+            enabled: true,
+            start: "00:00",
+            end: "23:59",
+          },
+        },
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      // Should only have player2's token (player1 in quiet hours)
+      expect(callArgs.tokens).toEqual(["token2"]);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle no players gracefully", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: [], // No players
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      const result = await onGameResultSubmittedHandler(change, context);
+
+      expect(result).toBeNull();
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+      expect(functions.logger.warn).toHaveBeenCalledWith(
+        "No players found for game result notification",
+        expect.any(Object)
+      );
+    });
+
+    it("should handle player without FCM tokens", async () => {
+      mockPlayer1Doc.data.mockReturnValue({
+        displayName: "Player 1",
+        fcmTokens: [], // No tokens
+        notificationPreferences: {
+          gameResultSubmitted: true,
+        },
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      // Should still send to player2
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.tokens).toEqual(["token2"]);
+    });
+
+    it("should handle only submitter in game", async () => {
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123"], // Only submitter
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+      expect(functions.logger.info).toHaveBeenCalledWith(
+        "No players to notify for game result submission",
+        expect.any(Object)
+      );
+    });
+
+    it("should handle missing submitter document gracefully", async () => {
+      mockSubmitterDoc.exists = false;
+      mockSubmitterDoc.data.mockReturnValue(null);
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      const callArgs = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(callArgs.notification.body).toContain("Someone posted the score");
+    });
+  });
+
+  describe("Invalid token cleanup", () => {
+    it("should remove invalid FCM tokens", async () => {
+      const mockUpdate = jest.fn().mockResolvedValue({});
+      mockDb.collection = jest.fn((collectionName: string) => {
+        if (collectionName === "users") {
+          return {
+            doc: jest.fn((userId: string) => ({
+              get: jest.fn().mockImplementation(() => {
+                if (userId === "submitter123") return Promise.resolve(mockSubmitterDoc);
+                if (userId === "player1") return Promise.resolve(mockPlayer1Doc);
+                if (userId === "player2") return Promise.resolve(mockPlayer2Doc);
+                return Promise.resolve({exists: false, data: () => null});
+              }),
+              update: mockUpdate,
+            })),
+          };
+        }
+        return {doc: jest.fn()};
+      });
+
+      mockMessaging.sendEachForMulticast.mockResolvedValue({
+        successCount: 1,
+        failureCount: 1,
+        responses: [
+          {success: true},
+          {
+            success: false,
+            error: {code: "messaging/invalid-registration-token"},
+          },
+        ],
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      // Should have called update to remove invalid tokens
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+
+    it("should not remove tokens on other errors", async () => {
+      mockMessaging.sendEachForMulticast.mockResolvedValue({
+        successCount: 1,
+        failureCount: 1,
+        responses: [
+          {success: true},
+          {
+            success: false,
+            error: {code: "messaging/server-unavailable"},
+          },
+        ],
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1", "player2"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      await onGameResultSubmittedHandler(change, context);
+
+      // Should not have called update (no invalid tokens)
+      expect(mockDb.collection("users").doc().update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should handle errors gracefully and log them", async () => {
+      mockDb.collection.mockImplementation(() => {
+        throw new Error("Firestore error");
+      });
+
+      const beforeSnapshot = {
+        data: () => ({
+          status: "completed",
+        }),
+      };
+
+      const afterSnapshot = {
+        data: () => ({
+          status: "verification",
+          groupId: "group123",
+          title: "Game",
+          playerIds: ["submitter123", "player1"],
+          resultSubmittedBy: "submitter123",
+        }),
+      };
+
+      const change = {
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      };
+
+      const context = {
+        params: {gameId: "game123"},
+      };
+
+      const result = await onGameResultSubmittedHandler(change, context);
+
+      expect(result).toBeNull();
+      expect(functions.logger.error).toHaveBeenCalledWith(
+        "Error sending game result verification notification",
+        expect.objectContaining({
+          error: "Firestore error",
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements push notifications to alert players when game results are submitted for verification, enabling timely confirmation and preventing games from getting stuck in pending verification state.

## Changes

### Cloud Function Implementation
- **Added `onGameResultSubmitted`** Cloud Function in `functions/src/notifications.ts`
  - Triggers on Firestore `games/{gameId}` updates when status changes to `verification`
  - Sends FCM push notifications to all participants except the submitter
  - Respects user notification preferences (global and group-specific)
  - Honors quiet hours settings
  - Automatically cleans up invalid FCM tokens
  
### Notification Content
- **Title:** "Game Result Posted"
- **Body:** "[Player Name] posted the score for [Game Title]. Please confirm the result."
- **Deep-link data:** Includes `gameId` for navigation to GameDetailsPage

### Testing
- **Unit Tests:** 19 comprehensive test cases covering:
  - Status transition detection (3 tests)
  - Notification sending (6 tests)
  - Notification preferences (2 tests)
  - Quiet hours (1 test)
  - Edge cases (4 tests)
  - Invalid token cleanup (2 tests)
  - Error handling (1 test)
- **Test Results:** ✅ All 19 tests passing
- **Flutter Tests:** ✅ All 1107 tests passing

### Deployment
- ✅ Deployed to `playwithme-dev`
- ✅ Deployed to `playwithme-stg`
- ✅ Deployed to `playwithme-prod`

## Files Changed

| File | Purpose |
|------|---------|
| `functions/src/notifications.ts` | Added `onGameResultSubmitted` function (235 lines) |
| `functions/src/index.ts` | Exported new function |
| `functions/test/unit/onGameResultSubmitted.test.ts` | Comprehensive unit tests (19 tests) |
| `docs/epic-14/story-14.15/README.md` | Complete documentation |

## Acceptance Criteria

- ✅ **Trigger:** Function triggers when game enters `verification` state
- ✅ **Audience:** Sends to all confirmed participants except the submitter
- ✅ **Content:** Correct title and body with submitter name and game title
- ✅ **Navigation:** Data payload includes `gameId` for deep-linking
- ✅ **Idempotency:** Only one notification per status transition to `verification`

## Integration with Existing Features

- **Story 14.11 (Game Result Verification):** Complements verification UI by notifying players when action is required
- **Story 14.14 (Democratize Result Entry):** Works with democratized result entry - any participant can submit
- **Notification Infrastructure:** Follows same patterns as `onGameCreated`, `onPlayerJoinedGame`, etc.

## User Experience Flow

1. Player A enters game results after the game ends
2. Game status changes from `completed` to `verification`
3. Cloud Function detects the status change
4. Notification sent to all other players (B, C, D) except Player A
5. Players receive: "Player A posted the score for Beach Volleyball. Please confirm the result."
6. Player taps notification → Deep-links to Game Details Page
7. Player confirms result → Game status changes to `completed`
8. ELO calculation proceeds (Story 14.5)

## Security & Privacy

- ✅ Only notifies confirmed participants (players in `playerIds`)
- ✅ Excludes the submitter from notifications
- ✅ Respects user notification preferences at global and group levels
- ✅ Honors quiet hours settings
- ✅ Secure FCM token handling with automatic cleanup
- ✅ Comprehensive error handling and logging

## Testing Instructions

### Verify Cloud Function (Dev Environment)

1. Create a game with multiple participants
2. Have one participant enter game results
3. Verify other participants receive push notifications
4. Tap notification to verify deep-link navigation works
5. Check Firestore logs for successful execution

### Run Unit Tests

```bash
cd functions
npm test -- onGameResultSubmitted.test.ts
```

Expected: All 19 tests pass ✅

## Related Issues

- Closes #266 
- Related to #264 (Story 14.11 - Game Result Verification)
- Related to #265 (Story 14.14 - Democratize Result Entry)

## Documentation

Complete documentation available in `docs/epic-14/story-14.15/README.md`

---

**Ready for Review** ✅