### PR TITLE
Story 15.1: Create Training Session (Group-Scoped)

### DIFF
--- a/docs/epic-15/story-15.1/README.md
+++ b/docs/epic-15/story-15.1/README.md
@@ -1,0 +1,443 @@
+# Story 15.1: Create Training Session (Group-Scoped)
+
+**Epic**: 15 - Training Sessions (Games-Layer Event Type)
+**Status**: ✅ Completed
+**Implemented**: January 2026
+
+---
+
+## Overview
+
+Implemented the ability for group members to create training sessions within their groups. Training sessions are practice events that do not affect ELO ratings and are strictly scoped to group membership.
+
+---
+
+## Architecture
+
+### Layer Positioning
+
+Training sessions operate in the **Games Layer** and follow strict architectural boundaries:
+
+```
+Training Sessions → Groups → My Community
+❌ Training Sessions → My Community (FORBIDDEN)
+```
+
+**Key Principles:**
+- ✅ Training sessions validate membership via `GroupRepository` only
+- ✅ Participants are ALWAYS resolved via `group.memberIds`
+- ❌ NO imports of `FriendRepository` or My Community layer code
+- ❌ NO direct queries to `friendships` collection
+
+### Enforcement
+
+Architecture compliance is enforced through:
+1. **Architecture Tests** (`test/architecture/dependency_test.dart`)
+   - Validates no friendship imports in training module
+   - Validates no friendship imports in training repositories
+   - Validates no friendship imports in training BLoCs
+
+2. **Code Review**
+   - Manual verification of import statements
+   - Validation of dependency flow
+
+---
+
+## Implementation
+
+### 1. Domain Model
+
+**File**: `lib/core/data/models/training_session_model.dart`
+
+```dart
+@freezed
+class TrainingSessionModel with _$TrainingSessionModel {
+  const factory TrainingSessionModel({
+    required String id,
+    required String groupId,
+    required String title,
+    String? description,
+    required GameLocation location,
+    required DateTime startTime,
+    required DateTime endTime,
+    required int minParticipants,
+    required int maxParticipants,
+    required String createdBy,
+    required DateTime createdAt,
+    DateTime? updatedAt,
+    String? recurrenceRule, // Future: Story 15.2
+    @Default(TrainingStatus.scheduled) TrainingStatus status,
+    @Default([]) List<String> participantIds,
+    String? notes,
+  }) = _TrainingSessionModel;
+}
+```
+
+**Business Logic Methods:**
+- `canUserJoin(userId)` - Check if user can join
+- `canUserLeave(userId)` - Check if user can leave
+- `isFull` - Check if session is at capacity
+- `hasMinimumParticipants` - Check minimum participant requirement
+- `addParticipant(userId)` - Add participant (returns new instance)
+- `removeParticipant(userId)` - Remove participant (returns new instance)
+
+---
+
+### 2. Repository Layer
+
+**Interface**: `lib/core/domain/repositories/training_session_repository.dart`
+**Implementation**: `lib/core/data/repositories/firestore_training_session_repository.dart`
+
+**Key Methods:**
+- `createTrainingSession(session)` - Calls Cloud Function for server-side validation
+- `getTrainingSessionById(sessionId)` - Fetch single session
+- `getUpcomingTrainingSessionsForGroup(groupId)` - Stream upcoming sessions
+- `addParticipant(sessionId, userId)` - Add participant with validation
+- `removeParticipant(sessionId, userId)` - Remove participant
+
+**Security Approach:**
+- Creation uses **Cloud Function** (`createTrainingSession`) for server-side validation
+- All other operations go through Firestore with security rules
+- Group membership validation happens server-side
+
+---
+
+### 3. Cloud Function
+
+**File**: `functions/src/createTrainingSession.ts`
+
+**Purpose**: Server-side validation and creation of training sessions
+
+**Validation Steps:**
+1. **Authentication** - Verify user is logged in
+2. **Input Validation**:
+   - Required fields present
+   - Title length (3-100 characters)
+   - Location provided
+   - Valid date/time format (ISO 8601)
+   - Start time in future
+   - End time after start time
+   - Minimum 30-minute duration
+   - Participant limits (2-30)
+3. **Group Membership Validation**:
+   - Group exists
+   - User is a member of the group (via Admin SDK)
+4. **Document Creation**:
+   - Uses Admin SDK to bypass Firestore rules
+   - Returns session ID
+
+**Error Codes:**
+- `unauthenticated` - User not logged in
+- `permission-denied` - User not a member of group
+- `not-found` - Group doesn't exist
+- `invalid-argument` - Invalid input data
+- `internal` - Server error
+
+**Deployment:**
+- ✅ Deployed to `playwithme-dev`
+- ✅ Deployed to `playwithme-stg`
+- ✅ Deployed to `playwithme-prod`
+
+---
+
+### 4. BLoC Layer
+
+**Files**:
+- `lib/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart`
+- `training_session_creation_event.dart`
+- `training_session_creation_state.dart`
+
+**Events:**
+- `SelectTrainingGroup` - Select group for session
+- `SetStartTime` / `SetEndTime` - Set session times
+- `SetTrainingLocation` - Set location
+- `SetTrainingTitle` / `SetTrainingDescription` - Set session details
+- `SetMaxParticipants` / `SetMinParticipants` - Set capacity
+- `SetSessionNotes` - Add session notes
+- `ValidateTrainingForm` - Trigger validation
+- `SubmitTrainingSession` - Create session
+- `ResetTrainingForm` - Reset form state
+
+**States:**
+- `TrainingSessionCreationInitial` - Initial state
+- `TrainingSessionCreationFormState` - Form being filled (with validation errors)
+- `TrainingSessionCreationSubmitting` - Submitting to Cloud Function
+- `TrainingSessionCreationSuccess` - Session created successfully
+- `TrainingSessionCreationError` - Creation failed
+
+**Validation Rules:**
+- Group must be selected
+- Start time must be in future
+- End time must be after start time
+- Minimum 30-minute duration
+- Location required
+- Title: 3-100 characters
+- Min participants: ≥ 2
+- Max participants: ≤ 30, ≥ min participants
+
+---
+
+### 5. Firestore Security Rules
+
+**File**: `firestore.rules`
+
+```javascript
+match /trainingSessions/{sessionId} {
+  // Read: Group members only
+  allow get, list: if isAuthenticated() &&
+    request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds;
+
+  // CRITICAL: Creation via Cloud Function ONLY
+  allow create: if false;
+
+  // Update: Creator or group members
+  allow update: if isAuthenticated() &&
+    (request.auth.uid == resource.data.createdBy ||
+     request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds);
+
+  // Delete: Creator only
+  allow delete: if isAuthenticated() &&
+    request.auth.uid == resource.data.createdBy;
+}
+```
+
+**Security Approach:**
+- ✅ Creation restricted to Cloud Function only (`allow create: if false`)
+- ✅ Reads require group membership validation
+- ✅ Updates allowed for creator and group members
+- ✅ Deletes restricted to creator only
+
+**Deployment:**
+- ✅ Deployed to `playwithme-dev`
+- ✅ Deployed to `playwithme-stg`
+- ✅ Deployed to `playwithme-prod`
+
+---
+
+## Testing
+
+### Unit Tests
+
+**File**: `test/unit/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc_test.dart`
+
+**Coverage**: 27 comprehensive tests
+
+**Test Categories:**
+1. **Initial State** (1 test)
+2. **Form Field Updates** (8 tests)
+   - Group selection
+   - Start/end time
+   - Location
+   - Title/description
+   - Participants
+   - Notes
+3. **Validation** (12 tests)
+   - Future date validation
+   - Time ordering validation
+   - Minimum duration (30 min)
+   - Title length validation
+   - Participant limits
+4. **Submission** (5 tests)
+   - Invalid form rejection
+   - Successful creation
+   - Error handling (not a member, group not found, generic errors)
+5. **Form Reset** (1 test)
+
+**Result**: ✅ All 27 tests passing
+
+### Architecture Tests
+
+**File**: `test/architecture/dependency_test.dart`
+
+**Tests Added:**
+1. Training module should not import FriendRepository
+2. Training repositories should not import FriendRepository
+3. Training BLoCs should not import FriendRepository
+
+**Result**: ✅ All architecture tests passing
+
+### Integration Tests
+
+**Status**: ⏸️ Deferred to future story
+
+Integration tests with Firebase Emulator will be added when UI implementation begins (Story 15.1.1 or similar).
+
+---
+
+## Data Model
+
+### Firestore Collection
+
+**Collection**: `trainingSessions`
+
+**Document Structure:**
+```json
+{
+  "id": "auto-generated",
+  "groupId": "group-123",
+  "title": "Advanced Serving Practice",
+  "description": "Focus on jump serves and float serves",
+  "location": {
+    "name": "Beach Court 1",
+    "address": "123 Beach Street, Venice Beach"
+  },
+  "startTime": Timestamp,
+  "endTime": Timestamp,
+  "minParticipants": 4,
+  "maxParticipants": 12,
+  "createdBy": "user-456",
+  "createdAt": Timestamp,
+  "updatedAt": Timestamp | null,
+  "recurrenceRule": null,
+  "status": "scheduled",
+  "participantIds": ["user-789", "user-101"],
+  "notes": "Bring water and sunscreen"
+}
+```
+
+---
+
+## Dependencies
+
+**Dart/Flutter Packages:**
+- `freezed` - Immutable data models
+- `cloud_firestore` - Firestore database access
+- `cloud_functions` - Cloud Functions callable interface
+- `flutter_bloc` - State management
+- `get_it` - Dependency injection
+
+**Cloud Functions:**
+- `firebase-functions` - Cloud Functions SDK
+- `firebase-admin` - Admin SDK for Firestore access
+
+---
+
+## Future Enhancements
+
+This story provides the foundation for:
+
+- **Story 15.2**: Recurring Training Sessions
+- **Story 15.3**: Join/Leave Training Session
+- **Story 15.4**: Training Sessions in Group Activity Feed
+- **Story 15.5**: No ELO or Competitive Impact (enforcement)
+- **Story 15.6**: Track Training Participation (Stats Foundation)
+- **Story 15.7**: Add Exercises to Training Session
+- **Story 15.8**: Anonymous Feedback After Training
+
+---
+
+## API Reference
+
+### Cloud Function
+
+**Function**: `createTrainingSession`
+
+**Request:**
+```typescript
+{
+  groupId: string;
+  title: string;
+  description?: string;
+  locationName: string;
+  locationAddress?: string;
+  startTime: string; // ISO 8601
+  endTime: string; // ISO 8601
+  minParticipants: number;
+  maxParticipants: number;
+  notes?: string;
+}
+```
+
+**Response:**
+```typescript
+{
+  success: boolean;
+  sessionId: string;
+}
+```
+
+**Usage (Dart):**
+```dart
+final callable = FirebaseFunctions.instance.httpsCallable('createTrainingSession');
+
+final result = await callable.call({
+  'groupId': 'group-123',
+  'title': 'Advanced Training',
+  'locationName': 'Beach Court 1',
+  'locationAddress': '123 Beach St',
+  'startTime': DateTime.now().add(Duration(days: 1)).toIso8601String(),
+  'endTime': DateTime.now().add(Duration(days: 1, hours: 2)).toIso8601String(),
+  'minParticipants': 4,
+  'maxParticipants': 12,
+});
+
+final sessionId = result.data['sessionId'];
+```
+
+---
+
+## Acceptance Criteria
+
+✅ **All Acceptance Criteria Met:**
+
+- [x] Training Session can only be created within an existing Group
+- [x] Creator must be a member of the Group
+- [x] Required fields validated: Title, Location, Start Time, End Time, Min/Max Participants
+- [x] No access to friendship or social graph data
+- [x] Group membership validation performed via `GroupRepository` only (through Cloud Function)
+- [x] Stored under the Games layer Firestore namespace
+- [x] Architecture tests ensure no social graph imports
+- [x] Security rules prevent non-members from creating sessions (via Cloud Function restriction)
+- [x] Code passes `flutter analyze` with 0 warnings
+- [x] Unit tests with 90%+ coverage (27 comprehensive tests)
+- [x] Documentation updated
+
+---
+
+## Related Files
+
+### Source Code
+- `lib/core/data/models/training_session_model.dart`
+- `lib/core/domain/repositories/training_session_repository.dart`
+- `lib/core/data/repositories/firestore_training_session_repository.dart`
+- `lib/features/training/presentation/bloc/training_session_creation/`
+- `functions/src/createTrainingSession.ts`
+
+### Configuration
+- `firestore.rules` (lines 212-243)
+- `functions/src/index.ts` (export createTrainingSession)
+- `lib/core/services/service_locator.dart` (dependency injection)
+
+### Tests
+- `test/unit/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc_test.dart`
+- `test/architecture/dependency_test.dart`
+
+### Documentation
+- `CLAUDE.md` (Section 2: Architecture Overview)
+- `docs/architecture/LAYERED_DEPENDENCIES.md`
+
+---
+
+## Deployment History
+
+| Environment | Date | Status | Notes |
+|------------|------|--------|-------|
+| Dev | 2026-01-07 | ✅ Deployed | Cloud Function + Rules deployed successfully |
+| Staging | 2026-01-07 | ✅ Deployed | Cloud Function + Rules deployed successfully |
+| Production | 2026-01-07 | ✅ Deployed | Cloud Function + Rules deployed successfully |
+
+---
+
+## Notes
+
+- Training sessions are **peer to Games**, not a sub-type of Game
+- Training sessions **do not affect ELO ratings** (enforced in Story 15.5)
+- Participant management (join/leave) implemented in Story 15.3
+- UI implementation deferred to separate story
+- Recurrence support (Story 15.2) foundation added but not implemented
+
+---
+
+**Implemented by**: Babas10
+**Reviewed by**: [Pending PR Review]
+**GitHub Issue**: [#346](https://github.com/Babas10/playWithMe/issues/346)

--- a/firestore.rules
+++ b/firestore.rules
@@ -209,6 +209,39 @@ service cloud.firestore {
                        request.auth.uid == resource.data.createdBy;
     }
 
+    // ============================================
+    // Training Sessions (Epic 15)
+    // ============================================
+
+    // Training Sessions: Group members can participate, creators can manage
+    // ARCHITECTURE: Training sessions are in Games layer, validate via group membership only
+    // SECURITY: Creation goes through Cloud Function for server-side validation
+    match /trainingSessions/{sessionId} {
+      // Individual session reads allowed for members (used by session details page)
+      allow get: if isAuthenticated() &&
+                    request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds;
+
+      // List/query operations allowed for group members
+      // Each document is checked individually - user must be member of the session's group
+      allow list: if isAuthenticated() &&
+                     request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds;
+
+      // CRITICAL: Training session creation is Cloud Functions ONLY
+      // Use createTrainingSession callable function for server-side validation
+      // This keeps rules minimal and validation logic centralized
+      allow create: if false;
+
+      // Training session updates allowed for creator or group members (for joining/leaving, completion)
+      // Note: Only group members can join (validated in repository layer)
+      allow update: if isAuthenticated() &&
+                       (request.auth.uid == resource.data.createdBy ||
+                        request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds);
+
+      // Only creator can delete training sessions
+      allow delete: if isAuthenticated() &&
+                       request.auth.uid == resource.data.createdBy;
+    }
+
     // Deny all other access
     match /{document=**} {
       allow read, write: if false;

--- a/functions/src/createTrainingSession.ts
+++ b/functions/src/createTrainingSession.ts
@@ -1,0 +1,312 @@
+// Cloud Function for creating training sessions with group membership validation
+// ARCHITECTURE: Training sessions are in Games layer, validate via GroupRepository only
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface CreateTrainingSessionRequest {
+  groupId: string;
+  title: string;
+  description?: string;
+  locationName: string;
+  locationAddress?: string;
+  startTime: string; // ISO 8601 string
+  endTime: string; // ISO 8601 string
+  minParticipants: number;
+  maxParticipants: number;
+  notes?: string;
+}
+
+interface CreateTrainingSessionResponse {
+  success: boolean;
+  sessionId: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Check if group exists and get group data
+ */
+async function getGroupData(groupId: string): Promise<{
+  name: string;
+  createdBy: string;
+  memberIds: string[];
+} | null> {
+  const db = admin.firestore();
+  const groupDoc = await db.collection("groups").doc(groupId).get();
+
+  if (!groupDoc.exists) {
+    return null;
+  }
+
+  const groupData = groupDoc.data()!;
+  return {
+    name: groupData.name,
+    createdBy: groupData.createdBy,
+    memberIds: groupData.memberIds || [],
+  };
+}
+
+/**
+ * Validate training session timing
+ */
+function validateTiming(startTime: Date, endTime: Date): string | null {
+  const now = new Date();
+
+  if (startTime <= now) {
+    return "Start time must be in the future";
+  }
+
+  if (endTime <= startTime) {
+    return "End time must be after start time";
+  }
+
+  const durationMinutes = (endTime.getTime() - startTime.getTime()) / (1000 * 60);
+  if (durationMinutes < 30) {
+    return "Training session must be at least 30 minutes long";
+  }
+
+  return null;
+}
+
+/**
+ * Validate participant limits
+ */
+function validateParticipants(minParticipants: number, maxParticipants: number): string | null {
+  if (minParticipants < 2) {
+    return "Minimum participants must be at least 2";
+  }
+
+  if (maxParticipants > 30) {
+    return "Maximum participants cannot exceed 30";
+  }
+
+  if (maxParticipants < minParticipants) {
+    return "Maximum participants must be greater than or equal to minimum participants";
+  }
+
+  return null;
+}
+
+/**
+ * Validate title
+ */
+function validateTitle(title: string): string | null {
+  if (!title || title.trim().length === 0) {
+    return "Title is required";
+  }
+
+  if (title.trim().length < 3) {
+    return "Title must be at least 3 characters";
+  }
+
+  if (title.trim().length > 100) {
+    return "Title must be less than 100 characters";
+  }
+
+  return null;
+}
+
+/**
+ * Validate location
+ */
+function validateLocation(locationName: string): string | null {
+  if (!locationName || locationName.trim().length === 0) {
+    return "Location is required";
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Main Cloud Function
+// ============================================================================
+
+/**
+ * Creates a new training session with server-side validation
+ *
+ * ARCHITECTURE ENFORCEMENT:
+ * - Validates group membership using Admin SDK (bypasses Firestore rules)
+ * - Does NOT import or check friendships (Games layer → Groups only)
+ * - Participants are always resolved via group.memberIds
+ *
+ * Security:
+ * - Validates authentication
+ * - Validates group membership
+ * - Validates all input parameters
+ * - Uses Admin SDK to write to Firestore (bypasses security rules)
+ *
+ * @param data - CreateTrainingSessionRequest
+ * @param context - CallableContext with authentication info
+ * @returns CreateTrainingSessionResponse with sessionId
+ */
+export const createTrainingSession = functions
+  .runWith({
+    timeoutSeconds: 30,
+    memory: "256MB",
+  })
+  .https.onCall(
+    async (
+      data: CreateTrainingSessionRequest,
+      context: functions.https.CallableContext
+    ): Promise<CreateTrainingSessionResponse> => {
+      // ========================================
+      // 1. Authentication Check
+      // ========================================
+      if (!context.auth) {
+        functions.logger.warn("Unauthenticated attempt to create training session");
+        throw new functions.https.HttpsError(
+          "unauthenticated",
+          "You must be logged in to create a training session"
+        );
+      }
+
+      const userId = context.auth.uid;
+      const db = admin.firestore();
+
+      functions.logger.info("Creating training session", {
+        userId,
+        groupId: data.groupId,
+        title: data.title,
+      });
+
+      // ========================================
+      // 2. Input Validation
+      // ========================================
+
+      // Validate required fields
+      if (!data.groupId || !data.title || !data.locationName || !data.startTime || !data.endTime) {
+        throw new functions.https.HttpsError(
+          "invalid-argument",
+          "Missing required fields: groupId, title, locationName, startTime, endTime"
+        );
+      }
+
+      // Validate title
+      const titleError = validateTitle(data.title);
+      if (titleError) {
+        throw new functions.https.HttpsError("invalid-argument", titleError);
+      }
+
+      // Validate location
+      const locationError = validateLocation(data.locationName);
+      if (locationError) {
+        throw new functions.https.HttpsError("invalid-argument", locationError);
+      }
+
+      // Parse and validate timestamps
+      let startTime: Date;
+      let endTime: Date;
+      try {
+        startTime = new Date(data.startTime);
+        endTime = new Date(data.endTime);
+
+        if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) {
+          throw new Error("Invalid date format");
+        }
+      } catch (error) {
+        throw new functions.https.HttpsError(
+          "invalid-argument",
+          "Invalid date format. Use ISO 8601 format (e.g., 2024-01-15T14:30:00.000Z)"
+        );
+      }
+
+      // Validate timing
+      const timingError = validateTiming(startTime, endTime);
+      if (timingError) {
+        throw new functions.https.HttpsError("invalid-argument", timingError);
+      }
+
+      // Validate participants
+      const participantsError = validateParticipants(
+        data.minParticipants || 4,
+        data.maxParticipants || 12
+      );
+      if (participantsError) {
+        throw new functions.https.HttpsError("invalid-argument", participantsError);
+      }
+
+      // ========================================
+      // 3. Group Membership Validation
+      // ========================================
+
+      // CRITICAL: Validate group exists and user is a member
+      // This enforces the architecture rule: Training Sessions → Groups only
+      const groupData = await getGroupData(data.groupId);
+
+      if (!groupData) {
+        functions.logger.warn("Group not found", {userId, groupId: data.groupId});
+        throw new functions.https.HttpsError(
+          "not-found",
+          "The selected group does not exist"
+        );
+      }
+
+      if (!groupData.memberIds.includes(userId)) {
+        functions.logger.warn("User not a member of group", {
+          userId,
+          groupId: data.groupId,
+        });
+        throw new functions.https.HttpsError(
+          "permission-denied",
+          "You must be a member of the group to create a training session"
+        );
+      }
+
+      // ========================================
+      // 4. Create Training Session Document
+      // ========================================
+
+      try {
+        const sessionData = {
+          groupId: data.groupId,
+          title: data.title.trim(),
+          description: data.description?.trim() || null,
+          location: {
+            name: data.locationName.trim(),
+            address: data.locationAddress?.trim() || null,
+          },
+          startTime: admin.firestore.Timestamp.fromDate(startTime),
+          endTime: admin.firestore.Timestamp.fromDate(endTime),
+          minParticipants: data.minParticipants || 4,
+          maxParticipants: data.maxParticipants || 12,
+          createdBy: userId,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedAt: null,
+          recurrenceRule: null, // Future enhancement (Story 15.2)
+          status: "scheduled",
+          participantIds: [], // Creator doesn't auto-join (they can join manually)
+          notes: data.notes?.trim() || null,
+        };
+
+        // Write using Admin SDK (bypasses Firestore security rules)
+        const sessionRef = await db.collection("trainingSessions").add(sessionData);
+
+        functions.logger.info("Training session created successfully", {
+          sessionId: sessionRef.id,
+          userId,
+          groupId: data.groupId,
+        });
+
+        return {
+          success: true,
+          sessionId: sessionRef.id,
+        };
+      } catch (error) {
+        functions.logger.error("Failed to create training session", {
+          userId,
+          groupId: data.groupId,
+          error,
+        });
+        throw new functions.https.HttpsError(
+          "internal",
+          "Failed to create training session. Please try again."
+        );
+      }
+    }
+  );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -21,6 +21,7 @@ export {getGamesForGroup} from "./getGamesForGroup"; // Story 3.5
 export {getCompletedGames} from "./getCompletedGames"; // Story 14.7
 export {getHeadToHeadStats} from "./getHeadToHeadStats"; // Story 301.8
 export {calculateUserRanking} from "./calculateUserRanking"; // Story 302.2
+export {createTrainingSession} from "./createTrainingSession"; // Story 15.1 (Epic 15: Training Sessions)
 
 // Export friendship functions (callable functions)
 export {

--- a/lib/core/data/models/training_session_model.dart
+++ b/lib/core/data/models/training_session_model.dart
@@ -1,0 +1,261 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'game_model.dart'; // For GameLocation reuse
+
+part 'training_session_model.freezed.dart';
+part 'training_session_model.g.dart';
+
+/// Represents a training session within a group
+/// Training sessions are practice events that do not affect ELO ratings
+/// They are bound to groups and participants are resolved via group membership only
+@freezed
+class TrainingSessionModel with _$TrainingSessionModel {
+  const factory TrainingSessionModel({
+    required String id,
+    required String groupId,
+    required String title,
+    String? description,
+    required GameLocation location,
+    @TimestampConverter() required DateTime startTime,
+    @TimestampConverter() required DateTime endTime,
+    required int minParticipants,
+    required int maxParticipants,
+    required String createdBy,
+    @TimestampConverter() required DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    // Recurrence support (for Story 15.2 - future enhancement)
+    String? recurrenceRule,
+    // Session status
+    @Default(TrainingStatus.scheduled) TrainingStatus status,
+    // Participant tracking
+    @Default([]) List<String> participantIds,
+    // Session notes
+    String? notes,
+  }) = _TrainingSessionModel;
+
+  const TrainingSessionModel._();
+
+  factory TrainingSessionModel.fromJson(Map<String, dynamic> json) =>
+      _$TrainingSessionModelFromJson(json);
+
+  /// Factory constructor for creating from Firestore DocumentSnapshot
+  factory TrainingSessionModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+
+    // Convert Firestore Timestamps to DateTime strings for JSON deserialization
+    final jsonData = Map<String, dynamic>.from(data);
+
+    if (data['createdAt'] is Timestamp) {
+      jsonData['createdAt'] =
+          (data['createdAt'] as Timestamp).toDate().toIso8601String();
+    }
+    if (data['startTime'] is Timestamp) {
+      jsonData['startTime'] =
+          (data['startTime'] as Timestamp).toDate().toIso8601String();
+    }
+    if (data['endTime'] is Timestamp) {
+      jsonData['endTime'] =
+          (data['endTime'] as Timestamp).toDate().toIso8601String();
+    }
+    if (data['updatedAt'] is Timestamp) {
+      jsonData['updatedAt'] =
+          (data['updatedAt'] as Timestamp).toDate().toIso8601String();
+    }
+
+    return TrainingSessionModel.fromJson({
+      ...jsonData,
+      'id': doc.id,
+    });
+  }
+
+  /// Convert to Firestore-compatible map (excludes id since it's the document ID)
+  Map<String, dynamic> toFirestore() {
+    final json = toJson();
+    json.remove('id'); // Remove id as it's the document ID
+
+    // Convert DateTime fields to Firestore Timestamps
+    if (json['createdAt'] is String) {
+      json['createdAt'] = Timestamp.fromDate(createdAt);
+    }
+    if (json['startTime'] is String) {
+      json['startTime'] = Timestamp.fromDate(startTime);
+    }
+    if (json['endTime'] is String) {
+      json['endTime'] = Timestamp.fromDate(endTime);
+    }
+    if (updatedAt != null && json['updatedAt'] is String) {
+      json['updatedAt'] = Timestamp.fromDate(updatedAt!);
+    }
+
+    // Ensure location is properly serialized
+    if (json['location'] is GameLocation) {
+      json['location'] = (json['location'] as GameLocation).toJson();
+    }
+
+    return json;
+  }
+
+  /// Business logic methods
+
+  /// Check if user is participating in the training session
+  bool isParticipant(String userId) => participantIds.contains(userId);
+
+  /// Check if user is the creator
+  bool isCreator(String userId) => createdBy == userId;
+
+  /// Check if user can manage the training session
+  bool canManage(String userId) => createdBy == userId;
+
+  /// Check if training session is full
+  bool get isFull => participantIds.length >= maxParticipants;
+
+  /// Check if training session has minimum participants
+  bool get hasMinimumParticipants =>
+      participantIds.length >= minParticipants;
+
+  /// Get available spots
+  int get availableSpots => maxParticipants - participantIds.length;
+
+  /// Get current participant count
+  int get currentParticipantCount => participantIds.length;
+
+  /// Check if training session is in the past
+  bool get isPast => startTime.isBefore(DateTime.now());
+
+  /// Check if training session is today
+  bool get isToday {
+    final now = DateTime.now();
+    final sessionDate = startTime;
+    return now.year == sessionDate.year &&
+        now.month == sessionDate.month &&
+        now.day == sessionDate.day;
+  }
+
+  /// Check if training session is this week
+  bool get isThisWeek {
+    final now = DateTime.now();
+    final startOfWeek = now.subtract(Duration(days: now.weekday - 1));
+    final endOfWeek = startOfWeek.add(const Duration(days: 6));
+    return startTime.isAfter(startOfWeek) && startTime.isBefore(endOfWeek);
+  }
+
+  /// Get training session duration
+  Duration get duration => endTime.difference(startTime);
+
+  /// Check if user can join the training session
+  bool canUserJoin(String userId) {
+    if (isParticipant(userId)) return false;
+    if (status != TrainingStatus.scheduled) return false;
+    if (isPast) return false;
+    return !isFull;
+  }
+
+  /// Check if user can leave the training session
+  bool canUserLeave(String userId) {
+    return isParticipant(userId) && status == TrainingStatus.scheduled;
+  }
+
+  /// Validation methods
+
+  /// Validate training session timing
+  bool get hasValidTiming => startTime.isAfter(DateTime.now()) && endTime.isAfter(startTime);
+
+  /// Validate participant limits
+  bool get hasValidParticipantLimits =>
+      minParticipants <= maxParticipants && minParticipants >= 2;
+
+  /// Update methods that return new instances
+
+  /// Update basic training session information
+  TrainingSessionModel updateInfo({
+    String? title,
+    String? description,
+    DateTime? startTime,
+    DateTime? endTime,
+    GameLocation? location,
+    String? notes,
+  }) {
+    return copyWith(
+      title: title ?? this.title,
+      description: description ?? this.description,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      location: location ?? this.location,
+      notes: notes ?? this.notes,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Update training session settings
+  TrainingSessionModel updateSettings({
+    int? maxParticipants,
+    int? minParticipants,
+  }) {
+    return copyWith(
+      maxParticipants: maxParticipants ?? this.maxParticipants,
+      minParticipants: minParticipants ?? this.minParticipants,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Add a participant to the training session
+  TrainingSessionModel addParticipant(String userId) {
+    if (isParticipant(userId) || isFull) return this;
+
+    return copyWith(
+      participantIds: [...participantIds, userId],
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Remove a participant from the training session
+  TrainingSessionModel removeParticipant(String userId) {
+    return copyWith(
+      participantIds: participantIds.where((id) => id != userId).toList(),
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Cancel the training session
+  TrainingSessionModel cancelSession() {
+    if (status == TrainingStatus.completed) return this;
+    return copyWith(
+      status: TrainingStatus.cancelled,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Complete the training session
+  TrainingSessionModel completeSession() {
+    if (status != TrainingStatus.scheduled) return this;
+    return copyWith(
+      status: TrainingStatus.completed,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Get formatted time until training session
+  String getTimeUntilSession() {
+    final now = DateTime.now();
+    if (startTime.isBefore(now)) return 'Past';
+
+    final difference = startTime.difference(now);
+    if (difference.inDays > 0) {
+      return '${difference.inDays}d ${difference.inHours.remainder(24)}h';
+    } else if (difference.inHours > 0) {
+      return '${difference.inHours}h ${difference.inMinutes.remainder(60)}m';
+    } else {
+      return '${difference.inMinutes}m';
+    }
+  }
+}
+
+enum TrainingStatus {
+  @JsonValue('scheduled')
+  scheduled,
+  @JsonValue('completed')
+  completed,
+  @JsonValue('cancelled')
+  cancelled,
+}

--- a/lib/core/data/models/training_session_model.freezed.dart
+++ b/lib/core/data/models/training_session_model.freezed.dart
@@ -1,0 +1,561 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'training_session_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+TrainingSessionModel _$TrainingSessionModelFromJson(Map<String, dynamic> json) {
+  return _TrainingSessionModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TrainingSessionModel {
+  String get id => throw _privateConstructorUsedError;
+  String get groupId => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String? get description => throw _privateConstructorUsedError;
+  GameLocation get location => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime get startTime => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime get endTime => throw _privateConstructorUsedError;
+  int get minParticipants => throw _privateConstructorUsedError;
+  int get maxParticipants => throw _privateConstructorUsedError;
+  String get createdBy => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get updatedAt => throw _privateConstructorUsedError; // Recurrence support (for Story 15.2 - future enhancement)
+  String? get recurrenceRule =>
+      throw _privateConstructorUsedError; // Session status
+  TrainingStatus get status =>
+      throw _privateConstructorUsedError; // Participant tracking
+  List<String> get participantIds =>
+      throw _privateConstructorUsedError; // Session notes
+  String? get notes => throw _privateConstructorUsedError;
+
+  /// Serializes this TrainingSessionModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TrainingSessionModelCopyWith<TrainingSessionModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TrainingSessionModelCopyWith<$Res> {
+  factory $TrainingSessionModelCopyWith(
+    TrainingSessionModel value,
+    $Res Function(TrainingSessionModel) then,
+  ) = _$TrainingSessionModelCopyWithImpl<$Res, TrainingSessionModel>;
+  @useResult
+  $Res call({
+    String id,
+    String groupId,
+    String title,
+    String? description,
+    GameLocation location,
+    @TimestampConverter() DateTime startTime,
+    @TimestampConverter() DateTime endTime,
+    int minParticipants,
+    int maxParticipants,
+    String createdBy,
+    @TimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    String? recurrenceRule,
+    TrainingStatus status,
+    List<String> participantIds,
+    String? notes,
+  });
+
+  $GameLocationCopyWith<$Res> get location;
+}
+
+/// @nodoc
+class _$TrainingSessionModelCopyWithImpl<
+  $Res,
+  $Val extends TrainingSessionModel
+>
+    implements $TrainingSessionModelCopyWith<$Res> {
+  _$TrainingSessionModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? groupId = null,
+    Object? title = null,
+    Object? description = freezed,
+    Object? location = null,
+    Object? startTime = null,
+    Object? endTime = null,
+    Object? minParticipants = null,
+    Object? maxParticipants = null,
+    Object? createdBy = null,
+    Object? createdAt = null,
+    Object? updatedAt = freezed,
+    Object? recurrenceRule = freezed,
+    Object? status = null,
+    Object? participantIds = null,
+    Object? notes = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            groupId: null == groupId
+                ? _value.groupId
+                : groupId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            description: freezed == description
+                ? _value.description
+                : description // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            location: null == location
+                ? _value.location
+                : location // ignore: cast_nullable_to_non_nullable
+                      as GameLocation,
+            startTime: null == startTime
+                ? _value.startTime
+                : startTime // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            endTime: null == endTime
+                ? _value.endTime
+                : endTime // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            minParticipants: null == minParticipants
+                ? _value.minParticipants
+                : minParticipants // ignore: cast_nullable_to_non_nullable
+                      as int,
+            maxParticipants: null == maxParticipants
+                ? _value.maxParticipants
+                : maxParticipants // ignore: cast_nullable_to_non_nullable
+                      as int,
+            createdBy: null == createdBy
+                ? _value.createdBy
+                : createdBy // ignore: cast_nullable_to_non_nullable
+                      as String,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            updatedAt: freezed == updatedAt
+                ? _value.updatedAt
+                : updatedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            recurrenceRule: freezed == recurrenceRule
+                ? _value.recurrenceRule
+                : recurrenceRule // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as TrainingStatus,
+            participantIds: null == participantIds
+                ? _value.participantIds
+                : participantIds // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            notes: freezed == notes
+                ? _value.notes
+                : notes // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $GameLocationCopyWith<$Res> get location {
+    return $GameLocationCopyWith<$Res>(_value.location, (value) {
+      return _then(_value.copyWith(location: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$TrainingSessionModelImplCopyWith<$Res>
+    implements $TrainingSessionModelCopyWith<$Res> {
+  factory _$$TrainingSessionModelImplCopyWith(
+    _$TrainingSessionModelImpl value,
+    $Res Function(_$TrainingSessionModelImpl) then,
+  ) = __$$TrainingSessionModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String groupId,
+    String title,
+    String? description,
+    GameLocation location,
+    @TimestampConverter() DateTime startTime,
+    @TimestampConverter() DateTime endTime,
+    int minParticipants,
+    int maxParticipants,
+    String createdBy,
+    @TimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    String? recurrenceRule,
+    TrainingStatus status,
+    List<String> participantIds,
+    String? notes,
+  });
+
+  @override
+  $GameLocationCopyWith<$Res> get location;
+}
+
+/// @nodoc
+class __$$TrainingSessionModelImplCopyWithImpl<$Res>
+    extends _$TrainingSessionModelCopyWithImpl<$Res, _$TrainingSessionModelImpl>
+    implements _$$TrainingSessionModelImplCopyWith<$Res> {
+  __$$TrainingSessionModelImplCopyWithImpl(
+    _$TrainingSessionModelImpl _value,
+    $Res Function(_$TrainingSessionModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? groupId = null,
+    Object? title = null,
+    Object? description = freezed,
+    Object? location = null,
+    Object? startTime = null,
+    Object? endTime = null,
+    Object? minParticipants = null,
+    Object? maxParticipants = null,
+    Object? createdBy = null,
+    Object? createdAt = null,
+    Object? updatedAt = freezed,
+    Object? recurrenceRule = freezed,
+    Object? status = null,
+    Object? participantIds = null,
+    Object? notes = freezed,
+  }) {
+    return _then(
+      _$TrainingSessionModelImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        groupId: null == groupId
+            ? _value.groupId
+            : groupId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        description: freezed == description
+            ? _value.description
+            : description // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        location: null == location
+            ? _value.location
+            : location // ignore: cast_nullable_to_non_nullable
+                  as GameLocation,
+        startTime: null == startTime
+            ? _value.startTime
+            : startTime // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        endTime: null == endTime
+            ? _value.endTime
+            : endTime // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        minParticipants: null == minParticipants
+            ? _value.minParticipants
+            : minParticipants // ignore: cast_nullable_to_non_nullable
+                  as int,
+        maxParticipants: null == maxParticipants
+            ? _value.maxParticipants
+            : maxParticipants // ignore: cast_nullable_to_non_nullable
+                  as int,
+        createdBy: null == createdBy
+            ? _value.createdBy
+            : createdBy // ignore: cast_nullable_to_non_nullable
+                  as String,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        updatedAt: freezed == updatedAt
+            ? _value.updatedAt
+            : updatedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        recurrenceRule: freezed == recurrenceRule
+            ? _value.recurrenceRule
+            : recurrenceRule // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as TrainingStatus,
+        participantIds: null == participantIds
+            ? _value._participantIds
+            : participantIds // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        notes: freezed == notes
+            ? _value.notes
+            : notes // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TrainingSessionModelImpl extends _TrainingSessionModel {
+  const _$TrainingSessionModelImpl({
+    required this.id,
+    required this.groupId,
+    required this.title,
+    this.description,
+    required this.location,
+    @TimestampConverter() required this.startTime,
+    @TimestampConverter() required this.endTime,
+    required this.minParticipants,
+    required this.maxParticipants,
+    required this.createdBy,
+    @TimestampConverter() required this.createdAt,
+    @TimestampConverter() this.updatedAt,
+    this.recurrenceRule,
+    this.status = TrainingStatus.scheduled,
+    final List<String> participantIds = const [],
+    this.notes,
+  }) : _participantIds = participantIds,
+       super._();
+
+  factory _$TrainingSessionModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TrainingSessionModelImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String groupId;
+  @override
+  final String title;
+  @override
+  final String? description;
+  @override
+  final GameLocation location;
+  @override
+  @TimestampConverter()
+  final DateTime startTime;
+  @override
+  @TimestampConverter()
+  final DateTime endTime;
+  @override
+  final int minParticipants;
+  @override
+  final int maxParticipants;
+  @override
+  final String createdBy;
+  @override
+  @TimestampConverter()
+  final DateTime createdAt;
+  @override
+  @TimestampConverter()
+  final DateTime? updatedAt;
+  // Recurrence support (for Story 15.2 - future enhancement)
+  @override
+  final String? recurrenceRule;
+  // Session status
+  @override
+  @JsonKey()
+  final TrainingStatus status;
+  // Participant tracking
+  final List<String> _participantIds;
+  // Participant tracking
+  @override
+  @JsonKey()
+  List<String> get participantIds {
+    if (_participantIds is EqualUnmodifiableListView) return _participantIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_participantIds);
+  }
+
+  // Session notes
+  @override
+  final String? notes;
+
+  @override
+  String toString() {
+    return 'TrainingSessionModel(id: $id, groupId: $groupId, title: $title, description: $description, location: $location, startTime: $startTime, endTime: $endTime, minParticipants: $minParticipants, maxParticipants: $maxParticipants, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, recurrenceRule: $recurrenceRule, status: $status, participantIds: $participantIds, notes: $notes)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TrainingSessionModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.minParticipants, minParticipants) ||
+                other.minParticipants == minParticipants) &&
+            (identical(other.maxParticipants, maxParticipants) ||
+                other.maxParticipants == maxParticipants) &&
+            (identical(other.createdBy, createdBy) ||
+                other.createdBy == createdBy) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.recurrenceRule, recurrenceRule) ||
+                other.recurrenceRule == recurrenceRule) &&
+            (identical(other.status, status) || other.status == status) &&
+            const DeepCollectionEquality().equals(
+              other._participantIds,
+              _participantIds,
+            ) &&
+            (identical(other.notes, notes) || other.notes == notes));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    groupId,
+    title,
+    description,
+    location,
+    startTime,
+    endTime,
+    minParticipants,
+    maxParticipants,
+    createdBy,
+    createdAt,
+    updatedAt,
+    recurrenceRule,
+    status,
+    const DeepCollectionEquality().hash(_participantIds),
+    notes,
+  );
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TrainingSessionModelImplCopyWith<_$TrainingSessionModelImpl>
+  get copyWith =>
+      __$$TrainingSessionModelImplCopyWithImpl<_$TrainingSessionModelImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TrainingSessionModelImplToJson(this);
+  }
+}
+
+abstract class _TrainingSessionModel extends TrainingSessionModel {
+  const factory _TrainingSessionModel({
+    required final String id,
+    required final String groupId,
+    required final String title,
+    final String? description,
+    required final GameLocation location,
+    @TimestampConverter() required final DateTime startTime,
+    @TimestampConverter() required final DateTime endTime,
+    required final int minParticipants,
+    required final int maxParticipants,
+    required final String createdBy,
+    @TimestampConverter() required final DateTime createdAt,
+    @TimestampConverter() final DateTime? updatedAt,
+    final String? recurrenceRule,
+    final TrainingStatus status,
+    final List<String> participantIds,
+    final String? notes,
+  }) = _$TrainingSessionModelImpl;
+  const _TrainingSessionModel._() : super._();
+
+  factory _TrainingSessionModel.fromJson(Map<String, dynamic> json) =
+      _$TrainingSessionModelImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get groupId;
+  @override
+  String get title;
+  @override
+  String? get description;
+  @override
+  GameLocation get location;
+  @override
+  @TimestampConverter()
+  DateTime get startTime;
+  @override
+  @TimestampConverter()
+  DateTime get endTime;
+  @override
+  int get minParticipants;
+  @override
+  int get maxParticipants;
+  @override
+  String get createdBy;
+  @override
+  @TimestampConverter()
+  DateTime get createdAt;
+  @override
+  @TimestampConverter()
+  DateTime? get updatedAt; // Recurrence support (for Story 15.2 - future enhancement)
+  @override
+  String? get recurrenceRule; // Session status
+  @override
+  TrainingStatus get status; // Participant tracking
+  @override
+  List<String> get participantIds; // Session notes
+  @override
+  String? get notes;
+
+  /// Create a copy of TrainingSessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TrainingSessionModelImplCopyWith<_$TrainingSessionModelImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/core/data/models/training_session_model.g.dart
+++ b/lib/core/data/models/training_session_model.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'training_session_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TrainingSessionModelImpl _$$TrainingSessionModelImplFromJson(
+  Map<String, dynamic> json,
+) => _$TrainingSessionModelImpl(
+  id: json['id'] as String,
+  groupId: json['groupId'] as String,
+  title: json['title'] as String,
+  description: json['description'] as String?,
+  location: GameLocation.fromJson(json['location'] as Map<String, dynamic>),
+  startTime: DateTime.parse(json['startTime'] as String),
+  endTime: DateTime.parse(json['endTime'] as String),
+  minParticipants: (json['minParticipants'] as num).toInt(),
+  maxParticipants: (json['maxParticipants'] as num).toInt(),
+  createdBy: json['createdBy'] as String,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: const TimestampConverter().fromJson(json['updatedAt']),
+  recurrenceRule: json['recurrenceRule'] as String?,
+  status:
+      $enumDecodeNullable(_$TrainingStatusEnumMap, json['status']) ??
+      TrainingStatus.scheduled,
+  participantIds:
+      (json['participantIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
+  notes: json['notes'] as String?,
+);
+
+Map<String, dynamic> _$$TrainingSessionModelImplToJson(
+  _$TrainingSessionModelImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'groupId': instance.groupId,
+  'title': instance.title,
+  'description': instance.description,
+  'location': instance.location,
+  'startTime': instance.startTime.toIso8601String(),
+  'endTime': instance.endTime.toIso8601String(),
+  'minParticipants': instance.minParticipants,
+  'maxParticipants': instance.maxParticipants,
+  'createdBy': instance.createdBy,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'updatedAt': const TimestampConverter().toJson(instance.updatedAt),
+  'recurrenceRule': instance.recurrenceRule,
+  'status': _$TrainingStatusEnumMap[instance.status]!,
+  'participantIds': instance.participantIds,
+  'notes': instance.notes,
+};
+
+const _$TrainingStatusEnumMap = {
+  TrainingStatus.scheduled: 'scheduled',
+  TrainingStatus.completed: 'completed',
+  TrainingStatus.cancelled: 'cancelled',
+};

--- a/lib/core/data/repositories/firestore_training_session_repository.dart
+++ b/lib/core/data/repositories/firestore_training_session_repository.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import '../../domain/repositories/group_repository.dart';
+import '../../domain/repositories/training_session_repository.dart';
+import '../models/game_model.dart';
+import '../models/training_session_model.dart';
+
+/// Firestore implementation of TrainingSessionRepository
+///
+/// ARCHITECTURE: This repository operates in the Games layer
+/// - ✅ Uses Cloud Function for creation (server-side validation)
+/// - ✅ Validates group membership via Cloud Function (not direct Firestore)
+/// - ❌ Never imports FriendRepository or My Community code
+/// - Participants are resolved via group.memberIds only
+class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
+  final FirebaseFirestore _firestore;
+  final FirebaseFunctions _functions;
+  final GroupRepository _groupRepository;
+
+  static const String _collection = 'trainingSessions';
+
+  FirestoreTrainingSessionRepository({
+    FirebaseFirestore? firestore,
+    FirebaseFunctions? functions,
+    required GroupRepository groupRepository,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _functions = functions ?? FirebaseFunctions.instance,
+        _groupRepository = groupRepository;
+
+  @override
+  Future<TrainingSessionModel?> getTrainingSessionById(String sessionId) async {
+    try {
+      final doc = await _firestore.collection(_collection).doc(sessionId).get();
+      return doc.exists ? TrainingSessionModel.fromFirestore(doc) : null;
+    } catch (e) {
+      throw Exception('Failed to get training session: $e');
+    }
+  }
+
+  @override
+  Stream<TrainingSessionModel?> getTrainingSessionStream(String sessionId) {
+    try {
+      return _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .snapshots()
+          .map((snapshot) => snapshot.exists
+              ? TrainingSessionModel.fromFirestore(snapshot)
+              : null);
+    } catch (e) {
+      throw Exception('Failed to stream training session: $e');
+    }
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForGroup(
+      String groupId) {
+    try {
+      return _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .orderBy('startTime', descending: false)
+          .snapshots()
+          .map((snapshot) => snapshot.docs
+              .where((doc) => doc.exists)
+              .map((doc) => TrainingSessionModel.fromFirestore(doc))
+              .toList());
+    } catch (e) {
+      throw Exception('Failed to get training sessions for group: $e');
+    }
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getUpcomingTrainingSessionsForGroup(
+      String groupId) {
+    try {
+      final now = Timestamp.now();
+      return _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('startTime', isGreaterThan: now)
+          .where('status', isEqualTo: 'scheduled')
+          .orderBy('startTime', descending: false)
+          .snapshots()
+          .map((snapshot) => snapshot.docs
+              .where((doc) => doc.exists)
+              .map((doc) => TrainingSessionModel.fromFirestore(doc))
+              .toList());
+    } catch (e) {
+      throw Exception('Failed to get upcoming training sessions for group: $e');
+    }
+  }
+
+  @override
+  Future<List<TrainingSessionModel>> getPastTrainingSessionsForGroup(
+    String groupId, {
+    int limit = 20,
+  }) async {
+    try {
+      final now = Timestamp.now();
+      final query = await _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('startTime', isLessThan: now)
+          .orderBy('startTime', descending: true)
+          .limit(limit)
+          .get();
+
+      return query.docs
+          .where((doc) => doc.exists)
+          .map((doc) => TrainingSessionModel.fromFirestore(doc))
+          .toList();
+    } catch (e) {
+      throw Exception('Failed to get past training sessions for group: $e');
+    }
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(
+      String userId) {
+    try {
+      return _firestore
+          .collection(_collection)
+          .where('participantIds', arrayContains: userId)
+          .orderBy('startTime', descending: false)
+          .snapshots()
+          .map((snapshot) => snapshot.docs
+              .where((doc) => doc.exists)
+              .map((doc) => TrainingSessionModel.fromFirestore(doc))
+              .toList());
+    } catch (e) {
+      throw Exception('Failed to get training sessions for user: $e');
+    }
+  }
+
+  @override
+  Stream<int> getUpcomingTrainingSessionsCount(String groupId) {
+    try {
+      final now = Timestamp.now();
+      return _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('startTime', isGreaterThan: now)
+          .where('status', isEqualTo: 'scheduled')
+          .snapshots()
+          .map((snapshot) => snapshot.docs.length);
+    } catch (e) {
+      throw Exception('Failed to get upcoming training sessions count: $e');
+    }
+  }
+
+  @override
+  Future<String> createTrainingSession(TrainingSessionModel session) async {
+    try {
+      // Call Cloud Function for server-side validation and creation
+      // This enforces security and keeps Firestore rules minimal
+      final callable = _functions.httpsCallable('createTrainingSession');
+
+      final result = await callable.call<Map<String, dynamic>>({
+        'groupId': session.groupId,
+        'title': session.title,
+        'description': session.description,
+        'locationName': session.location.name,
+        'locationAddress': session.location.address,
+        'startTime': session.startTime.toIso8601String(),
+        'endTime': session.endTime.toIso8601String(),
+        'minParticipants': session.minParticipants,
+        'maxParticipants': session.maxParticipants,
+        'notes': session.notes,
+      });
+
+      final sessionId = result.data['sessionId'] as String;
+      return sessionId;
+    } on FirebaseFunctionsException catch (e) {
+      // Handle specific Cloud Function errors with user-friendly messages
+      switch (e.code) {
+        case 'unauthenticated':
+          throw Exception('You must be logged in to create a training session');
+        case 'permission-denied':
+          throw Exception('Creator is not a member of the group');
+        case 'not-found':
+          throw Exception('Group not found');
+        case 'invalid-argument':
+          throw Exception(e.message ?? 'Invalid session data');
+        default:
+          throw Exception('Failed to create training session: ${e.message}');
+      }
+    } catch (e) {
+      throw Exception('Failed to create training session: $e');
+    }
+  }
+
+  @override
+  Future<void> updateTrainingSessionInfo(
+    String sessionId, {
+    String? title,
+    String? description,
+    DateTime? startTime,
+    DateTime? endTime,
+    GameLocation? location,
+    String? notes,
+  }) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      final updatedSession = currentSession.updateInfo(
+        title: title,
+        description: description,
+        startTime: startTime,
+        endTime: endTime,
+        location: location,
+        notes: notes,
+      );
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to update training session info: $e');
+    }
+  }
+
+  @override
+  Future<void> updateTrainingSessionSettings(
+    String sessionId, {
+    int? maxParticipants,
+    int? minParticipants,
+  }) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      final updatedSession = currentSession.updateSettings(
+        maxParticipants: maxParticipants,
+        minParticipants: minParticipants,
+      );
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to update training session settings: $e');
+    }
+  }
+
+  @override
+  Future<void> addParticipant(String sessionId, String userId) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      // Validate user is a member of the group
+      final groupMembers =
+          await _groupRepository.getGroupMembers(currentSession.groupId);
+      if (!groupMembers.contains(userId)) {
+        throw Exception('User is not a member of the group');
+      }
+
+      // Check if session is full
+      if (currentSession.isFull) {
+        throw Exception('Training session is full');
+      }
+
+      // Check if session is still scheduled
+      if (currentSession.status != TrainingStatus.scheduled) {
+        throw Exception('Training session is not scheduled');
+      }
+
+      final updatedSession = currentSession.addParticipant(userId);
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      if (e.toString().contains('Training session not found') ||
+          e.toString().contains('User is not a member') ||
+          e.toString().contains('Training session is full') ||
+          e.toString().contains('Training session is not scheduled')) {
+        rethrow;
+      }
+      throw Exception('Failed to add participant: $e');
+    }
+  }
+
+  @override
+  Future<void> removeParticipant(String sessionId, String userId) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      final updatedSession = currentSession.removeParticipant(userId);
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to remove participant: $e');
+    }
+  }
+
+  @override
+  Future<void> cancelTrainingSession(String sessionId) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      final updatedSession = currentSession.cancelSession();
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to cancel training session: $e');
+    }
+  }
+
+  @override
+  Future<void> completeTrainingSession(String sessionId) async {
+    try {
+      final currentSession = await getTrainingSessionById(sessionId);
+      if (currentSession == null) {
+        throw Exception('Training session not found');
+      }
+
+      final updatedSession = currentSession.completeSession();
+
+      await _firestore
+          .collection(_collection)
+          .doc(sessionId)
+          .set(updatedSession.toFirestore(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception('Failed to complete training session: $e');
+    }
+  }
+
+  @override
+  Future<void> deleteTrainingSession(String sessionId) async {
+    try {
+      await _firestore.collection(_collection).doc(sessionId).delete();
+    } catch (e) {
+      throw Exception('Failed to delete training session: $e');
+    }
+  }
+
+  @override
+  Future<bool> trainingSessionExists(String sessionId) async {
+    try {
+      final doc = await _firestore.collection(_collection).doc(sessionId).get();
+      return doc.exists;
+    } catch (e) {
+      throw Exception('Failed to check if training session exists: $e');
+    }
+  }
+
+  @override
+  Future<List<String>> getTrainingSessionParticipants(String sessionId) async {
+    try {
+      final session = await getTrainingSessionById(sessionId);
+      return session?.participantIds ?? [];
+    } catch (e) {
+      throw Exception('Failed to get training session participants: $e');
+    }
+  }
+
+  @override
+  Future<bool> canUserJoinTrainingSession(
+      String sessionId, String userId) async {
+    try {
+      final session = await getTrainingSessionById(sessionId);
+      if (session == null) return false;
+
+      // Check if user is a member of the group
+      final groupMembers =
+          await _groupRepository.getGroupMembers(session.groupId);
+      if (!groupMembers.contains(userId)) return false;
+
+      return session.canUserJoin(userId);
+    } catch (e) {
+      throw Exception('Failed to check if user can join training session: $e');
+    }
+  }
+}

--- a/lib/core/domain/repositories/training_session_repository.dart
+++ b/lib/core/domain/repositories/training_session_repository.dart
@@ -1,0 +1,116 @@
+import '../../data/models/game_model.dart';
+import '../../data/models/training_session_model.dart';
+
+/// Repository for managing training sessions in the Games layer
+/// Training sessions are group-bound practice events that do not affect ELO ratings
+///
+/// ARCHITECTURE RULE: This repository operates in the Games layer
+/// - ✅ CAN import: GroupRepository
+/// - ❌ CANNOT import: FriendRepository or any My Community layer code
+/// - Participants are ALWAYS resolved via group.memberIds
+abstract class TrainingSessionRepository {
+  /// Get training session by ID
+  Future<TrainingSessionModel?> getTrainingSessionById(String sessionId);
+
+  /// Stream training session by ID (real-time updates)
+  Stream<TrainingSessionModel?> getTrainingSessionStream(String sessionId);
+
+  /// Get training sessions for a group
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForGroup(
+      String groupId);
+
+  /// Get upcoming training sessions for a group
+  Stream<List<TrainingSessionModel>> getUpcomingTrainingSessionsForGroup(
+      String groupId);
+
+  /// Get past training sessions for a group
+  Future<List<TrainingSessionModel>> getPastTrainingSessionsForGroup(
+    String groupId, {
+    int limit = 20,
+  });
+
+  /// Get training sessions for a user (across all groups they're members of)
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(String userId);
+
+  /// Get count of upcoming training sessions for a group
+  Stream<int> getUpcomingTrainingSessionsCount(String groupId);
+
+  /// Create a new training session
+  ///
+  /// Validates that:
+  /// - The creator is a member of the specified group
+  /// - The group exists and is accessible
+  ///
+  /// Throws:
+  /// - [Exception] if creator is not a member of the group
+  /// - [Exception] if group does not exist
+  Future<String> createTrainingSession(TrainingSessionModel session);
+
+  /// Update training session information
+  Future<void> updateTrainingSessionInfo(
+    String sessionId, {
+    String? title,
+    String? description,
+    DateTime? startTime,
+    DateTime? endTime,
+    GameLocation? location,
+    String? notes,
+  });
+
+  /// Update training session settings
+  Future<void> updateTrainingSessionSettings(
+    String sessionId, {
+    int? maxParticipants,
+    int? minParticipants,
+  });
+
+  /// Add participant to training session
+  ///
+  /// Validates that:
+  /// - The user is a member of the group
+  /// - The session is not full
+  /// - The session is still scheduled (not cancelled or completed)
+  ///
+  /// Throws:
+  /// - [Exception] if user is not a member of the group
+  /// - [Exception] if session is full
+  Future<void> addParticipant(String sessionId, String userId);
+
+  /// Remove participant from training session
+  ///
+  /// Only allowed if:
+  /// - The session is still scheduled (not started or completed)
+  Future<void> removeParticipant(String sessionId, String userId);
+
+  /// Cancel training session
+  ///
+  /// Only the creator can cancel a training session
+  Future<void> cancelTrainingSession(String sessionId);
+
+  /// Complete training session
+  ///
+  /// Marks the session as completed
+  /// This does NOT affect ELO ratings (training sessions are practice only)
+  Future<void> completeTrainingSession(String sessionId);
+
+  /// Delete training session
+  ///
+  /// Only the creator can delete a training session
+  /// Only allowed if the session hasn't started yet
+  Future<void> deleteTrainingSession(String sessionId);
+
+  /// Check if training session exists
+  Future<bool> trainingSessionExists(String sessionId);
+
+  /// Get training session participants
+  Future<List<String>> getTrainingSessionParticipants(String sessionId);
+
+  /// Check if user can join training session
+  ///
+  /// Validates:
+  /// - User is a member of the group
+  /// - Session is not full
+  /// - Session is scheduled (not cancelled or completed)
+  /// - Session hasn't started yet
+  Future<bool> canUserJoinTrainingSession(String sessionId, String userId);
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -14,12 +14,14 @@ import 'package:play_with_me/features/auth/presentation/bloc/password_reset/pass
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/core/domain/repositories/group_repository.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/training_session_repository.dart';
 import 'package:play_with_me/core/domain/repositories/image_storage_repository.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
 import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_user_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_group_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_game_repository.dart';
+import 'package:play_with_me/core/data/repositories/firestore_training_session_repository.dart';
 import 'package:play_with_me/core/data/repositories/firebase_image_storage_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_invitation_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_friend_repository.dart';
@@ -39,6 +41,7 @@ import 'package:play_with_me/features/friends/presentation/bloc/friend_request_c
 import 'package:play_with_me/features/games/presentation/bloc/game_creation/game_creation_bloc.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_details/game_details_bloc.dart';
 import 'package:play_with_me/features/games/presentation/bloc/games_list/games_list_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -110,6 +113,14 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<GameRepository>()) {
     sl.registerLazySingleton<GameRepository>(
       () => FirestoreGameRepository(),
+    );
+  }
+
+  if (!sl.isRegistered<TrainingSessionRepository>()) {
+    sl.registerLazySingleton<TrainingSessionRepository>(
+      () => FirestoreTrainingSessionRepository(
+        groupRepository: sl(),
+      ),
     );
   }
 
@@ -270,6 +281,14 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<GamesListBloc>()) {
     sl.registerFactory<GamesListBloc>(
       () => GamesListBloc(gameRepository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<TrainingSessionCreationBloc>()) {
+    sl.registerFactory<TrainingSessionCreationBloc>(
+      () => TrainingSessionCreationBloc(
+        trainingSessionRepository: sl(),
+      ),
     );
   }
 }

--- a/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart
+++ b/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart
@@ -1,0 +1,280 @@
+// Validates CreateTrainingSessionBloc manages training session creation form state and submission logic.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/data/models/game_model.dart';
+import '../../../../../core/data/models/training_session_model.dart';
+import '../../../../../core/domain/repositories/training_session_repository.dart';
+import 'training_session_creation_event.dart';
+import 'training_session_creation_state.dart';
+
+class TrainingSessionCreationBloc
+    extends Bloc<TrainingSessionCreationEvent, TrainingSessionCreationState> {
+  final TrainingSessionRepository _trainingSessionRepository;
+
+  TrainingSessionCreationBloc({
+    required TrainingSessionRepository trainingSessionRepository,
+  })  : _trainingSessionRepository = trainingSessionRepository,
+        super(const TrainingSessionCreationInitial()) {
+    on<SelectTrainingGroup>(_onSelectTrainingGroup);
+    on<SetStartTime>(_onSetStartTime);
+    on<SetEndTime>(_onSetEndTime);
+    on<SetTrainingLocation>(_onSetTrainingLocation);
+    on<SetTrainingTitle>(_onSetTrainingTitle);
+    on<SetTrainingDescription>(_onSetTrainingDescription);
+    on<SetMaxParticipants>(_onSetMaxParticipants);
+    on<SetMinParticipants>(_onSetMinParticipants);
+    on<SetSessionNotes>(_onSetSessionNotes);
+    on<ValidateTrainingForm>(_onValidateTrainingForm);
+    on<SubmitTrainingSession>(_onSubmitTrainingSession);
+    on<ResetTrainingForm>(_onResetTrainingForm);
+  }
+
+  TrainingSessionCreationFormState get _currentFormState {
+    final currentState = state;
+    if (currentState is TrainingSessionCreationFormState) {
+      return currentState;
+    }
+    return const TrainingSessionCreationFormState();
+  }
+
+  void _onSelectTrainingGroup(
+      SelectTrainingGroup event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      groupId: event.groupId,
+      groupName: event.groupName,
+      groupError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetStartTime(
+      SetStartTime event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      startTime: event.startTime,
+      startTimeError: null,
+      // Also validate end time if it's already set
+      endTimeError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetEndTime(
+      SetEndTime event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      endTime: event.endTime,
+      endTimeError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetTrainingLocation(
+      SetTrainingLocation event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      locationName: event.locationName,
+      address: event.address,
+      locationError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetTrainingTitle(
+      SetTrainingTitle event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      title: event.title,
+      titleError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetTrainingDescription(SetTrainingDescription event,
+      Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      description: event.description,
+    );
+    emit(formState);
+  }
+
+  void _onSetMaxParticipants(
+      SetMaxParticipants event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      maxParticipants: event.maxParticipants,
+      participantsError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetMinParticipants(
+      SetMinParticipants event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      minParticipants: event.minParticipants,
+      participantsError: null,
+    );
+    emit(_validateAndEmit(formState));
+  }
+
+  void _onSetSessionNotes(
+      SetSessionNotes event, Emitter<TrainingSessionCreationState> emit) {
+    final formState = _currentFormState.copyWith(
+      notes: event.notes,
+    );
+    emit(formState);
+  }
+
+  void _onValidateTrainingForm(ValidateTrainingForm event,
+      Emitter<TrainingSessionCreationState> emit) {
+    emit(_validateAndEmit(_currentFormState));
+  }
+
+  Future<void> _onSubmitTrainingSession(SubmitTrainingSession event,
+      Emitter<TrainingSessionCreationState> emit) async {
+    final formState = _currentFormState;
+
+    // Validate form
+    final validatedState = _validateForm(formState);
+    if (!validatedState.isValid) {
+      emit(validatedState);
+      return;
+    }
+
+    try {
+      emit(const TrainingSessionCreationSubmitting());
+
+      // Create training session model
+      final session = TrainingSessionModel(
+        id: '', // Will be set by Firestore
+        groupId: formState.groupId!,
+        title: formState.title,
+        description: formState.description,
+        location: GameLocation(
+          name: formState.locationName!,
+          address: formState.address,
+        ),
+        startTime: formState.startTime!,
+        endTime: formState.endTime!,
+        minParticipants: formState.minParticipants,
+        maxParticipants: formState.maxParticipants,
+        createdBy: event.createdBy,
+        createdAt: DateTime.now(),
+        notes: formState.notes,
+      );
+
+      // Create training session in repository
+      final sessionId =
+          await _trainingSessionRepository.createTrainingSession(session);
+      final createdSession = session.copyWith(id: sessionId);
+
+      emit(TrainingSessionCreationSuccess(
+        sessionId: sessionId,
+        session: createdSession,
+      ));
+    } catch (e) {
+      // Check for specific error messages
+      String errorMessage = 'Failed to create training session';
+      String? errorCode;
+
+      if (e.toString().contains('Creator is not a member of the group')) {
+        errorMessage = 'You must be a member of the group to create a training session';
+        errorCode = 'NOT_A_MEMBER';
+      } else if (e.toString().contains('Group not found')) {
+        errorMessage = 'The selected group no longer exists';
+        errorCode = 'GROUP_NOT_FOUND';
+      } else {
+        errorMessage = 'Failed to create training session: ${e.toString()}';
+        errorCode = 'CREATE_SESSION_ERROR';
+      }
+
+      emit(TrainingSessionCreationError(
+        message: errorMessage,
+        errorCode: errorCode,
+      ));
+    }
+  }
+
+  void _onResetTrainingForm(
+      ResetTrainingForm event, Emitter<TrainingSessionCreationState> emit) {
+    emit(const TrainingSessionCreationFormState());
+  }
+
+  /// Validates the form and returns a new state with validation errors
+  TrainingSessionCreationFormState _validateForm(
+      TrainingSessionCreationFormState formState) {
+    String? groupError;
+    String? startTimeError;
+    String? endTimeError;
+    String? locationError;
+    String? titleError;
+    String? participantsError;
+
+    // Validate group selection
+    if (formState.groupId == null || formState.groupId!.isEmpty) {
+      groupError = 'Please select a group';
+    }
+
+    // Validate start time
+    if (formState.startTime == null) {
+      startTimeError = 'Please select a start time';
+    } else if (formState.startTime!.isBefore(DateTime.now())) {
+      startTimeError = 'Start time must be in the future';
+    }
+
+    // Validate end time
+    if (formState.endTime == null) {
+      endTimeError = 'Please select an end time';
+    } else if (formState.startTime != null &&
+        formState.endTime!.isBefore(formState.startTime!)) {
+      endTimeError = 'End time must be after start time';
+    } else if (formState.startTime != null &&
+        formState.endTime!.difference(formState.startTime!).inMinutes < 30) {
+      endTimeError = 'Training session must be at least 30 minutes long';
+    }
+
+    // Validate location
+    if (formState.locationName == null ||
+        formState.locationName!.trim().isEmpty) {
+      locationError = 'Please enter a location';
+    }
+
+    // Validate title
+    if (formState.title.trim().isEmpty) {
+      titleError = 'Please enter a session title';
+    } else if (formState.title.trim().length < 3) {
+      titleError = 'Title must be at least 3 characters';
+    } else if (formState.title.trim().length > 100) {
+      titleError = 'Title must be less than 100 characters';
+    }
+
+    // Validate participant limits
+    if (formState.minParticipants < 2) {
+      participantsError = 'Minimum participants must be at least 2';
+    } else if (formState.maxParticipants < formState.minParticipants) {
+      participantsError =
+          'Maximum participants must be greater than or equal to minimum participants';
+    } else if (formState.maxParticipants > 30) {
+      participantsError = 'Maximum participants cannot exceed 30';
+    }
+
+    final isValid = groupError == null &&
+        startTimeError == null &&
+        endTimeError == null &&
+        locationError == null &&
+        titleError == null &&
+        participantsError == null;
+
+    return formState.copyWith(
+      groupError: groupError,
+      startTimeError: startTimeError,
+      endTimeError: endTimeError,
+      locationError: locationError,
+      titleError: titleError,
+      participantsError: participantsError,
+      isValid: isValid,
+    );
+  }
+
+  /// Helper method to validate and emit state
+  TrainingSessionCreationFormState _validateAndEmit(
+      TrainingSessionCreationFormState formState) {
+    return _validateForm(formState);
+  }
+}

--- a/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_event.dart
+++ b/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_event.dart
@@ -1,0 +1,125 @@
+// Validates CreateTrainingSessionBloc events for managing training session creation form state.
+
+import '../../../../../core/presentation/bloc/base_bloc_event.dart';
+
+abstract class TrainingSessionCreationEvent extends BaseBlocEvent {
+  const TrainingSessionCreationEvent();
+}
+
+/// Event to select a group for the training session
+class SelectTrainingGroup extends TrainingSessionCreationEvent {
+  final String groupId;
+  final String groupName;
+
+  const SelectTrainingGroup({
+    required this.groupId,
+    required this.groupName,
+  });
+
+  @override
+  List<Object?> get props => [groupId, groupName];
+}
+
+/// Event to set the training session start time
+class SetStartTime extends TrainingSessionCreationEvent {
+  final DateTime startTime;
+
+  const SetStartTime({required this.startTime});
+
+  @override
+  List<Object?> get props => [startTime];
+}
+
+/// Event to set the training session end time
+class SetEndTime extends TrainingSessionCreationEvent {
+  final DateTime endTime;
+
+  const SetEndTime({required this.endTime});
+
+  @override
+  List<Object?> get props => [endTime];
+}
+
+/// Event to set the training session location
+class SetTrainingLocation extends TrainingSessionCreationEvent {
+  final String locationName;
+  final String? address;
+
+  const SetTrainingLocation({
+    required this.locationName,
+    this.address,
+  });
+
+  @override
+  List<Object?> get props => [locationName, address];
+}
+
+/// Event to set the training session title
+class SetTrainingTitle extends TrainingSessionCreationEvent {
+  final String title;
+
+  const SetTrainingTitle({required this.title});
+
+  @override
+  List<Object?> get props => [title];
+}
+
+/// Event to set the training session description
+class SetTrainingDescription extends TrainingSessionCreationEvent {
+  final String? description;
+
+  const SetTrainingDescription({this.description});
+
+  @override
+  List<Object?> get props => [description];
+}
+
+/// Event to set the maximum number of participants
+class SetMaxParticipants extends TrainingSessionCreationEvent {
+  final int maxParticipants;
+
+  const SetMaxParticipants({required this.maxParticipants});
+
+  @override
+  List<Object?> get props => [maxParticipants];
+}
+
+/// Event to set the minimum number of participants
+class SetMinParticipants extends TrainingSessionCreationEvent {
+  final int minParticipants;
+
+  const SetMinParticipants({required this.minParticipants});
+
+  @override
+  List<Object?> get props => [minParticipants];
+}
+
+/// Event to set session notes
+class SetSessionNotes extends TrainingSessionCreationEvent {
+  final String? notes;
+
+  const SetSessionNotes({this.notes});
+
+  @override
+  List<Object?> get props => [notes];
+}
+
+/// Event to validate the form
+class ValidateTrainingForm extends TrainingSessionCreationEvent {
+  const ValidateTrainingForm();
+}
+
+/// Event to submit the form and create the training session
+class SubmitTrainingSession extends TrainingSessionCreationEvent {
+  final String createdBy;
+
+  const SubmitTrainingSession({required this.createdBy});
+
+  @override
+  List<Object?> get props => [createdBy];
+}
+
+/// Event to reset the form
+class ResetTrainingForm extends TrainingSessionCreationEvent {
+  const ResetTrainingForm();
+}

--- a/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_state.dart
+++ b/lib/features/training/presentation/bloc/training_session_creation/training_session_creation_state.dart
@@ -1,0 +1,166 @@
+// Validates CreateTrainingSessionBloc states for tracking training session creation form state and validation.
+
+import '../../../../../core/data/models/training_session_model.dart';
+import '../../../../../core/presentation/bloc/base_bloc_state.dart';
+
+abstract class TrainingSessionCreationState extends BaseBlocState {
+  const TrainingSessionCreationState();
+}
+
+/// Initial state
+class TrainingSessionCreationInitial extends TrainingSessionCreationState
+    implements InitialState {
+  const TrainingSessionCreationInitial();
+}
+
+/// State when form is being filled
+class TrainingSessionCreationFormState extends TrainingSessionCreationState {
+  final String? groupId;
+  final String? groupName;
+  final DateTime? startTime;
+  final DateTime? endTime;
+  final String? locationName;
+  final String? address;
+  final String title;
+  final String? description;
+  final int maxParticipants;
+  final int minParticipants;
+  final String? notes;
+
+  // Validation errors
+  final String? groupError;
+  final String? startTimeError;
+  final String? endTimeError;
+  final String? locationError;
+  final String? titleError;
+  final String? participantsError;
+
+  // Form validity
+  final bool isValid;
+
+  const TrainingSessionCreationFormState({
+    this.groupId,
+    this.groupName,
+    this.startTime,
+    this.endTime,
+    this.locationName,
+    this.address,
+    this.title = '',
+    this.description,
+    this.maxParticipants = 12,
+    this.minParticipants = 4,
+    this.notes,
+    this.groupError,
+    this.startTimeError,
+    this.endTimeError,
+    this.locationError,
+    this.titleError,
+    this.participantsError,
+    this.isValid = false,
+  });
+
+  TrainingSessionCreationFormState copyWith({
+    String? groupId,
+    String? groupName,
+    DateTime? startTime,
+    DateTime? endTime,
+    String? locationName,
+    String? address,
+    String? title,
+    String? description,
+    int? maxParticipants,
+    int? minParticipants,
+    String? notes,
+    String? groupError,
+    String? startTimeError,
+    String? endTimeError,
+    String? locationError,
+    String? titleError,
+    String? participantsError,
+    bool? isValid,
+  }) {
+    return TrainingSessionCreationFormState(
+      groupId: groupId ?? this.groupId,
+      groupName: groupName ?? this.groupName,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      locationName: locationName ?? this.locationName,
+      address: address ?? this.address,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      maxParticipants: maxParticipants ?? this.maxParticipants,
+      minParticipants: minParticipants ?? this.minParticipants,
+      notes: notes ?? this.notes,
+      groupError: groupError,
+      startTimeError: startTimeError,
+      endTimeError: endTimeError,
+      locationError: locationError,
+      titleError: titleError,
+      participantsError: participantsError,
+      isValid: isValid ?? this.isValid,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        groupId,
+        groupName,
+        startTime,
+        endTime,
+        locationName,
+        address,
+        title,
+        description,
+        maxParticipants,
+        minParticipants,
+        notes,
+        groupError,
+        startTimeError,
+        endTimeError,
+        locationError,
+        titleError,
+        participantsError,
+        isValid,
+      ];
+}
+
+/// State when submitting the training session
+class TrainingSessionCreationSubmitting extends TrainingSessionCreationState
+    implements LoadingState {
+  const TrainingSessionCreationSubmitting();
+}
+
+/// State when training session creation succeeds
+class TrainingSessionCreationSuccess extends TrainingSessionCreationState
+    implements SuccessState {
+  final String sessionId;
+  final TrainingSessionModel session;
+
+  const TrainingSessionCreationSuccess({
+    required this.sessionId,
+    required this.session,
+  });
+
+  @override
+  List<Object?> get props => [sessionId, session];
+}
+
+/// State when training session creation fails
+class TrainingSessionCreationError extends TrainingSessionCreationState
+    implements ErrorState {
+  @override
+  final String message;
+  @override
+  final String? errorCode;
+  @override
+  final bool isRetryable;
+
+  const TrainingSessionCreationError({
+    required this.message,
+    this.errorCode,
+    this.isRetryable = true,
+  });
+
+  @override
+  List<Object?> get props => [message, errorCode, isRetryable];
+}

--- a/test/architecture/dependency_test.dart
+++ b/test/architecture/dependency_test.dart
@@ -118,5 +118,107 @@ void main() {
         );
       }
     });
+
+    test('Training module should not import FriendRepository (Story 15.1)', () {
+      final trainingDir = Directory('lib/features/training');
+
+      if (!trainingDir.existsSync()) {
+        // If directory doesn't exist yet, test passes
+        return;
+      }
+
+      final violations = <String>[];
+
+      // Recursively check all Dart files in training directory
+      trainingDir
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'))
+          .forEach((file) {
+        final content = file.readAsStringSync();
+
+        // Check for friendship-related imports
+        if (content.contains('FriendRepository') ||
+            content.contains('friend_repository') ||
+            content.contains('features/friends/')) {
+          violations.add(file.path);
+        }
+      });
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Training module should not import friendship-related code.\n'
+            'Violations found in:\n${violations.join('\n')}\n\n'
+            'ARCHITECTURE RULE: Training Sessions → Groups → My Community\n'
+            'Training sessions are in the Games layer and participants are resolved via group.memberIds only.\n'
+            'See Epic 15 specification and CLAUDE.md for details.',
+      );
+    });
+
+    test('Training repositories should not import FriendRepository (Story 15.1)', () {
+      final trainingRepoFiles = [
+        'lib/core/data/repositories/firestore_training_session_repository.dart',
+        'lib/core/domain/repositories/training_session_repository.dart',
+      ];
+
+      final violations = <String>[];
+
+      for (final filePath in trainingRepoFiles) {
+        final file = File(filePath);
+        if (!file.existsSync()) continue;
+
+        final content = file.readAsStringSync();
+
+        // Check for actual imports, not comments
+        // Look for import statements specifically
+        if (RegExp(r"import\s+.*friend", caseSensitive: false).hasMatch(content) ||
+            RegExp(r"import\s+.*features/friends").hasMatch(content)) {
+          violations.add(filePath);
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Training repositories should not depend on friendship layer.\n'
+            'Violations found in:\n${violations.join('\n')}\n\n'
+            'ARCHITECTURE RULE: Training Sessions access participants via Groups only\n'
+            'Participants must be validated using GroupRepository.getGroupMembers()',
+      );
+    });
+
+    test('Training BLoCs should not import FriendRepository (Story 15.1)', () {
+      final trainingBlocDir = Directory('lib/features/training/presentation/bloc');
+
+      if (!trainingBlocDir.existsSync()) {
+        // If directory doesn't exist yet, test passes
+        return;
+      }
+
+      final violations = <String>[];
+
+      trainingBlocDir
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'))
+          .forEach((file) {
+        final content = file.readAsStringSync();
+
+        if (content.contains('FriendRepository') ||
+            content.contains('friend_repository') ||
+            content.contains('features/friends/')) {
+          violations.add(file.path);
+        }
+      });
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Training BLoCs should not depend on friendship layer.\n'
+            'Violations found in:\n${violations.join('\n')}\n\n'
+            'ARCHITECTURE RULE: Training Sessions → Groups → My Community',
+      );
+    });
   });
 }

--- a/test/unit/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc_test.dart
+++ b/test/unit/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc_test.dart
@@ -1,0 +1,536 @@
+// Validates CreateTrainingSessionBloc correctly manages form state and creates training sessions
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
+import 'package:play_with_me/core/domain/repositories/training_session_repository.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_event.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_state.dart';
+
+class MockTrainingSessionRepository extends Mock
+    implements TrainingSessionRepository {}
+
+class FakeTrainingSessionModel extends Fake implements TrainingSessionModel {}
+
+void main() {
+  late TrainingSessionCreationBloc bloc;
+  late MockTrainingSessionRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeTrainingSessionModel());
+  });
+
+  setUp(() {
+    mockRepository = MockTrainingSessionRepository();
+    bloc = TrainingSessionCreationBloc(
+      trainingSessionRepository: mockRepository,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('TrainingSessionCreationBloc', () {
+    group('Initial State', () {
+      test('initial state is TrainingSessionCreationInitial', () {
+        expect(bloc.state, equals(const TrainingSessionCreationInitial()));
+      });
+    });
+
+    group('SelectTrainingGroup', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with group selected and no error',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SelectTrainingGroup(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.groupId, 'groupId', 'group-1')
+              .having((s) => s.groupName, 'groupName', 'Test Group')
+              .having((s) => s.groupError, 'groupError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetStartTime', () {
+      final futureTime = DateTime.now().add(const Duration(days: 1));
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with start time set and no error',
+        build: () => bloc,
+        act: (bloc) => bloc.add(SetStartTime(startTime: futureTime)),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.startTime, 'startTime', futureTime)
+              .having((s) => s.startTimeError, 'startTimeError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates that start time is in the future',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+          startTime: DateTime.now().subtract(const Duration(hours: 1)),
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.startTimeError, 'startTimeError',
+                  'Start time must be in the future')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetEndTime', () {
+      final startTime = DateTime.now().add(const Duration(days: 1));
+      final endTime = startTime.add(const Duration(hours: 2));
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with end time set and no error',
+        build: () => bloc,
+        act: (bloc) => bloc.add(SetEndTime(endTime: endTime)),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.endTime, 'endTime', endTime)
+              .having((s) => s.endTimeError, 'endTimeError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates that end time is after start time',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+          startTime: DateTime.now().add(const Duration(days: 1)),
+          endTime: DateTime.now(),
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.endTimeError, 'endTimeError',
+                  'End time must be after start time')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates minimum session duration of 30 minutes',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+          startTime: DateTime.now().add(const Duration(days: 1)),
+          endTime: DateTime.now().add(const Duration(days: 1, minutes: 15)),
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.endTimeError, 'endTimeError',
+                  'Training session must be at least 30 minutes long')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetTrainingLocation', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with location set',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetTrainingLocation(
+          locationName: 'Beach Court 1',
+          address: '123 Beach St',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.locationName, 'locationName', 'Beach Court 1')
+              .having((s) => s.address, 'address', '123 Beach St')
+              .having((s) => s.locationError, 'locationError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates location is not empty',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(
+          locationName: '',
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.locationError, 'locationError',
+                  'Please enter a location')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetTrainingTitle', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with title set',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetTrainingTitle(
+            title: 'Advanced Serving Practice')),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having(
+                  (s) => s.title, 'title', 'Advanced Serving Practice')
+              .having((s) => s.titleError, 'titleError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates title is not empty',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(title: ''),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.titleError, 'titleError',
+                  'Please enter a session title')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates title minimum length (3 characters)',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(title: 'AB'),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.titleError, 'titleError',
+                  'Title must be at least 3 characters')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates title maximum length (100 characters)',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+            title: 'A' * 101),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.titleError, 'titleError',
+                  'Title must be less than 100 characters')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetTrainingDescription', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with description set (no validation)',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetTrainingDescription(
+            description: 'Focus on serves and blocks')),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.description, 'description',
+                  'Focus on serves and blocks')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetMaxParticipants', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with maxParticipants set',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetMaxParticipants(maxParticipants: 10)),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.maxParticipants, 'maxParticipants', 10)
+              .having((s) => s.participantsError, 'participantsError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates maxParticipants cannot exceed 30',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(
+          maxParticipants: 35,
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.participantsError, 'participantsError',
+                  'Maximum participants cannot exceed 30')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetMinParticipants', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with minParticipants set',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetMinParticipants(minParticipants: 6)),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.minParticipants, 'minParticipants', 6)
+              .having((s) => s.participantsError, 'participantsError', null)
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates minParticipants is at least 2',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(
+          minParticipants: 1,
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.participantsError, 'participantsError',
+                  'Minimum participants must be at least 2')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'validates maxParticipants >= minParticipants',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(
+          minParticipants: 10,
+          maxParticipants: 8,
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.participantsError, 'participantsError',
+                  'Maximum participants must be greater than or equal to minimum participants')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SetSessionNotes', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits form state with notes set (no validation)',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const SetSessionNotes(
+            notes: 'Bring water and sunscreen')),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.notes, 'notes', 'Bring water and sunscreen')
+              .having((s) => s.isValid, 'isValid', false),
+        ],
+      );
+    });
+
+    group('SubmitTrainingSession', () {
+      final validStartTime = DateTime.now().add(const Duration(days: 1));
+      final validEndTime = validStartTime.add(const Duration(hours: 2));
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits validation errors when form is invalid',
+        build: () => bloc,
+        seed: () => const TrainingSessionCreationFormState(),
+        act: (bloc) => bloc.add(const SubmitTrainingSession(
+          createdBy: 'user-1',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.isValid, 'isValid', false)
+              .having((s) => s.groupError, 'groupError', isNotNull)
+              .having((s) => s.startTimeError, 'startTimeError', isNotNull)
+              .having((s) => s.endTimeError, 'endTimeError', isNotNull)
+              .having((s) => s.locationError, 'locationError', isNotNull)
+              .having((s) => s.titleError, 'titleError', isNotNull),
+        ],
+        verify: (_) {
+          verifyNever(() => mockRepository.createTrainingSession(any()));
+        },
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'successfully creates training session with valid form',
+        build: () => bloc,
+        setUp: () {
+          when(() => mockRepository.createTrainingSession(any()))
+              .thenAnswer((_) async => 'session-123');
+        },
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          startTime: validStartTime,
+          endTime: validEndTime,
+          locationName: 'Beach Court 1',
+          address: '123 Beach St',
+          title: 'Advanced Training',
+          description: 'Practice session',
+          maxParticipants: 12,
+          minParticipants: 4,
+          notes: 'Bring equipment',
+        ),
+        act: (bloc) => bloc.add(const SubmitTrainingSession(
+          createdBy: 'user-1',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationSubmitting>(),
+          isA<TrainingSessionCreationSuccess>()
+              .having((s) => s.sessionId, 'sessionId', 'session-123')
+              .having((s) => s.session.id, 'session.id', 'session-123')
+              .having((s) => s.session.groupId, 'session.groupId', 'group-1')
+              .having((s) => s.session.title, 'session.title',
+                  'Advanced Training')
+              .having((s) => s.session.createdBy, 'session.createdBy', 'user-1')
+              .having((s) => s.session.minParticipants,
+                  'session.minParticipants', 4)
+              .having((s) => s.session.maxParticipants,
+                  'session.maxParticipants', 12),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.createTrainingSession(any())).called(1);
+        },
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits error when repository throws not a member exception',
+        build: () => bloc,
+        setUp: () {
+          when(() => mockRepository.createTrainingSession(any())).thenThrow(
+              Exception('Creator is not a member of the group'));
+        },
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          startTime: validStartTime,
+          endTime: validEndTime,
+          locationName: 'Beach Court 1',
+          title: 'Advanced Training',
+        ),
+        act: (bloc) => bloc.add(const SubmitTrainingSession(
+          createdBy: 'user-1',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationSubmitting>(),
+          isA<TrainingSessionCreationError>()
+              .having((s) => s.message, 'message',
+                  'You must be a member of the group to create a training session')
+              .having((s) => s.errorCode, 'errorCode', 'NOT_A_MEMBER')
+              .having((s) => s.isRetryable, 'isRetryable', true),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits error when repository throws group not found exception',
+        build: () => bloc,
+        setUp: () {
+          when(() => mockRepository.createTrainingSession(any()))
+              .thenThrow(Exception('Group not found'));
+        },
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          startTime: validStartTime,
+          endTime: validEndTime,
+          locationName: 'Beach Court 1',
+          title: 'Advanced Training',
+        ),
+        act: (bloc) => bloc.add(const SubmitTrainingSession(
+          createdBy: 'user-1',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationSubmitting>(),
+          isA<TrainingSessionCreationError>()
+              .having((s) => s.message, 'message',
+                  'The selected group no longer exists')
+              .having((s) => s.errorCode, 'errorCode', 'GROUP_NOT_FOUND')
+              .having((s) => s.isRetryable, 'isRetryable', true),
+        ],
+      );
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits generic error for other exceptions',
+        build: () => bloc,
+        setUp: () {
+          when(() => mockRepository.createTrainingSession(any()))
+              .thenThrow(Exception('Network error'));
+        },
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          startTime: validStartTime,
+          endTime: validEndTime,
+          locationName: 'Beach Court 1',
+          title: 'Advanced Training',
+        ),
+        act: (bloc) => bloc.add(const SubmitTrainingSession(
+          createdBy: 'user-1',
+        )),
+        expect: () => [
+          isA<TrainingSessionCreationSubmitting>(),
+          isA<TrainingSessionCreationError>()
+              .having((s) => s.message, 'message',
+                  contains('Failed to create training session'))
+              .having((s) => s.errorCode, 'errorCode', 'CREATE_SESSION_ERROR')
+              .having((s) => s.isRetryable, 'isRetryable', true),
+        ],
+      );
+    });
+
+    group('ResetTrainingForm', () {
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'resets form to initial state',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          title: 'Test Title',
+          startTime: DateTime.now().add(const Duration(days: 1)),
+        ),
+        act: (bloc) => bloc.add(const ResetTrainingForm()),
+        expect: () => [
+          const TrainingSessionCreationFormState(),
+        ],
+      );
+    });
+
+    group('Form Validation', () {
+      final validStartTime = DateTime.now().add(const Duration(days: 1));
+      final validEndTime = validStartTime.add(const Duration(hours: 2));
+
+      blocTest<TrainingSessionCreationBloc, TrainingSessionCreationState>(
+        'emits valid state when all fields are correct',
+        build: () => bloc,
+        seed: () => TrainingSessionCreationFormState(
+          groupId: 'group-1',
+          groupName: 'Test Group',
+          startTime: validStartTime,
+          endTime: validEndTime,
+          locationName: 'Beach Court 1',
+          address: '123 Beach St',
+          title: 'Advanced Training',
+          description: 'Practice session',
+          maxParticipants: 12,
+          minParticipants: 4,
+        ),
+        act: (bloc) => bloc.add(const ValidateTrainingForm()),
+        expect: () => [
+          isA<TrainingSessionCreationFormState>()
+              .having((s) => s.isValid, 'isValid', true)
+              .having((s) => s.groupError, 'groupError', null)
+              .having((s) => s.startTimeError, 'startTimeError', null)
+              .having((s) => s.endTimeError, 'endTimeError', null)
+              .having((s) => s.locationError, 'locationError', null)
+              .having((s) => s.titleError, 'titleError', null)
+              .having((s) => s.participantsError, 'participantsError', null),
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Story 15.1** from **Epic 15: Training Sessions (Games-Layer Event Type)**.

This PR adds the ability for group members to create training sessions within their groups. Training sessions are practice events that do not affect ELO ratings.

## Implementation

### Architecture (Games Layer)
- ✅ Training Sessions → Groups → My Community (strict dependency)
- ✅ NO imports of FriendRepository or My Community code
- ✅ Participants resolved via `group.memberIds` only
- ✅ Architecture tests enforce layered dependencies

### Domain Model
- `TrainingSessionModel` with freezed (immutable)
- Business logic methods (`canUserJoin`, `isFull`, `addParticipant`, etc.)
- Complete validation (timing, participants, location)

### Repository Layer
- `TrainingSessionRepository` interface
- `FirestoreTrainingSessionRepository` implementation
- Uses Cloud Function for creation (server-side validation)
- Registered in dependency injection

### Cloud Function (Security-First)
- `createTrainingSession` callable function
- Server-side validation using Admin SDK
- Validates: authentication, group membership, input data, timing
- Returns user-friendly error messages
- **Deployed to dev/stg/prod** ✅

### Firestore Security Rules
- Creation via Cloud Function ONLY (`allow create: if false`)
- Read/update restricted to group members
- Delete restricted to creator only
- **Deployed to dev/stg/prod** ✅

### BLoC Layer
- `TrainingSessionCreationBloc` with complete form validation
- Events: `SelectGroup`, `SetTimes`, `SetLocation`, `SetTitle`, `Submit`, `Reset`
- States: `Initial`, `FormState`, `Submitting`, `Success`, `Error`
- Comprehensive validation (30min minimum, future dates, etc.)

## Testing

- ✅ **27 comprehensive BLoC unit tests** (100% pass rate)
- ✅ **3 architecture tests** (enforce no friendship imports)
- ✅ **All existing tests passing** (1143 total tests)
- ⏸️ Integration tests deferred to UI story

## Deployment

| Environment | Cloud Function | Firestore Rules | Status |
|------------|---------------|-----------------|--------|
| Dev | ✅ Deployed | ✅ Deployed | Live |
| Staging | ✅ Deployed | ✅ Deployed | Live |
| Production | ✅ Deployed | ✅ Deployed | Live |

## Files Changed

### Source Code (15 files, +3417 lines)
- `lib/core/data/models/training_session_model.dart` - Domain model
- `lib/core/domain/repositories/training_session_repository.dart` - Repository interface
- `lib/core/data/repositories/firestore_training_session_repository.dart` - Repository implementation
- `lib/features/training/presentation/bloc/training_session_creation/` - BLoC layer
- `functions/src/createTrainingSession.ts` - Cloud Function
- `functions/src/index.ts` - Export function
- `lib/core/services/service_locator.dart` - DI registration

### Configuration
- `firestore.rules` - Security rules (creation via function only)

### Tests
- `test/unit/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc_test.dart` - 27 tests
- `test/architecture/dependency_test.dart` - 3 architecture tests

### Documentation
- `docs/epic-15/story-15.1/README.md` - Comprehensive documentation

## Acceptance Criteria

✅ **All Acceptance Criteria Met:**

- [x] Training session can only be created within an existing Group
- [x] Creator must be a member of the Group (validated server-side)
- [x] Required fields validated: Title, Location, Start Time, End Time, Min/Max Participants
- [x] No access to friendship or social graph data
- [x] Group membership validation via `GroupRepository` only (through Cloud Function)
- [x] Stored under Games layer Firestore namespace (`trainingSessions` collection)
- [x] Architecture tests ensure no social graph imports
- [x] Security rules prevent unauthorized access
- [x] Code passes `flutter analyze` with 0 warnings
- [x] Unit tests with 90%+ coverage (27 comprehensive tests)
- [x] Documentation updated

## Security

- ✅ No Firebase configs committed
- ✅ No API keys or secrets committed
- ✅ Cloud Function enforces server-side validation
- ✅ Minimal Firestore rules (creation via function only)
- ✅ `PRE_COMMIT_SECURITY_CHECKLIST.md` verified

## Breaking Changes

None. This is a new feature with no impact on existing functionality.

## Related Issues

Closes #346

## Next Steps

This story provides the foundation for:
- **Story 15.2**: Recurring Training Sessions
- **Story 15.3**: Join/Leave Training Session
- **Story 15.4**: Training Sessions in Group Activity Feed
- **Story 15.5**: No ELO or Competitive Impact
- **Story 15.6**: Track Training Participation
- **Story 15.7**: Add Exercises to Training Session
- **Story 15.8**: Anonymous Feedback After Training