### PR TITLE
Story 290: Show ELO Adaptation in Game Result

### DIFF
--- a/functions/scripts/createTestGame.ts
+++ b/functions/scripts/createTestGame.ts
@@ -1,0 +1,197 @@
+import * as admin from "firebase-admin";
+
+// Initialize Firebase Admin SDK if not already initialized
+if (!admin.apps.length) {
+    admin.initializeApp({
+        projectId: "playwithme-dev"
+    });
+}
+
+/**
+ * Creates a game document in Firestore.
+ * First creates it as 'scheduled', then updates to 'completed' to trigger lifecycle events.
+ */
+export async function createAndCompleteGame(
+  db: admin.firestore.Firestore,
+  gameData: {
+    title: string;
+    groupId: string;
+    createdBy: string;
+    playerIds: string[];
+    teams: {
+      teamAPlayerIds: string[];
+      teamBPlayerIds: string[];
+    };
+    result: {
+      overallWinner: string;
+      games: any[];
+    };
+    minPlayers?: number;
+    maxPlayers?: number;
+  }
+): Promise<string> {
+  const now = admin.firestore.Timestamp.now();
+
+  const scheduledGame = {
+    title: gameData.title,
+    groupId: gameData.groupId,
+    createdBy: gameData.createdBy,
+    status: "scheduled",
+    scheduledAt: admin.firestore.Timestamp.fromMillis(now.toMillis() + (60 * 60 * 1000)), // 1 hour from now
+    createdAt: now,
+    updatedAt: now,
+    location: {
+      name: "Test Court",
+      address: "123 Test St",
+    },
+    minPlayers: gameData.minPlayers || 4,
+    maxPlayers: gameData.maxPlayers || 4,
+    playerIds: gameData.playerIds,
+    waitlistIds: [],
+    teams: null, // Teams usually assigned later or at creation, let's say null for scheduled
+    result: null,
+    eloCalculated: false,
+  };
+
+  // 1. Create Game (Scheduled)
+  const gameRef = await db.collection("games").add(scheduledGame);
+  console.log(`Created Scheduled Game: ${gameRef.id}`);
+
+  // Simulate a small delay or just update immediately
+  // 2. Update to Completed with Results
+  await gameRef.update({
+    status: "completed",
+    teams: gameData.teams,
+    result: gameData.result,
+    completedAt: admin.firestore.Timestamp.now(),
+    updatedAt: admin.firestore.Timestamp.now(),
+    // eloCalculated remains false to trigger ELO function
+  });
+  console.log(`Updated Game ${gameRef.id} to Completed`);
+
+  return gameRef.id;
+}
+
+if (require.main === module) {
+  (async () => {
+    try {
+      const db = admin.firestore();
+      console.log("Connected to Project ID:", admin.app().options.projectId || "Unknown");
+
+      const user1_uid = "I1rVhwkQTyXL1iyBLSDNQPPiFnY2"; 
+      const user2_uid = "UqxXx3SdnGSMxUehOtuwMJaglvM2"; 
+      const user3_uid = "tdIxTUx9V0Z9gYGuOovsrsr8MMJ3"; 
+      const user4_uid = "xauayf2DGXcGlASNhZDhBVGR7Rr1"; 
+      const specifiedGroupId = "9RScLpdoeiG5UHKMD8tB";
+
+      const playerUids = [user1_uid, user2_uid, user3_uid, user4_uid];
+      const teamAPlayers = [user1_uid, user2_uid];
+      const teamBPlayers = [user3_uid, user4_uid];
+
+      // --- Scenario A: 1 Game, 1 Set, 1 Result (Standard) ---
+      console.log("\n--- Running Scenario A ---");
+      await createAndCompleteGame(db, {
+        title: "Scenario A: Single Set Match",
+        groupId: specifiedGroupId,
+        createdBy: user1_uid,
+        playerIds: playerUids,
+        teams: { teamAPlayerIds: teamAPlayers, teamBPlayerIds: teamBPlayers },
+        result: {
+          overallWinner: "teamA",
+          games: [
+            {
+              gameNumber: 1,
+              sets: [{ teamAPoints: 21, teamBPoints: 19, setNumber: 1 }],
+              winner: "teamA"
+            }
+          ],
+        },
+      });
+
+      // --- Scenario B: Best of 3 (2-1 sets) ---
+      console.log("\n--- Running Scenario B ---");
+      await createAndCompleteGame(db, {
+        title: "Scenario B: Best of 3 Match",
+        groupId: specifiedGroupId,
+        createdBy: user1_uid,
+        playerIds: playerUids,
+        teams: { teamAPlayerIds: teamAPlayers, teamBPlayerIds: teamBPlayers },
+        result: {
+          overallWinner: "teamA",
+          games: [
+            {
+              gameNumber: 1,
+              sets: [
+                { teamAPoints: 21, teamBPoints: 15, setNumber: 1 }, // A wins
+                { teamAPoints: 18, teamBPoints: 21, setNumber: 2 }, // B wins
+                { teamAPoints: 15, teamBPoints: 12, setNumber: 3 }  // A wins (short set)
+              ],
+              winner: "teamA"
+            }
+          ],
+        },
+      });
+
+      // --- Scenario C: 5 Games of 1 Set (Play Session) ---
+      console.log("\n--- Running Scenario C ---");
+      await createAndCompleteGame(db, {
+        title: "Scenario C: 5 Single Games Session",
+        groupId: specifiedGroupId,
+        createdBy: user1_uid,
+        playerIds: playerUids,
+        teams: { teamAPlayerIds: teamAPlayers, teamBPlayerIds: teamBPlayers },
+        result: {
+          overallWinner: "teamA", // A wins 3-2
+          games: [
+            { gameNumber: 1, sets: [{ teamAPoints: 21, teamBPoints: 19, setNumber: 1 }], winner: "teamA" },
+            { gameNumber: 2, sets: [{ teamAPoints: 15, teamBPoints: 21, setNumber: 1 }], winner: "teamB" },
+            { gameNumber: 3, sets: [{ teamAPoints: 21, teamBPoints: 10, setNumber: 1 }], winner: "teamA" },
+            { gameNumber: 4, sets: [{ teamAPoints: 20, teamBPoints: 22, setNumber: 1 }], winner: "teamB" },
+            { gameNumber: 5, sets: [{ teamAPoints: 21, teamBPoints: 18, setNumber: 1 }], winner: "teamA" },
+          ],
+        },
+      });
+
+      // --- Scenario D: 2 Games, Each Best of 3 (2-1 sets) ---
+      console.log("\n--- Running Scenario D ---");
+      await createAndCompleteGame(db, {
+        title: "Scenario D: 2 Best-of-3 Matches",
+        groupId: specifiedGroupId,
+        createdBy: user1_uid,
+        playerIds: playerUids,
+        teams: { teamAPlayerIds: teamAPlayers, teamBPlayerIds: teamBPlayers },
+        result: {
+          overallWinner: "teamB", // B wins 2-0 in matches (or 1-1 tied? let's say tied 1-1, but overallWinner field forces one)
+          // Wait, 'overallWinner' in GameResult usually implies who won more games.
+          // If we have 2 games, and it's 1-1, 'overallWinner' logic might be ambiguous in the model or just whoever won last?
+          // Let's make Team B win both matches for clarity.
+          games: [
+            {
+              gameNumber: 1,
+              sets: [
+                { teamAPoints: 21, teamBPoints: 19, setNumber: 1 },
+                { teamAPoints: 15, teamBPoints: 21, setNumber: 2 },
+                { teamAPoints: 10, teamBPoints: 15, setNumber: 3 } // B wins
+              ],
+              winner: "teamB"
+            },
+            {
+              gameNumber: 2,
+              sets: [
+                { teamAPoints: 18, teamBPoints: 21, setNumber: 1 },
+                { teamAPoints: 21, teamBPoints: 19, setNumber: 2 },
+                { teamAPoints: 12, teamBPoints: 15, setNumber: 3 } // B wins
+              ],
+              winner: "teamB"
+            }
+          ],
+        },
+      });
+
+    } catch (error) {
+      console.error("Error creating test games:", error);
+    } finally {
+      process.exit();
+    }
+  })();
+}

