### PR TITLE
Story 293: Verify Score Validation (21-Point Rule) and Improve UI Feedback

### DIFF
--- a/lib/features/games/presentation/bloc/score_entry/score_entry_state.dart
+++ b/lib/features/games/presentation/bloc/score_entry/score_entry_state.dart
@@ -50,6 +50,32 @@ class SetScoreData {
     return (maxPoints - minPoints) == 2;
   }
 
+  /// Get a user-friendly error message if the score is invalid
+  String? get validationError {
+    if (!isComplete) return null;
+    
+    final maxPoints = teamAPoints! > teamBPoints! ? teamAPoints! : teamBPoints!;
+    final minPoints = teamAPoints! < teamBPoints! ? teamAPoints! : teamBPoints!;
+
+    if (maxPoints < 21) {
+      return 'Winning team must reach at least 21 points';
+    }
+    
+    if (maxPoints == 21) {
+      if (minPoints > 19) {
+        return 'Must win by at least 2 points (e.g., 21-19)';
+      }
+    }
+    
+    if (maxPoints > 21) {
+      if ((maxPoints - minPoints) != 2) {
+        return 'In extra points, must win by exactly 2 points';
+      }
+    }
+
+    return isValid ? null : 'Invalid score';
+  }
+
   String? get winner {
     if (!isValid) return null;
     return teamAPoints! > teamBPoints! ? 'teamA' : 'teamB';

--- a/lib/features/games/presentation/pages/score_entry_page.dart
+++ b/lib/features/games/presentation/pages/score_entry_page.dart
@@ -447,7 +447,11 @@ class _SetScoreInputState extends State<_SetScoreInput> {
             child: widget.setData.isValid
                 ? const Icon(Icons.check, color: Colors.green, size: 20)
                 : widget.setData.isComplete
-                    ? const Icon(Icons.error, color: Colors.red, size: 20)
+                    ? Tooltip(
+                        message: widget.setData.validationError ?? 'Invalid score',
+                        triggerMode: TooltipTriggerMode.tap,
+                        child: const Icon(Icons.error, color: Colors.red, size: 20),
+                      )
                     : null,
           ),
         ],

--- a/test/unit/core/data/models/score_validation_verification_test.dart
+++ b/test/unit/core/data/models/score_validation_verification_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/features/games/presentation/bloc/score_entry/score_entry_state.dart';
+
+/// This test file explicitly verifies the requirements from Story #293
+/// "Verify Score Validation (21-Point Rule)"
+void main() {
+  group('Story #293 - Score Validation Verification', () {
+    
+    // Requirement 1: Score can be 21-x (Standard win)
+    test('Requirement: Score can be 21-x (where x <= 19)', () {
+      // 21-19 (Closest standard win)
+      expect(
+        const SetScore(teamAPoints: 21, teamBPoints: 19, setNumber: 1).isValid(),
+        isTrue,
+        reason: '21-19 should be valid'
+      );
+
+      // 21-0 (Shutout)
+      expect(
+        const SetScore(teamAPoints: 21, teamBPoints: 0, setNumber: 1).isValid(),
+        isTrue,
+        reason: '21-0 should be valid'
+      );
+
+       // 21-20 (Invalid - must win by 2)
+      expect(
+        const SetScore(teamAPoints: 21, teamBPoints: 20, setNumber: 1).isValid(),
+        isFalse,
+        reason: '21-20 should be INVALID (must win by 2)'
+      );
+    });
+
+    // Requirement 2: Score can be 23-21 (Extended set)
+    test('Requirement: Score can be 23-21', () {
+      expect(
+        const SetScore(teamAPoints: 23, teamBPoints: 21, setNumber: 1).isValid(),
+        isTrue,
+        reason: '23-21 should be valid'
+      );
+    });
+
+    // Requirement 3: Two point of difference after the game goes above 21 points
+    test('Requirement: Two point of difference after 21 points', () {
+      // 22-20
+      expect(
+        const SetScore(teamAPoints: 22, teamBPoints: 20, setNumber: 1).isValid(),
+        isTrue,
+        reason: '22-20 should be valid'
+      );
+
+      // 24-22
+      expect(
+        const SetScore(teamAPoints: 24, teamBPoints: 22, setNumber: 1).isValid(),
+        isTrue,
+        reason: '24-22 should be valid'
+      );
+
+      // 30-28 (Long set)
+      expect(
+        const SetScore(teamAPoints: 30, teamBPoints: 28, setNumber: 1).isValid(),
+        isTrue,
+        reason: '30-28 should be valid'
+      );
+
+      // 22-21 (Invalid - only 1 point diff)
+      expect(
+        const SetScore(teamAPoints: 22, teamBPoints: 21, setNumber: 1).isValid(),
+        isFalse,
+        reason: '22-21 should be INVALID (only 1 point diff)'
+      );
+
+      // 25-22 (Invalid - 3 points diff)
+      expect(
+        const SetScore(teamAPoints: 25, teamBPoints: 22, setNumber: 1).isValid(),
+        isFalse,
+        reason: '25-22 should be INVALID (game would have ended at 24-22)'
+      );
+    });
+
+    group('UI Error Message Verification', () {
+      test('Returns correct error for scores < 21', () {
+        final data = SetScoreData(teamAPoints: 20, teamBPoints: 18);
+        expect(data.isValid, isFalse);
+        expect(data.validationError, 'Winning team must reach at least 21 points');
+      });
+
+      test('Returns correct error for 21-20 (not winning by 2)', () {
+        final data = SetScoreData(teamAPoints: 21, teamBPoints: 20);
+        expect(data.isValid, isFalse);
+        expect(data.validationError, 'Must win by at least 2 points (e.g., 21-19)');
+      });
+
+      test('Returns correct error for > 21 and diff != 2', () {
+        final data = SetScoreData(teamAPoints: 25, teamBPoints: 22);
+        expect(data.isValid, isFalse);
+        expect(data.validationError, 'In extra points, must win by exactly 2 points');
+      });
+
+      test('Returns null for valid scores', () {
+        final data = SetScoreData(teamAPoints: 21, teamBPoints: 19);
+        expect(data.isValid, isTrue);
+        expect(data.validationError, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR implements the verification for Story #293, ensuring that standard beach volleyball scoring rules (first to 21, win by 2) are strictly enforced and tested.

## Changes
- **Testing:** Added `test/unit/core/data/models/score_validation_verification_test.dart` to explicitly verify:
    - Standard wins (e.g., 21-19).
    - Shutouts (e.g., 21-0).
    - Extended sets (e.g., 22-20, 24-22).
    - Invalid scores (e.g., 21-20, 22-21).
- **Business Logic:** Added `validationError` getter to `SetScoreData` in `ScoreEntryState` to generate user-friendly error messages.
- **UI:** Updated `ScoreEntryPage` to display these specific error messages via a Tooltip on the error icon, giving users clear feedback on why their score is invalid.

## Verification
- Run `flutter test test/unit/core/data/models/score_validation_verification_test.dart` to verify all scoring scenarios.
- Run `flutter test test/unit/features/games/presentation/bloc/score_entry/score_entry_bloc_test.dart` (if applicable) to ensure no regressions.

## Screenshots
(N/A - Unit logic verification)

Fixes #293