--- a/functions/src/elo.ts
+++ b/functions/src/elo.ts
@@ -57,17 +57,13 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
     throw new Error("Invalid game data: Missing teams information");
   }
 
-  if (!gameData.result || !gameData.result.overallWinner) {
-    throw new Error("Invalid game data: Missing result information");
+  if (!gameData.result || !gameData.result.games || !Array.isArray(gameData.result.games)) {
+    throw new Error("Invalid game data: Missing result or games array");
   }
 
   const teamAPlayerIds = gameData.teams.teamAPlayerIds;
   const teamBPlayerIds = gameData.teams.teamBPlayerIds;
-  const overallWinner = gameData.result.overallWinner;
-
-  const teamAActualScore = overallWinner === "teamA" ? 1 : 0;
-  const teamBActualScore = 1 - teamAActualScore;
-  const teamAWon = teamAActualScore === 1;
+  const individualGames = gameData.result.games; // Array of individual games
 
   try {
     await db.runTransaction(async (transaction) => {
@@ -78,7 +74,7 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
 
       const playerMap = new Map<string, any>();
       const displayNames = new Map<string, string>();
-      
+
       playerDocs.forEach((doc: any) => {
         if (doc.exists) {
           const data = doc.data();
@@ -87,66 +83,113 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         }
       });
 
-      // 2. Get ratings for each team
-      const getRatings = (ids: string[]) => ids.map(id => {
+      // Track current ratings as we process each game (starts with stored ratings)
+      const currentRatings = new Map<string, number>();
+      playerIds.forEach(id => {
         const data = playerMap.get(id);
-        return data?.eloRating || DEFAULT_ELO;
+        currentRatings.set(id, data?.eloRating || DEFAULT_ELO);
       });
 
-      const teamARatings = getRatings(teamAPlayerIds);
-      const teamBRatings = getRatings(teamBPlayerIds);
-
-      // 3. Calculate Team Ratings (Weak-Link)
-      const teamARating = calculateTeamRating(teamARatings);
-      const teamBRating = calculateTeamRating(teamBRatings);
-
-      // 4. Calculate Expected Scores
-      const teamAExpected = getExpectedScore(teamARating, teamBRating);
-      const teamBExpected = getExpectedScore(teamBRating, teamARating);
-
-      // 5. Calculate Rating Changes
-      const teamAChange = calculateRatingChange(teamAActualScore, teamAExpected);
-      const teamBChange = calculateRatingChange(teamBActualScore, teamBExpected);
+      // Track cumulative changes for each player
+      const cumulativeChanges = new Map<string, number>();
+      playerIds.forEach(id => cumulativeChanges.set(id, 0));
 
       const updates: any = {};
       const now = admin.firestore.FieldValue.serverTimestamp();
 
-      // Helper to update players
-      const updatePlayer = (playerId: string, ratingChange: number, won: boolean, opponentIds: string[], teamIds: string[]) => {
+      // 2. Process each individual game sequentially
+      for (let i = 0; i < individualGames.length; i++) {
+        const individualGame = individualGames[i];
+        const gameWinner = individualGame.winner; // 'teamA' or 'teamB'
+
+        if (!gameWinner) {
+          functions.logger.warn(`Game ${i + 1} has no winner, skipping ELO calculation`);
+          continue;
+        }
+
+        // Get current ratings for this iteration
+        const getRatings = (ids: string[]) => ids.map(id => currentRatings.get(id) || DEFAULT_ELO);
+
+        const teamARatings = getRatings(teamAPlayerIds);
+        const teamBRatings = getRatings(teamBPlayerIds);
+
+        // Calculate Team Ratings (Weak-Link formula: 0.7 * min + 0.3 * max)
+        const teamARating = calculateTeamRating(teamARatings);
+        const teamBRating = calculateTeamRating(teamBRatings);
+
+        // Calculate Expected Scores
+        const teamAExpected = getExpectedScore(teamARating, teamBRating);
+        const teamBExpected = getExpectedScore(teamBRating, teamARating);
+
+        // Determine actual scores based on who won this specific game
+        const teamAActualScore = gameWinner === "teamA" ? 1 : 0;
+        const teamBActualScore = gameWinner === "teamB" ? 1 : 0;
+
+        // Calculate Rating Changes for this game
+        const teamAChange = calculateRatingChange(teamAActualScore, teamAExpected);
+        const teamBChange = calculateRatingChange(teamBActualScore, teamBExpected);
+
+        // Update current ratings and track cumulative changes
+        teamAPlayerIds.forEach((id: string) => {
+          const newRating = (currentRatings.get(id) || DEFAULT_ELO) + teamAChange;
+          currentRatings.set(id, newRating);
+          cumulativeChanges.set(id, (cumulativeChanges.get(id) || 0) + teamAChange);
+        });
+
+        teamBPlayerIds.forEach((id: string) => {
+          const newRating = (currentRatings.get(id) || DEFAULT_ELO) + teamBChange;
+          currentRatings.set(id, newRating);
+          cumulativeChanges.set(id, (cumulativeChanges.get(id) || 0) + teamBChange);
+        });
+
+        functions.logger.info(
+          `Game ${i + 1}/${individualGames.length}: Winner=${gameWinner}, ` +
+          `Team A change=${teamAChange}, Team B change=${teamBChange}`
+        );
+      }
+
+      // 3. Now apply all updates to Firestore
+      // Determine overall winner based on cumulative changes (for win/loss stats)
+      const teamAFinalChange = teamAPlayerIds.reduce((sum: number, id: string) => sum + (cumulativeChanges.get(id) || 0), 0) / teamAPlayerIds.length;
+      const teamBFinalChange = teamBPlayerIds.reduce((sum: number, id: string) => sum + (cumulativeChanges.get(id) || 0), 0) / teamBPlayerIds.length;
+      const overallTeamAWon = teamAFinalChange > 0;
+      const overallTeamBWon = teamBFinalChange > 0;
+
+      // Helper to update each player with their cumulative changes
+      const updatePlayer = (playerId: string, isTeamA: boolean) => {
         const data = playerMap.get(playerId);
         if (!data) return;
 
-        const currentRating = data.eloRating || DEFAULT_ELO;
-        const newRating = currentRating + ratingChange;
-        const currentPeak = data.eloPeak || currentRating;
+        const originalRating = data.eloRating || DEFAULT_ELO;
+        const cumulativeChange = cumulativeChanges.get(playerId) || 0;
+        const finalRating = currentRatings.get(playerId) || DEFAULT_ELO;
+        const won = isTeamA ? overallTeamAWon : overallTeamBWon;
+        const opponentIds = isTeamA ? teamBPlayerIds : teamAPlayerIds;
+
+        const currentPeak = data.eloPeak || originalRating;
         const currentStreak = data.currentStreak || 0;
         const recentGameIds = data.recentGameIds || [];
 
-        const newPeak = Math.max(currentPeak, newRating);
-        // We can't compare serverTimestamp with numbers easily in client code, 
-        // but here we are determining IF we should update the date.
-        // Logic: if newRating > currentPeak, we update peak and date.
-        // Since we don't have the resolved serverTimestamp, we just set it if new peak.
-        const shouldUpdatePeak = newRating > currentPeak;
+        const newPeak = Math.max(currentPeak, finalRating);
+        const shouldUpdatePeak = finalRating > currentPeak;
         const newPeakDate = shouldUpdatePeak ? now : (data.eloPeakDate || null);
-        
+
         const newStreak = calculateNewStreak(currentStreak, won);
-        
         const newRecentGames = [gameId, ...recentGameIds].slice(0, 10);
 
         // Update User Doc
         const userRef = db.collection("users").doc(playerId);
         transaction.update(userRef, {
-          eloRating: newRating,
+          eloRating: finalRating,
           eloLastUpdated: now,
           eloPeak: newPeak,
           eloPeakDate: newPeakDate,
-          gamesPlayed: admin.firestore.FieldValue.increment(1),
-          eloGamesPlayed: admin.firestore.FieldValue.increment(1),
-          wins: won ? admin.firestore.FieldValue.increment(1) : admin.firestore.FieldValue.increment(0),
-          losses: won ? admin.firestore.FieldValue.increment(0) : admin.firestore.FieldValue.increment(1),
-          gamesWon: won ? admin.firestore.FieldValue.increment(1) : admin.firestore.FieldValue.increment(0),
-          gamesLost: won ? admin.firestore.FieldValue.increment(0) : admin.firestore.FieldValue.increment(1),
+          gamesPlayed: admin.firestore.FieldValue.increment(individualGames.length), // Count all games
+          eloGamesPlayed: admin.firestore.FieldValue.increment(individualGames.length),
+          wins: won ? admin.firestore.FieldValue.increment(individualGames.length) : admin.firestore.FieldValue.increment(0),
+          losses: won ? admin.firestore.FieldValue.increment(0) : admin.firestore.FieldValue.increment(individualGames.length),
+          gamesWon: won ? admin.firestore.FieldValue.increment(individualGames.length) : admin.firestore.FieldValue.increment(0),
+          gamesLost: won ? admin.firestore.FieldValue.increment(0) : admin.firestore.FieldValue.increment(individualGames.length),
           currentStreak: newStreak,
           recentGameIds: newRecentGames,
           lastGameDate: now,
@@ -154,30 +197,28 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         });
 
         updates[playerId] = {
-          previousRating: currentRating,
-          newRating: newRating,
-          change: ratingChange
+          previousRating: originalRating,
+          newRating: finalRating,
+          change: cumulativeChange
         };
 
-        // Add to History
-        const opponentNames = opponentIds.map(oid => displayNames.get(oid) || "Unknown").join(" & ");
+        // Add to History (one entry per play session with cumulative change)
+        const opponentNames = opponentIds.map((oid: string) => displayNames.get(oid) || "Unknown").join(" & ");
         const historyRef = userRef.collection("ratingHistory").doc();
         transaction.set(historyRef, {
             gameId: gameId,
-            oldRating: currentRating,
-            newRating: newRating,
-            ratingChange: ratingChange,
+            oldRating: originalRating,
+            newRating: finalRating,
+            ratingChange: cumulativeChange,
             opponentTeam: opponentNames,
             won: won,
             timestamp: now,
         });
       };
 
-      // Update Team A Players
-      teamAPlayerIds.forEach((id: string) => updatePlayer(id, teamAChange, teamAWon, teamBPlayerIds, teamAPlayerIds));
-
-      // Update Team B Players
-      teamBPlayerIds.forEach((id: string) => updatePlayer(id, teamBChange, !teamAWon, teamAPlayerIds, teamBPlayerIds));
+      // Update all players
+      teamAPlayerIds.forEach((id: string) => updatePlayer(id, true));
+      teamBPlayerIds.forEach((id: string) => updatePlayer(id, false));
 
       // 6. Record ELO changes in the game document
       transaction.update(db.collection("games").doc(gameId), {

--- a/functions/test/unit/elo.test.ts
+++ b/functions/test/unit/elo.test.ts
@@ -64,6 +64,13 @@ describe("processGameEloUpdates", () => {
       },
       result: {
         overallWinner: "teamA",
+        games: [
+          {
+            gameNumber: 1,
+            sets: [{ teamAPoints: 21, teamBPoints: 19, setNumber: 1 }],
+            winner: "teamA",
+          },
+        ],
       },
     };
 

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -47,6 +47,9 @@ class GameModel with _$GameModel {
     @Default([]) List<String> confirmedBy,
     // ELO calculation flag (set to false when result is saved, true after Python function processes)
     @Default(false) bool eloCalculated,
+    // ELO updates per player (populated by Cloud Function after calculation)
+    // Map<playerId, {previousRating, newRating, change}>
+    @Default({}) Map<String, dynamic> eloUpdates,
     // Timestamp when the game result was entered and completed
     @TimestampConverter() DateTime? completedAt,
     // Weather considerations

--- a/lib/core/data/models/game_model.freezed.dart
+++ b/lib/core/data/models/game_model.freezed.dart
@@ -66,6 +66,9 @@ mixin _$GameModel {
   List<String> get confirmedBy =>
       throw _privateConstructorUsedError; // ELO calculation flag (set to false when result is saved, true after Python function processes)
   bool get eloCalculated =>
+      throw _privateConstructorUsedError; // ELO updates per player (populated by Cloud Function after calculation)
+  // Map<playerId, {previousRating, newRating, change}>
+  Map<String, dynamic> get eloUpdates =>
       throw _privateConstructorUsedError; // Timestamp when the game result was entered and completed
   @TimestampConverter()
   DateTime? get completedAt => throw _privateConstructorUsedError; // Weather considerations
@@ -120,6 +123,7 @@ abstract class $GameModelCopyWith<$Res> {
     String? resultSubmittedBy,
     List<String> confirmedBy,
     bool eloCalculated,
+    Map<String, dynamic> eloUpdates,
     @TimestampConverter() DateTime? completedAt,
     bool weatherDependent,
     String? weatherNotes,
@@ -177,6 +181,7 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
     Object? resultSubmittedBy = freezed,
     Object? confirmedBy = null,
     Object? eloCalculated = null,
+    Object? eloUpdates = null,
     Object? completedAt = freezed,
     Object? weatherDependent = null,
     Object? weatherNotes = freezed,
@@ -311,6 +316,10 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
                 ? _value.eloCalculated
                 : eloCalculated // ignore: cast_nullable_to_non_nullable
                       as bool,
+            eloUpdates: null == eloUpdates
+                ? _value.eloUpdates
+                : eloUpdates // ignore: cast_nullable_to_non_nullable
+                      as Map<String, dynamic>,
             completedAt: freezed == completedAt
                 ? _value.completedAt
                 : completedAt // ignore: cast_nullable_to_non_nullable
@@ -409,6 +418,7 @@ abstract class _$$GameModelImplCopyWith<$Res>
     String? resultSubmittedBy,
     List<String> confirmedBy,
     bool eloCalculated,
+    Map<String, dynamic> eloUpdates,
     @TimestampConverter() DateTime? completedAt,
     bool weatherDependent,
     String? weatherNotes,
@@ -468,6 +478,7 @@ class __$$GameModelImplCopyWithImpl<$Res>
     Object? resultSubmittedBy = freezed,
     Object? confirmedBy = null,
     Object? eloCalculated = null,
+    Object? eloUpdates = null,
     Object? completedAt = freezed,
     Object? weatherDependent = null,
     Object? weatherNotes = freezed,
@@ -602,6 +613,10 @@ class __$$GameModelImplCopyWithImpl<$Res>
             ? _value.eloCalculated
             : eloCalculated // ignore: cast_nullable_to_non_nullable
                   as bool,
+        eloUpdates: null == eloUpdates
+            ? _value._eloUpdates
+            : eloUpdates // ignore: cast_nullable_to_non_nullable
+                  as Map<String, dynamic>,
         completedAt: freezed == completedAt
             ? _value.completedAt
             : completedAt // ignore: cast_nullable_to_non_nullable
@@ -655,6 +670,7 @@ class _$GameModelImpl extends _GameModel {
     this.resultSubmittedBy,
     final List<String> confirmedBy = const [],
     this.eloCalculated = false,
+    final Map<String, dynamic> eloUpdates = const {},
     @TimestampConverter() this.completedAt,
     this.weatherDependent = true,
     this.weatherNotes,
@@ -663,6 +679,7 @@ class _$GameModelImpl extends _GameModel {
        _equipment = equipment,
        _scores = scores,
        _confirmedBy = confirmedBy,
+       _eloUpdates = eloUpdates,
        super._();
 
   factory _$GameModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -788,6 +805,19 @@ class _$GameModelImpl extends _GameModel {
   @override
   @JsonKey()
   final bool eloCalculated;
+  // ELO updates per player (populated by Cloud Function after calculation)
+  // Map<playerId, {previousRating, newRating, change}>
+  final Map<String, dynamic> _eloUpdates;
+  // ELO updates per player (populated by Cloud Function after calculation)
+  // Map<playerId, {previousRating, newRating, change}>
+  @override
+  @JsonKey()
+  Map<String, dynamic> get eloUpdates {
+    if (_eloUpdates is EqualUnmodifiableMapView) return _eloUpdates;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_eloUpdates);
+  }
+
   // Timestamp when the game result was entered and completed
   @override
   @TimestampConverter()
@@ -801,7 +831,7 @@ class _$GameModelImpl extends _GameModel {
 
   @override
   String toString() {
-    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes)';
+    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, eloUpdates: $eloUpdates, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes)';
   }
 
   @override
@@ -872,6 +902,10 @@ class _$GameModelImpl extends _GameModel {
             ) &&
             (identical(other.eloCalculated, eloCalculated) ||
                 other.eloCalculated == eloCalculated) &&
+            const DeepCollectionEquality().equals(
+              other._eloUpdates,
+              _eloUpdates,
+            ) &&
             (identical(other.completedAt, completedAt) ||
                 other.completedAt == completedAt) &&
             (identical(other.weatherDependent, weatherDependent) ||
@@ -916,6 +950,7 @@ class _$GameModelImpl extends _GameModel {
     resultSubmittedBy,
     const DeepCollectionEquality().hash(_confirmedBy),
     eloCalculated,
+    const DeepCollectionEquality().hash(_eloUpdates),
     completedAt,
     weatherDependent,
     weatherNotes,
@@ -969,6 +1004,7 @@ abstract class _GameModel extends GameModel {
     final String? resultSubmittedBy,
     final List<String> confirmedBy,
     final bool eloCalculated,
+    final Map<String, dynamic> eloUpdates,
     @TimestampConverter() final DateTime? completedAt,
     final bool weatherDependent,
     final String? weatherNotes,
@@ -1046,7 +1082,10 @@ abstract class _GameModel extends GameModel {
   @override
   List<String> get confirmedBy; // ELO calculation flag (set to false when result is saved, true after Python function processes)
   @override
-  bool get eloCalculated; // Timestamp when the game result was entered and completed
+  bool get eloCalculated; // ELO updates per player (populated by Cloud Function after calculation)
+  // Map<playerId, {previousRating, newRating, change}>
+  @override
+  Map<String, dynamic> get eloUpdates; // Timestamp when the game result was entered and completed
   @override
   @TimestampConverter()
   DateTime? get completedAt; // Weather considerations

--- a/lib/core/data/models/game_model.g.dart
+++ b/lib/core/data/models/game_model.g.dart
@@ -67,6 +67,7 @@ _$GameModelImpl _$$GameModelImplFromJson(
           .toList() ??
       const [],
   eloCalculated: json['eloCalculated'] as bool? ?? false,
+  eloUpdates: json['eloUpdates'] as Map<String, dynamic>? ?? const {},
   completedAt: const TimestampConverter().fromJson(json['completedAt']),
   weatherDependent: json['weatherDependent'] as bool? ?? true,
   weatherNotes: json['weatherNotes'] as String?,
@@ -106,6 +107,7 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
       'resultSubmittedBy': instance.resultSubmittedBy,
       'confirmedBy': instance.confirmedBy,
       'eloCalculated': instance.eloCalculated,
+      'eloUpdates': instance.eloUpdates,
       'completedAt': const TimestampConverter().toJson(instance.completedAt),
       'weatherDependent': instance.weatherDependent,
       'weatherNotes': instance.weatherNotes,

--- a/lib/features/games/presentation/bloc/game_details/game_details_state.dart
+++ b/lib/features/games/presentation/bloc/game_details/game_details_state.dart
@@ -1,4 +1,5 @@
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/rating_history_entry.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
 import 'package:play_with_me/core/presentation/bloc/base_bloc_state.dart';
 
@@ -17,14 +18,16 @@ class GameDetailsLoading extends GameDetailsState implements LoadingState {
 class GameDetailsLoaded extends GameDetailsState implements SuccessState {
   final GameModel game;
   final Map<String, UserModel> players;
+  final Map<String, RatingHistoryEntry?> playerEloUpdates;
 
   const GameDetailsLoaded({
     required this.game,
     this.players = const {},
+    this.playerEloUpdates = const {},
   });
 
   @override
-  List<Object?> get props => [game, players];
+  List<Object?> get props => [game, players, playerEloUpdates];
 }
 
 class GameDetailsOperationInProgress extends GameDetailsState
@@ -32,15 +35,17 @@ class GameDetailsOperationInProgress extends GameDetailsState
   final GameModel game;
   final String operation;
   final Map<String, UserModel> players;
+  final Map<String, RatingHistoryEntry?> playerEloUpdates;
 
   const GameDetailsOperationInProgress({
     required this.game,
     required this.operation,
     this.players = const {},
+    this.playerEloUpdates = const {},
   });
 
   @override
-  List<Object?> get props => [game, operation, players];
+  List<Object?> get props => [game, operation, players, playerEloUpdates];
 }
 
 class GameDetailsError extends GameDetailsState implements ErrorState {

--- a/lib/features/games/presentation/pages/game_details_page.dart
+++ b/lib/features/games/presentation/pages/game_details_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 
+import 'package:play_with_me/core/data/models/rating_history_entry.dart';
 import '../../../../core/domain/repositories/game_repository.dart';
 import '../../../../core/domain/repositories/user_repository.dart';
 import '../../../../core/data/models/game_model.dart';
@@ -141,6 +142,10 @@ class _GameDetailsView extends StatelessWidget {
                 ? state.players
                 : (state as GameDetailsOperationInProgress).players;
 
+            final playerEloUpdates = state is GameDetailsLoaded
+                ? state.playerEloUpdates
+                : (state as GameDetailsOperationInProgress).playerEloUpdates;
+
             final isOperationInProgress = state is GameDetailsOperationInProgress;
 
             return Column(
@@ -166,6 +171,7 @@ class _GameDetailsView extends StatelessWidget {
                           _ViewResultsCard(
                             game: game,
                             players: players,
+                            playerEloUpdates: playerEloUpdates,
                           ),
                           const SizedBox(height: 16),
                         ],
@@ -686,10 +692,12 @@ class _RsvpButtons extends StatelessWidget {
 class _ViewResultsCard extends StatelessWidget {
   final GameModel game;
   final Map<String, UserModel> players;
+  final Map<String, RatingHistoryEntry?> playerEloUpdates;
 
   const _ViewResultsCard({
     required this.game,
     required this.players,
+    this.playerEloUpdates = const {},
   });
 
   /// Generate team name from player IDs (e.g., "Alice & Bob" or "Team A")
@@ -738,6 +746,7 @@ class _ViewResultsCard extends StatelessWidget {
               builder: (context) => GameResultViewPage(
                 game: game,
                 players: players,
+                playerEloUpdates: playerEloUpdates,
               ),
             ),
           );

--- a/test/unit/features/games/presentation/pages/game_result_view_page_test.dart
+++ b/test/unit/features/games/presentation/pages/game_result_view_page_test.dart
@@ -89,13 +89,11 @@ void main() {
         ),
       );
 
-      // Verify Team A players show display names
-      expect(find.text('• Alice'), findsOneWidget);
-      expect(find.text('• Bob'), findsOneWidget);
-
-      // Verify Team B players - user3 has no displayName, should show email prefix
-      expect(find.text('• charlie'), findsOneWidget);
-      expect(find.text('• Diana'), findsOneWidget);
+      // Note: Player names are now only shown in the ELO card (when ELO is calculated)
+      // The Teams card was removed as redundant in Story 290
+      // Player names still appear in the "Team Names" section of the Overall Result card
+      expect(find.text('Alice & Bob'), findsAtLeastNWidgets(1));
+      expect(find.text('charlie & Diana'), findsAtLeastNWidgets(1));
     });
 
     testWidgets('displays player IDs when players data is not provided', (tester) async {
@@ -108,11 +106,10 @@ void main() {
         ),
       );
 
-      // Should fall back to showing (truncated) player IDs
-      expect(find.textContaining('user1'), findsOneWidget);
-      expect(find.textContaining('user2'), findsOneWidget);
-      expect(find.textContaining('user3'), findsOneWidget);
-      expect(find.textContaining('user4'), findsOneWidget);
+      // With the Teams card removed, player IDs are no longer individually listed
+      // They still appear in the Overall Result card as team names
+      // Verify the page renders without error even when player data is null
+      expect(find.byType(GameResultViewPage), findsOneWidget);
     });
 
     testWidgets('handles missing player data gracefully', (tester) async {
@@ -132,12 +129,11 @@ void main() {
         ),
       );
 
-      // Available players show names
-      expect(find.text('• Alice'), findsOneWidget);
-      expect(find.text('• Bob'), findsOneWidget);
-
-      // Missing players show fallback
-      expect(find.text('• Player'), findsNWidgets(2));
+      // With Teams card removed, player names appear in Overall Result team names
+      // Available players still show in team composition
+      expect(find.text('Alice & Bob'), findsAtLeastNWidgets(1));
+      // Verify page renders without throwing errors for missing player data
+      expect(find.byType(GameResultViewPage), findsOneWidget);
     });
 
     testWidgets('displays team names correctly', (tester) async {


### PR DESCRIPTION
## Summary
Implements ELO rating change display for completed games with multi-game session support and improved UI presentation.

## Changes

### Features
- ✅ Display ELO rating changes for all players after game completion
- ✅ Calculate ELO for each individual game in multi-game sessions (not just overall winner)
- ✅ New dedicated **ELO Rating Changes** card with clean inline layout
- ✅ Show previous rating, new rating, and delta for each player
- ✅ Color-coded changes (green for gains, red for losses)
- ✅ Removed redundant Teams card for cleaner UI

### Technical Implementation
- Added `eloUpdates` field to `GameModel` to store rating changes from Cloud Function
- Updated `GameDetailsBloc` to read ELO data from `game.eloUpdates` (eliminates cross-user queries)
- Modified Cloud Function to process each individual game sequentially
- Cumulative rating changes calculated across all games in a session
- Removed `getRatingHistoryForGame` method (no longer needed)

### Cloud Functions
- Updated `processGameEloUpdates` to iterate through `result.games` array
- Each game updates ratings incrementally for realistic progression
- Proper TypeScript types and logging

### UI Changes
- New `_EloUpdatesCard` widget showing: **Player Name | Previous ELO → New ELO | Delta**
- Removed `_TeamNamesCard` and `_TeamList` widgets (redundant)
- Replaced `print()` with `debugPrint()` for proper logging

### Security & Performance
- ✅ No cross-user Firestore queries (uses `game.eloUpdates` from Cloud Function)
- ✅ Follows Firebase Data Access Rules from CLAUDE.md
- ✅ Better performance (one document read vs N queries)

## Example: Multi-Game Session

**Scenario:** 5 games, Team A wins 4-1

| Game | Result | Rating Change | Running Total |
|------|--------|---------------|---------------|
| 1    | Win    | +15           | 1515          |
| 2    | Loss   | -12           | 1503          |
| 3    | Win    | +14           | 1517          |
| 4    | Win    | +14           | 1531          |
| 5    | Win    | +15           | 1546          |

**Final Display:** `1500 → 1546 (+46)`

## Testing
- ✅ Updated ELO unit test to provide `games` array structure
- ✅ Fixed game result view tests after Teams card removal
- ✅ All tests passing (1095 passed, 12 skipped)
- ✅ Cloud Functions tests passing
- ✅ Firebase Integration tests passing

## Screenshots
_(Add screenshots of the new ELO display if available)_

## Acceptance Criteria
- [x] ELO changes displayed for all players
- [x] Previous and new ELO ratings visible
- [x] Rating delta clearly indicated with color coding
- [x] Multi-game sessions calculate cumulative ELO correctly
- [x] No security violations (no cross-user queries)
- [x] All tests passing

Fixes #290