### PR TITLE
Story 15.4: Training Sessions in Group Activity Feed

### DIFF
--- a/docs/epic-15/story-15.4/README.md
+++ b/docs/epic-15/story-15.4/README.md
@@ -1,0 +1,111 @@
+# Story 15.4: Training Sessions in Group Activity Feed
+
+## Overview
+
+Extends the Group Activity Feed to display both games and training sessions in a unified view, with distinct visual treatment for training sessions.
+
+## Implementation Summary
+
+### 1. Core Models
+
+**GroupActivityItem** (`lib/core/data/models/group_activity_item.dart`)
+- Union type using Freezed
+- Variants: `GameActivityItem` and `TrainingActivityItem`
+- Common interface for accessing `id`, `startTime`, `title`, `groupId`
+- Helper properties: `isPast`, `isUpcoming`
+
+### 2. BLoC Layer
+
+**GamesListBloc** (`lib/features/games/presentation/bloc/games_list/`)
+- Now combines streams from `GameRepository` and `TrainingSessionRepository`
+- Uses `RxDart.combineLatest2` to merge game and training session streams
+- Sorts all activities by start time
+- Separates into upcoming and past activities
+
+**GamesListState**
+- Updated to hold `List<GroupActivityItem>` instead of separate game lists
+- Maintains backward compatibility with helper getters (`upcomingGames`, `pastGames`)
+
+### 3. UI Layer
+
+**TrainingSessionListItem** (`lib/features/games/presentation/widgets/training_session_list_item.dart`)
+- Distinct visual treatment with fitness icon
+- Shows participant count (not player count)
+- No scores displayed (training sessions don't affect ELO)
+- Different badge styles: "TRAINING", "JOINED", "CANCELLED"
+- Shows session duration
+
+**GamesListPage** (`lib/features/games/presentation/pages/games_list_page.dart`)
+- Renders both activity types using pattern matching
+- Section headers changed to "Upcoming Activities" / "Past Activities"
+- Handles navigation to both game details and training session details
+
+### 4. Dependency Injection
+
+**ServiceLocator** (`lib/core/services/service_locator.dart`)
+- `GamesListBloc` now requires both `GameRepository` and `TrainingSessionRepository`
+
+## Key Features
+
+1. **Combined Feed**: Shows games and training sessions together
+2. **Time-based Sorting**: All activities sorted by start time across both types
+3. **Visual Distinction**: Training sessions have unique icon, colors, and badges
+4. **No ELO Display**: Training sessions don't show scores or results
+5. **Real-time Updates**: Streams from both repositories combined reactively
+
+## Architecture Compliance
+
+- ✅ No violation of layered architecture
+- ✅ Games layer can import TrainingSessionRepository (both in same layer)
+- ✅ No direct access to My Community layer
+- ✅ Follows BLoC with Repository pattern
+
+## Testing
+
+**Unit Tests** (`test/unit/features/games/presentation/bloc/games_list/games_list_bloc_test.dart`)
+- All existing game-only tests pass
+- New tests for combined activities:
+  - Emits combined activities from both sources
+  - Sorts activities by start time
+  - Separates past/upcoming correctly
+  - Filters by groupId for both types
+
+**Mock Repositories**
+- `MockTrainingSessionRepository` created for testing
+- Mirrors pattern of `MockGameRepository`
+
+## User Impact
+
+Users now see a unified activity feed showing:
+- Upcoming games (with scores/RSVP)
+- Upcoming training sessions (with participation)
+- Past games (with results)
+- Past training sessions (completed/cancelled)
+
+All sorted chronologically for better visibility and planning.
+
+## Files Changed
+
+- `lib/core/data/models/group_activity_item.dart` (new)
+- `lib/core/data/models/group_activity_item.freezed.dart` (generated)
+- `lib/features/games/presentation/bloc/games_list/games_list_bloc.dart`
+- `lib/features/games/presentation/bloc/games_list/games_list_state.dart`
+- `lib/features/games/presentation/bloc/games_list/games_list_event.dart`
+- `lib/features/games/presentation/pages/games_list_page.dart`
+- `lib/features/games/presentation/widgets/training_session_list_item.dart` (new)
+- `lib/core/services/service_locator.dart`
+- `test/unit/core/data/repositories/mock_training_session_repository.dart` (new)
+- `test/unit/features/games/presentation/bloc/games_list/games_list_bloc_test.dart`
+
+## Dependencies
+
+- `rxdart: ^0.28.0` (already in project for stream combination)
+
+## Future Enhancements
+
+- Add filtering to show games-only or training-only view
+- Add search functionality across both types
+- Show calendar view of combined activities
+- Add quick actions (join, leave) directly from feed
+
+Authored by Babas10 <etienne.dubois91@gmail.com>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -161,6 +161,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "trainingSessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groupId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/scripts/testConfig.json
+++ b/functions/scripts/testConfig.json
@@ -1,127 +1,101 @@
 {
-  "timestamp": "2025-12-29T22:15:19.738Z",
+  "timestamp": "2026-01-07T21:17:07.058Z",
   "users": [
     {
       "index": 0,
-      "uid": "yj7IiUWu1yMJrTReRa46uVLZ9hz1",
+      "uid": "fRdPfMDzGXb9Kyc3OE9Un9LhmaH3",
       "email": "test1@mysta.com",
       "displayName": "Test1",
       "firstName": "Test",
       "lastName": "One",
-      "password": "test1010",
-      "eloRating": 1600
+      "password": "test1010"
     },
     {
       "index": 1,
-      "uid": "tbz2LsELgreG1R5b4uMbZr2XydF3",
+      "uid": "nxTlV1lKH4eQXxiMXbDL6aJh9gb2",
       "email": "test2@mysta.com",
       "displayName": "Test2",
       "firstName": "Test",
       "lastName": "Two",
-      "password": "test1010",
-      "eloRating": 1800
+      "password": "test1010"
     },
     {
       "index": 2,
-      "uid": "OpwamTLIGxb31Gt0FWUpuc9HQ5y2",
+      "uid": "BJJbUgGDMfY0EkZjksBrH2Sp3bD2",
       "email": "test3@mysta.com",
       "displayName": "Test3",
       "firstName": "Test",
       "lastName": "Three",
-      "password": "test1010",
-      "eloRating": 1700
+      "password": "test1010"
     },
     {
       "index": 3,
-      "uid": "VAok4KUt3lSdObP2MsPnDzDIpMk2",
+      "uid": "NZwWTWZiqtRGvSslvnmK7u9bh922",
       "email": "test4@mysta.com",
       "displayName": "Test4",
       "firstName": "Test",
       "lastName": "Four",
-      "password": "test1010",
-      "eloRating": 1500
+      "password": "test1010"
     },
     {
       "index": 4,
-      "uid": "8m1pG1A8LidvjMegBLPpacjCi453",
+      "uid": "lo2DetKa1cXtc29u8wzWxEEe96b2",
       "email": "test5@mysta.com",
       "displayName": "Test5",
       "firstName": "Test",
       "lastName": "Five",
-      "password": "test1010",
-      "eloRating": 1900
+      "password": "test1010"
     },
     {
       "index": 5,
-      "uid": "g9FWizMyYiOt2GNDzjcQvdWN4iE2",
+      "uid": "u7Lw1LvGD0hn2TE6ehmFtFvyvSD3",
       "email": "test6@mysta.com",
       "displayName": "Test6",
       "firstName": "Test",
       "lastName": "Six",
-      "password": "test1010",
-      "eloRating": 1400
+      "password": "test1010"
     },
     {
       "index": 6,
-      "uid": "eV1FSN9hC7Q4f755a7eHQDTyyvg1",
+      "uid": "WwmWbyqNJ7ZgiPNYYqWSKPoTYkv1",
       "email": "test7@mysta.com",
       "displayName": "Test7",
       "firstName": "Test",
       "lastName": "Seven",
-      "password": "test1010",
-      "eloRating": 1600
+      "password": "test1010"
     },
     {
       "index": 7,
-      "uid": "ELqPGMwwT1OBVHIsGAPqipQkz1o1",
+      "uid": "Pf4oXQeH72g8ydofnyIxyGkf5Lg1",
       "email": "test8@mysta.com",
       "displayName": "Test8",
       "firstName": "Test",
       "lastName": "Eight",
-      "password": "test1010",
-      "eloRating": 1300
+      "password": "test1010"
+    },
+    {
+      "index": 8,
+      "uid": "xkqR6TydIUXzCVicdtDFCH7LPy72",
+      "email": "test9@mysta.com",
+      "displayName": "Test9",
+      "firstName": "Test",
+      "lastName": "Nine",
+      "password": "test1010"
+    },
+    {
+      "index": 9,
+      "uid": "S9OEhfmXETe6qFzI1iw0oB99Y5C3",
+      "email": "test10@mysta.com",
+      "displayName": "Test10",
+      "firstName": "Test",
+      "lastName": "Ten",
+      "password": "test1010"
     }
   ],
-  "groupId": "Asx7FLYGuP5Cj71bSEOe",
-  "gameIds": [
-    "7Ukp0lC1k4gxMBBOdxnU",
-    "PQDVhbWSNeCilzTdSdDD",
-    "e3YWmbmvfwLCtz38nb3W",
-    "HBanHLGKj2fiydf3fO4R",
-    "UKvXpZC4Ncd0vwRqaXN1",
-    "0jVnPSyMt5ilI488iaUV",
-    "ONMnkDKLF803E7oM0MlJ",
-    "Z974gWvGq2RamH3qYf9C",
-    "4QEP6wbcXMD22frhQLWp",
-    "IS14GTY69Kf4YLcLjUQg",
-    "QOHAFIL84F6nG3bj0OKn",
-    "lVX5yfDJPBF6Ty4c1c6b",
-    "P7Bp1dGEffKu0ztlfxEu"
-  ],
+  "groupId": "98R8Gss7N1uFFMBOClDy",
+  "gameIds": [],
   "notes": {
     "password": "test1010",
-    "friendships": "All users are friends with each other",
-    "group": "All users are members of the test group",
-    "games": "13 games created for role-based performance test",
-    "scenario": "test1 plays in all three roles (weak-link, carry, balanced)",
-    "expectedResult": {
-      "weakLink": {
-        "games": 4,
-        "wins": 2,
-        "winRate": "50.0%"
-      },
-      "carry": {
-        "games": 6,
-        "wins": 5,
-        "winRate": "83.3%"
-      },
-      "balanced": {
-        "games": 3,
-        "wins": 2,
-        "winRate": "66.7%"
-      },
-      "totalGames": 13,
-      "insight": "💪 Strong carry performance! You elevate your teammates."
-    }
+    "description": "ELO Chart Test Environment"
   }
 }

--- a/lib/core/data/models/group_activity_item.dart
+++ b/lib/core/data/models/group_activity_item.dart
@@ -1,0 +1,47 @@
+// Represents an item in the group activity feed (either a game or training session)
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'game_model.dart';
+import 'training_session_model.dart';
+
+part 'group_activity_item.freezed.dart';
+
+/// Union type representing an activity in a group (game or training session)
+/// Used to combine and display both types in a unified activity feed
+@freezed
+class GroupActivityItem with _$GroupActivityItem {
+  const factory GroupActivityItem.game(GameModel game) = GameActivityItem;
+  const factory GroupActivityItem.training(TrainingSessionModel session) =
+      TrainingActivityItem;
+
+  const GroupActivityItem._();
+
+  /// Get the activity ID (either game.id or session.id)
+  String get id => when(
+        game: (game) => game.id,
+        training: (session) => session.id,
+      );
+
+  /// Get the activity start time for sorting
+  DateTime get startTime => when(
+        game: (game) => game.scheduledAt,
+        training: (session) => session.startTime,
+      );
+
+  /// Get the activity title
+  String get title => when(
+        game: (game) => game.title,
+        training: (session) => session.title,
+      );
+
+  /// Get the group ID
+  String get groupId => when(
+        game: (game) => game.groupId,
+        training: (session) => session.groupId,
+      );
+
+  /// Check if activity is in the past
+  bool get isPast => startTime.isBefore(DateTime.now());
+
+  /// Check if activity is upcoming
+  bool get isUpcoming => !isPast;
+}

--- a/lib/core/data/models/group_activity_item.freezed.dart
+++ b/lib/core/data/models/group_activity_item.freezed.dart
@@ -1,0 +1,392 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'group_activity_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$GroupActivityItem {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(GameModel game) game,
+    required TResult Function(TrainingSessionModel session) training,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(GameModel game)? game,
+    TResult? Function(TrainingSessionModel session)? training,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(GameModel game)? game,
+    TResult Function(TrainingSessionModel session)? training,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameActivityItem value) game,
+    required TResult Function(TrainingActivityItem value) training,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameActivityItem value)? game,
+    TResult? Function(TrainingActivityItem value)? training,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameActivityItem value)? game,
+    TResult Function(TrainingActivityItem value)? training,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GroupActivityItemCopyWith<$Res> {
+  factory $GroupActivityItemCopyWith(
+    GroupActivityItem value,
+    $Res Function(GroupActivityItem) then,
+  ) = _$GroupActivityItemCopyWithImpl<$Res, GroupActivityItem>;
+}
+
+/// @nodoc
+class _$GroupActivityItemCopyWithImpl<$Res, $Val extends GroupActivityItem>
+    implements $GroupActivityItemCopyWith<$Res> {
+  _$GroupActivityItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$GameActivityItemImplCopyWith<$Res> {
+  factory _$$GameActivityItemImplCopyWith(
+    _$GameActivityItemImpl value,
+    $Res Function(_$GameActivityItemImpl) then,
+  ) = __$$GameActivityItemImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({GameModel game});
+
+  $GameModelCopyWith<$Res> get game;
+}
+
+/// @nodoc
+class __$$GameActivityItemImplCopyWithImpl<$Res>
+    extends _$GroupActivityItemCopyWithImpl<$Res, _$GameActivityItemImpl>
+    implements _$$GameActivityItemImplCopyWith<$Res> {
+  __$$GameActivityItemImplCopyWithImpl(
+    _$GameActivityItemImpl _value,
+    $Res Function(_$GameActivityItemImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? game = null}) {
+    return _then(
+      _$GameActivityItemImpl(
+        null == game
+            ? _value.game
+            : game // ignore: cast_nullable_to_non_nullable
+                  as GameModel,
+      ),
+    );
+  }
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $GameModelCopyWith<$Res> get game {
+    return $GameModelCopyWith<$Res>(_value.game, (value) {
+      return _then(_value.copyWith(game: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$GameActivityItemImpl extends GameActivityItem {
+  const _$GameActivityItemImpl(this.game) : super._();
+
+  @override
+  final GameModel game;
+
+  @override
+  String toString() {
+    return 'GroupActivityItem.game(game: $game)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameActivityItemImpl &&
+            (identical(other.game, game) || other.game == game));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, game);
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameActivityItemImplCopyWith<_$GameActivityItemImpl> get copyWith =>
+      __$$GameActivityItemImplCopyWithImpl<_$GameActivityItemImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(GameModel game) game,
+    required TResult Function(TrainingSessionModel session) training,
+  }) {
+    return game(this.game);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(GameModel game)? game,
+    TResult? Function(TrainingSessionModel session)? training,
+  }) {
+    return game?.call(this.game);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(GameModel game)? game,
+    TResult Function(TrainingSessionModel session)? training,
+    required TResult orElse(),
+  }) {
+    if (game != null) {
+      return game(this.game);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameActivityItem value) game,
+    required TResult Function(TrainingActivityItem value) training,
+  }) {
+    return game(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameActivityItem value)? game,
+    TResult? Function(TrainingActivityItem value)? training,
+  }) {
+    return game?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameActivityItem value)? game,
+    TResult Function(TrainingActivityItem value)? training,
+    required TResult orElse(),
+  }) {
+    if (game != null) {
+      return game(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class GameActivityItem extends GroupActivityItem {
+  const factory GameActivityItem(final GameModel game) = _$GameActivityItemImpl;
+  const GameActivityItem._() : super._();
+
+  GameModel get game;
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameActivityItemImplCopyWith<_$GameActivityItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$TrainingActivityItemImplCopyWith<$Res> {
+  factory _$$TrainingActivityItemImplCopyWith(
+    _$TrainingActivityItemImpl value,
+    $Res Function(_$TrainingActivityItemImpl) then,
+  ) = __$$TrainingActivityItemImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({TrainingSessionModel session});
+
+  $TrainingSessionModelCopyWith<$Res> get session;
+}
+
+/// @nodoc
+class __$$TrainingActivityItemImplCopyWithImpl<$Res>
+    extends _$GroupActivityItemCopyWithImpl<$Res, _$TrainingActivityItemImpl>
+    implements _$$TrainingActivityItemImplCopyWith<$Res> {
+  __$$TrainingActivityItemImplCopyWithImpl(
+    _$TrainingActivityItemImpl _value,
+    $Res Function(_$TrainingActivityItemImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? session = null}) {
+    return _then(
+      _$TrainingActivityItemImpl(
+        null == session
+            ? _value.session
+            : session // ignore: cast_nullable_to_non_nullable
+                  as TrainingSessionModel,
+      ),
+    );
+  }
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $TrainingSessionModelCopyWith<$Res> get session {
+    return $TrainingSessionModelCopyWith<$Res>(_value.session, (value) {
+      return _then(_value.copyWith(session: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$TrainingActivityItemImpl extends TrainingActivityItem {
+  const _$TrainingActivityItemImpl(this.session) : super._();
+
+  @override
+  final TrainingSessionModel session;
+
+  @override
+  String toString() {
+    return 'GroupActivityItem.training(session: $session)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TrainingActivityItemImpl &&
+            (identical(other.session, session) || other.session == session));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, session);
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TrainingActivityItemImplCopyWith<_$TrainingActivityItemImpl>
+  get copyWith =>
+      __$$TrainingActivityItemImplCopyWithImpl<_$TrainingActivityItemImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(GameModel game) game,
+    required TResult Function(TrainingSessionModel session) training,
+  }) {
+    return training(session);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(GameModel game)? game,
+    TResult? Function(TrainingSessionModel session)? training,
+  }) {
+    return training?.call(session);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(GameModel game)? game,
+    TResult Function(TrainingSessionModel session)? training,
+    required TResult orElse(),
+  }) {
+    if (training != null) {
+      return training(session);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GameActivityItem value) game,
+    required TResult Function(TrainingActivityItem value) training,
+  }) {
+    return training(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GameActivityItem value)? game,
+    TResult? Function(TrainingActivityItem value)? training,
+  }) {
+    return training?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GameActivityItem value)? game,
+    TResult Function(TrainingActivityItem value)? training,
+    required TResult orElse(),
+  }) {
+    if (training != null) {
+      return training(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class TrainingActivityItem extends GroupActivityItem {
+  const factory TrainingActivityItem(final TrainingSessionModel session) =
+      _$TrainingActivityItemImpl;
+  const TrainingActivityItem._() : super._();
+
+  TrainingSessionModel get session;
+
+  /// Create a copy of GroupActivityItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TrainingActivityItemImplCopyWith<_$TrainingActivityItemImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -280,7 +280,10 @@ Future<void> initializeDependencies() async {
 
   if (!sl.isRegistered<GamesListBloc>()) {
     sl.registerFactory<GamesListBloc>(
-      () => GamesListBloc(gameRepository: sl()),
+      () => GamesListBloc(
+        gameRepository: sl(),
+        trainingSessionRepository: sl(),
+      ),
     );
   }
 

--- a/lib/features/games/presentation/bloc/games_list/games_list_bloc.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_bloc.dart
@@ -1,21 +1,28 @@
-// Manages games list state with real-time Firestore updates for a group.
+// Manages group activity feed state with real-time Firestore updates (games + training sessions).
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/training_session_repository.dart';
+import 'package:play_with_me/core/data/models/group_activity_item.dart';
+import 'package:rxdart/rxdart.dart';
 import 'games_list_event.dart';
 import 'games_list_state.dart';
 
 class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
   final GameRepository _gameRepository;
-  StreamSubscription<dynamic>? _gamesSubscription;
+  final TrainingSessionRepository _trainingSessionRepository;
+  StreamSubscription<dynamic>? _activitiesSubscription;
   String? _currentGroupId;
   String? _currentUserId;
 
-  GamesListBloc({required GameRepository gameRepository})
-      : _gameRepository = gameRepository,
+  GamesListBloc({
+    required GameRepository gameRepository,
+    required TrainingSessionRepository trainingSessionRepository,
+  })  : _gameRepository = gameRepository,
+        _trainingSessionRepository = trainingSessionRepository,
         super(const GamesListInitial()) {
     on<LoadGamesForGroup>(_onLoadGamesForGroup);
-    on<GamesListUpdated>(_onGamesListUpdated);
+    on<ActivityListUpdated>(_onActivityListUpdated);
     on<RefreshGamesList>(_onRefreshGamesList);
   }
 
@@ -29,45 +36,64 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
       _currentGroupId = event.groupId;
       _currentUserId = event.userId;
 
-      await _gamesSubscription?.cancel();
-      _gamesSubscription = _gameRepository.getGamesForGroup(event.groupId).listen(
-        (games) {
-          add(GamesListUpdated(games: games));
+      await _activitiesSubscription?.cancel();
+
+      // Combine games and training sessions streams
+      final gamesStream = _gameRepository.getGamesForGroup(event.groupId);
+      final trainingsStream = _trainingSessionRepository
+          .getTrainingSessionsForGroup(event.groupId);
+
+      _activitiesSubscription =
+          Rx.combineLatest2(gamesStream, trainingsStream, (games, trainings) {
+        // Convert to GroupActivityItem
+        final gameActivities =
+            games.map((game) => GroupActivityItem.game(game)).toList();
+        final trainingActivities = trainings
+            .map((session) => GroupActivityItem.training(session))
+            .toList();
+
+        return [...gameActivities, ...trainingActivities];
+      }).listen(
+        (activities) {
+          add(ActivityListUpdated(activities: activities));
         },
         onError: (error) {
           print('❌ GamesListBloc: Stream error: $error');
-          add(const GamesListUpdated(games: []));
+          add(const ActivityListUpdated(activities: []));
         },
       );
     } catch (e) {
-      emit(GamesListError(message: 'Failed to load games: ${e.toString()}'));
+      emit(GamesListError(
+          message: 'Failed to load activities: ${e.toString()}'));
     }
   }
 
-  Future<void> _onGamesListUpdated(
-    GamesListUpdated event,
+  Future<void> _onActivityListUpdated(
+    ActivityListUpdated event,
     Emitter<GamesListState> emit,
   ) async {
     final now = DateTime.now();
-    final upcomingGames = event.games
-        .where((game) => game.scheduledAt.isAfter(now))
-        .toList()
-      ..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
 
-    final pastGames = event.games
-        .where((game) => !game.scheduledAt.isAfter(now))
+    // Separate into upcoming and past activities
+    final upcomingActivities = event.activities
+        .where((activity) => activity.startTime.isAfter(now))
         .toList()
-      ..sort((a, b) => b.scheduledAt.compareTo(a.scheduledAt));
+      ..sort((a, b) => a.startTime.compareTo(b.startTime));
+
+    final pastActivities = event.activities
+        .where((activity) => !activity.startTime.isAfter(now))
+        .toList()
+      ..sort((a, b) => b.startTime.compareTo(a.startTime));
 
     // Emit empty state only if both lists are empty after filtering
-    if (upcomingGames.isEmpty && pastGames.isEmpty) {
+    if (upcomingActivities.isEmpty && pastActivities.isEmpty) {
       emit(GamesListEmpty(userId: _currentUserId ?? ''));
       return;
     }
 
     emit(GamesListLoaded(
-      upcomingGames: upcomingGames,
-      pastGames: pastGames,
+      upcomingActivities: upcomingActivities,
+      pastActivities: pastActivities,
       userId: _currentUserId ?? '',
     ));
   }
@@ -86,7 +112,7 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
 
   @override
   Future<void> close() {
-    _gamesSubscription?.cancel();
+    _activitiesSubscription?.cancel();
     return super.close();
   }
 }

--- a/lib/features/games/presentation/bloc/games_list/games_list_event.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_event.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/group_activity_item.dart';
 
 abstract class GamesListEvent extends Equatable {
   const GamesListEvent();
@@ -28,6 +29,15 @@ class GamesListUpdated extends GamesListEvent {
 
   @override
   List<Object?> get props => [games];
+}
+
+class ActivityListUpdated extends GamesListEvent {
+  final List<GroupActivityItem> activities;
+
+  const ActivityListUpdated({required this.activities});
+
+  @override
+  List<Object?> get props => [activities];
 }
 
 class RefreshGamesList extends GamesListEvent {

--- a/lib/features/games/presentation/bloc/games_list/games_list_state.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/group_activity_item.dart';
 
 abstract class GamesListState extends Equatable {
   const GamesListState();
@@ -17,18 +18,27 @@ class GamesListLoading extends GamesListState {
 }
 
 class GamesListLoaded extends GamesListState {
-  final List<GameModel> upcomingGames;
-  final List<GameModel> pastGames;
+  final List<GroupActivityItem> upcomingActivities;
+  final List<GroupActivityItem> pastActivities;
   final String userId;
 
   const GamesListLoaded({
-    required this.upcomingGames,
-    required this.pastGames,
+    required this.upcomingActivities,
+    required this.pastActivities,
     required this.userId,
   });
 
   @override
-  List<Object?> get props => [upcomingGames, pastGames, userId];
+  List<Object?> get props => [upcomingActivities, pastActivities, userId];
+
+  // Helper getters for backward compatibility and filtering
+  List<GameModel> get upcomingGames => upcomingActivities
+      .whereType<GameActivityItem>()
+      .map((item) => item.game)
+      .toList();
+
+  List<GameModel> get pastGames =>
+      pastActivities.whereType<GameActivityItem>().map((item) => item.game).toList();
 }
 
 class GamesListError extends GamesListState {

--- a/lib/features/games/presentation/pages/games_list_page.dart
+++ b/lib/features/games/presentation/pages/games_list_page.dart
@@ -1,8 +1,9 @@
-// Displays a list of all games for a group with real-time updates.
+// Displays the group activity feed with games and training sessions.
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/group_activity_item.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -13,6 +14,7 @@ import 'package:play_with_me/features/games/presentation/bloc/game_creation/game
 import 'package:play_with_me/features/games/presentation/pages/game_creation_page.dart';
 import 'package:play_with_me/features/games/presentation/pages/game_details_page.dart';
 import 'package:play_with_me/features/games/presentation/widgets/game_list_item.dart';
+import 'package:play_with_me/features/games/presentation/widgets/training_session_list_item.dart';
 
 class GamesListPage extends StatelessWidget {
   final String groupId;
@@ -102,26 +104,41 @@ class _GamesListPageContent extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (state.upcomingGames.isNotEmpty) ...[
-              _buildSectionHeader(context, 'Upcoming Games'),
-              ...state.upcomingGames.map((game) => GameListItem(
-                    game: game,
-                    userId: state.userId,
-                    onTap: () => _navigateToGameDetails(context, game.id),
-                  )),
+            if (state.upcomingActivities.isNotEmpty) ...[
+              _buildSectionHeader(context, 'Upcoming Activities'),
+              ...state.upcomingActivities.map((activity) =>
+                  _buildActivityItem(context, activity, state.userId, false)),
             ],
-            if (state.pastGames.isNotEmpty) ...[
-              _buildSectionHeader(context, 'Past Games'),
-              ...state.pastGames.map((game) => GameListItem(
-                    game: game,
-                    userId: state.userId,
-                    isPast: true,
-                    onTap: () => _navigateToGameDetails(context, game.id),
-                  )),
+            if (state.pastActivities.isNotEmpty) ...[
+              _buildSectionHeader(context, 'Past Activities'),
+              ...state.pastActivities.map((activity) =>
+                  _buildActivityItem(context, activity, state.userId, true)),
             ],
             const SizedBox(height: 80), // Space for FAB
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildActivityItem(
+    BuildContext context,
+    GroupActivityItem activity,
+    String userId,
+    bool isPast,
+  ) {
+    return activity.when(
+      game: (game) => GameListItem(
+        game: game,
+        userId: userId,
+        isPast: isPast,
+        onTap: () => _navigateToGameDetails(context, game.id),
+      ),
+      training: (session) => TrainingSessionListItem(
+        session: session,
+        userId: userId,
+        isPast: isPast,
+        onTap: () => _navigateToTrainingDetails(context, session.id),
       ),
     );
   }
@@ -229,6 +246,17 @@ class _GamesListPageContent extends StatelessWidget {
       context,
       MaterialPageRoute(
         builder: (context) => GameDetailsPage(gameId: gameId),
+      ),
+    );
+  }
+
+  void _navigateToTrainingDetails(BuildContext context, String sessionId) {
+    // TODO: Navigate to training session details page when implemented
+    // For now, show a placeholder snackbar
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Training session details: $sessionId'),
+        duration: const Duration(seconds: 2),
       ),
     );
   }

--- a/lib/features/games/presentation/widgets/training_session_list_item.dart
+++ b/lib/features/games/presentation/widgets/training_session_list_item.dart
@@ -1,0 +1,292 @@
+// Widget for displaying a training session in the group activity feed
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
+
+class TrainingSessionListItem extends StatelessWidget {
+  final TrainingSessionModel session;
+  final String userId;
+  final bool isPast;
+  final VoidCallback onTap;
+
+  const TrainingSessionListItem({
+    super.key,
+    required this.session,
+    required this.userId,
+    this.isPast = false,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isCancelled = session.status == TrainingStatus.cancelled;
+    final isCompleted = session.status == TrainingStatus.completed;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      elevation: isPast ? 0 : 1,
+      color: _getCardBackgroundColor(context),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Title row with training badge
+              Row(
+                children: [
+                  // Training icon to distinguish from games
+                  Icon(
+                    Icons.fitness_center,
+                    size: 20,
+                    color: isCancelled
+                        ? Colors.grey
+                        : Theme.of(context).colorScheme.secondary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      session.title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: isCancelled
+                                ? Theme.of(context).colorScheme.onSurfaceVariant
+                                : null,
+                            decoration:
+                                isCancelled ? TextDecoration.lineThrough : null,
+                          ),
+                    ),
+                  ),
+                  _buildTrainingBadge(context),
+                ],
+              ),
+              const SizedBox(height: 12),
+              // Date/Time
+              _buildInfoRow(
+                context,
+                Icons.calendar_today,
+                _formatDateTime(session.startTime),
+                isCancelled ? Colors.grey : Theme.of(context).colorScheme.secondary,
+              ),
+              const SizedBox(height: 8),
+              // Location
+              _buildInfoRow(
+                context,
+                Icons.location_on,
+                session.location.name,
+                isCancelled ? Colors.grey : Theme.of(context).colorScheme.secondary,
+              ),
+              const SizedBox(height: 8),
+              // Duration
+              _buildInfoRow(
+                context,
+                Icons.access_time,
+                _formatDuration(session.duration),
+                isCancelled ? Colors.grey : Theme.of(context).colorScheme.secondary,
+              ),
+              const SizedBox(height: 12),
+              // Participant count (no scores for training sessions)
+              if (!isCancelled) _buildParticipantCountBar(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color? _getCardBackgroundColor(BuildContext context) {
+    if (session.status == TrainingStatus.cancelled) {
+      return Theme.of(context)
+          .colorScheme
+          .surfaceContainerHighest
+          .withOpacity(0.5);
+    }
+
+    if (session.status == TrainingStatus.completed) {
+      return Theme.of(context).colorScheme.secondaryContainer.withOpacity(0.2);
+    }
+
+    // Subtle background for training sessions
+    return Theme.of(context).colorScheme.secondaryContainer.withOpacity(0.1);
+  }
+
+  Widget _buildTrainingBadge(BuildContext context) {
+    final isCancelled = session.status == TrainingStatus.cancelled;
+    final isParticipant = session.isParticipant(userId);
+
+    if (isCancelled) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Colors.grey.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.grey),
+        ),
+        child: Text(
+          'CANCELLED',
+          style: TextStyle(
+            color: Colors.grey.shade700,
+            fontWeight: FontWeight.bold,
+            fontSize: 10,
+          ),
+        ),
+      );
+    }
+
+    if (isParticipant) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.secondary.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: Theme.of(context).colorScheme.secondary,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.check_circle,
+              size: 12,
+              color: Theme.of(context).colorScheme.secondary,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              'JOINED',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.secondary,
+                fontWeight: FontWeight.bold,
+                fontSize: 10,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'TRAINING',
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.onSecondaryContainer,
+          fontWeight: FontWeight.bold,
+          fontSize: 10,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+      BuildContext context, IconData icon, String text, Color iconColor) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: iconColor,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: isPast
+                      ? Theme.of(context).colorScheme.onSurfaceVariant
+                      : null,
+                ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildParticipantCountBar(BuildContext context) {
+    final progress = session.currentParticipantCount / session.maxParticipants;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '${session.currentParticipantCount}/${session.maxParticipants} participants',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: isPast
+                        ? Theme.of(context).colorScheme.onSurfaceVariant
+                        : Theme.of(context).colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+            ),
+            if (session.currentParticipantCount < session.minParticipants)
+              Text(
+                'Min: ${session.minParticipants}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: progress,
+            minHeight: 6,
+            backgroundColor: isPast
+                ? Theme.of(context).colorScheme.surfaceVariant
+                : Theme.of(context).colorScheme.surfaceVariant,
+            valueColor: AlwaysStoppedAnimation<Color>(
+              isPast
+                  ? Theme.of(context).colorScheme.onSurfaceVariant
+                  : session.currentParticipantCount >= session.minParticipants
+                      ? Theme.of(context).colorScheme.secondary
+                      : Colors.orange,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final tomorrow = today.add(const Duration(days: 1));
+    final sessionDate =
+        DateTime(dateTime.year, dateTime.month, dateTime.day);
+
+    String dayString;
+    if (sessionDate == today) {
+      dayString = 'Today';
+    } else if (sessionDate == tomorrow) {
+      dayString = 'Tomorrow';
+    } else {
+      dayString = DateFormat('EEE, MMM d').format(dateTime);
+    }
+
+    final timeString = DateFormat('h:mm a').format(dateTime);
+    return '$dayString • $timeString';
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+
+    if (hours > 0 && minutes > 0) {
+      return '${hours}h ${minutes}m';
+    } else if (hours > 0) {
+      return '${hours}h';
+    } else {
+      return '${minutes}m';
+    }
+  }
+}

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -22,6 +22,8 @@ import 'package:play_with_me/features/groups/presentation/widgets/group_bottom_n
 import 'package:play_with_me/features/games/presentation/bloc/game_creation/game_creation_bloc.dart';
 import 'package:play_with_me/features/games/presentation/pages/game_creation_page.dart';
 import 'package:play_with_me/features/games/presentation/pages/games_list_page.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
+import 'package:play_with_me/features/training/presentation/pages/training_session_creation_page.dart';
 
 class GroupDetailsPage extends StatelessWidget {
   final String groupId;
@@ -369,6 +371,8 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
                         upcomingGamesCount: gameCount,
                         onInviteTap: () => _navigateToInvitePage(context),
                         onCreateGameTap: () => _navigateToGameCreation(context),
+                        onCreateTrainingTap: () =>
+                            _navigateToTrainingCreation(context),
                         onGamesListTap: () => _showGamesListComingSoon(context),
                       );
                     },
@@ -630,6 +634,23 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
         builder: (context) => GamesListPage(
           groupId: widget.groupId,
           groupName: _group!.name,
+        ),
+      ),
+    );
+  }
+
+  void _navigateToTrainingCreation(BuildContext context) {
+    if (_group == null) return;
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => BlocProvider(
+          create: (context) => sl<TrainingSessionCreationBloc>(),
+          child: TrainingSessionCreationPage(
+            groupId: widget.groupId,
+            groupName: _group!.name,
+          ),
         ),
       ),
     );

--- a/lib/features/groups/presentation/widgets/group_bottom_nav_bar.dart
+++ b/lib/features/groups/presentation/widgets/group_bottom_nav_bar.dart
@@ -6,6 +6,7 @@ class GroupBottomNavBar extends StatelessWidget {
   final int upcomingGamesCount;
   final VoidCallback? onInviteTap;
   final VoidCallback? onCreateGameTap;
+  final VoidCallback? onCreateTrainingTap;
   final VoidCallback? onGamesListTap;
 
   const GroupBottomNavBar({
@@ -14,8 +15,42 @@ class GroupBottomNavBar extends StatelessWidget {
     this.upcomingGamesCount = 0,
     this.onInviteTap,
     this.onCreateGameTap,
+    this.onCreateTrainingTap,
     this.onGamesListTap,
   });
+
+  void _showCreateMenu(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.sports_volleyball),
+                title: const Text('Create Game'),
+                subtitle: const Text('Competitive game with ELO ratings'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onCreateGameTap?.call();
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.fitness_center),
+                title: const Text('Create Training Session'),
+                subtitle: const Text('Practice session without ELO impact'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onCreateTrainingTap?.call();
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +64,7 @@ class GroupBottomNavBar extends StatelessWidget {
             }
             break;
           case 1:
-            onCreateGameTap?.call();
+            _showCreateMenu(context);
             break;
           case 2:
             onGamesListTap?.call();
@@ -52,8 +87,8 @@ class GroupBottomNavBar extends StatelessWidget {
             Icons.add_circle,
             color: Theme.of(context).colorScheme.primary,
           ),
-          label: 'Create Game',
-          tooltip: 'Create a new game',
+          label: 'Create',
+          tooltip: 'Create game or training session',
         ),
         BottomNavigationBarItem(
           icon: Badge(
@@ -64,8 +99,8 @@ class GroupBottomNavBar extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
             ),
           ),
-          label: 'Games',
-          tooltip: 'View all games',
+          label: 'Activities',
+          tooltip: 'View all activities',
         ),
       ],
       selectedItemColor: Theme.of(context).colorScheme.primary,

--- a/lib/features/training/presentation/pages/training_session_creation_page.dart
+++ b/lib/features/training/presentation/pages/training_session_creation_page.dart
@@ -1,0 +1,394 @@
+// Training session creation page - simplified version for Story 15.4
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_event.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_state.dart';
+
+class TrainingSessionCreationPage extends StatefulWidget {
+  final String groupId;
+  final String groupName;
+
+  const TrainingSessionCreationPage({
+    super.key,
+    required this.groupId,
+    required this.groupName,
+  });
+
+  @override
+  State<TrainingSessionCreationPage> createState() =>
+      _TrainingSessionCreationPageState();
+}
+
+class _TrainingSessionCreationPageState
+    extends State<TrainingSessionCreationPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _locationController = TextEditingController();
+
+  DateTime? _selectedStartTime;
+  DateTime? _selectedEndTime;
+  int _maxParticipants = 10;
+  int _minParticipants = 2;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize the bloc with the group information
+    context.read<TrainingSessionCreationBloc>().add(SelectTrainingGroup(
+          groupId: widget.groupId,
+          groupName: widget.groupName,
+        ));
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _locationController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectStartTime(BuildContext context) async {
+    final now = DateTime.now();
+    final initialDate = now.add(const Duration(days: 1));
+
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365)),
+      helpText: 'Select Start Date',
+    );
+
+    if (date == null || !mounted) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: const TimeOfDay(hour: 14, minute: 0),
+      helpText: 'Select Start Time',
+    );
+
+    if (time == null || !mounted) return;
+
+    final dateTime = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+
+    setState(() {
+      _selectedStartTime = dateTime;
+      // Auto-set end time to 2 hours later
+      _selectedEndTime = dateTime.add(const Duration(hours: 2));
+    });
+  }
+
+  Future<void> _selectEndTime(BuildContext context) async {
+    if (_selectedStartTime == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select start time first')),
+      );
+      return;
+    }
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay(
+        hour: _selectedEndTime?.hour ?? 16,
+        minute: _selectedEndTime?.minute ?? 0,
+      ),
+      helpText: 'Select End Time',
+    );
+
+    if (time == null || !mounted) return;
+
+    final dateTime = DateTime(
+      _selectedStartTime!.year,
+      _selectedStartTime!.month,
+      _selectedStartTime!.day,
+      time.hour,
+      time.minute,
+    );
+
+    setState(() {
+      _selectedEndTime = dateTime;
+    });
+  }
+
+  void _handleSubmit(BuildContext context, String userId) {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (_selectedStartTime == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select start time')),
+      );
+      return;
+    }
+
+    if (_selectedEndTime == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select end time')),
+      );
+      return;
+    }
+
+    final bloc = context.read<TrainingSessionCreationBloc>();
+
+    // Dispatch all form field events
+    bloc.add(SetTrainingTitle(title: _titleController.text.trim()));
+
+    if (_descriptionController.text.trim().isNotEmpty) {
+      bloc.add(SetTrainingDescription(
+          description: _descriptionController.text.trim()));
+    }
+
+    bloc.add(SetTrainingLocation(locationName: _locationController.text.trim()));
+    bloc.add(SetStartTime(startTime: _selectedStartTime!));
+    bloc.add(SetEndTime(endTime: _selectedEndTime!));
+    bloc.add(SetMinParticipants(minParticipants: _minParticipants));
+    bloc.add(SetMaxParticipants(maxParticipants: _maxParticipants));
+
+    // Finally submit
+    bloc.add(SubmitTrainingSession(createdBy: userId));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<TrainingSessionCreationBloc,
+        TrainingSessionCreationState>(
+      listener: (context, state) {
+        if (state is TrainingSessionCreationSuccess) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Training session created successfully!'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        } else if (state is TrainingSessionCreationError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Create Training Session'),
+          centerTitle: true,
+        ),
+        body: BlocBuilder<AuthenticationBloc, AuthenticationState>(
+          builder: (context, authState) {
+            if (authState is! AuthenticationAuthenticated) {
+              return const Center(
+                child: Text('Please log in to create a training session'),
+              );
+            }
+
+            return BlocBuilder<TrainingSessionCreationBloc,
+                TrainingSessionCreationState>(
+              builder: (context, state) {
+                final isLoading = state is TrainingSessionCreationSubmitting;
+
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          widget.groupName,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 24),
+                        TextFormField(
+                          controller: _titleController,
+                          decoration: const InputDecoration(
+                            labelText: 'Title',
+                            border: OutlineInputBorder(),
+                            prefixIcon: Icon(Icons.fitness_center),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Please enter a title';
+                            }
+                            return null;
+                          },
+                          enabled: !isLoading,
+                        ),
+                        const SizedBox(height: 16),
+                        TextFormField(
+                          controller: _descriptionController,
+                          decoration: const InputDecoration(
+                            labelText: 'Description (Optional)',
+                            border: OutlineInputBorder(),
+                            prefixIcon: Icon(Icons.description),
+                          ),
+                          maxLines: 3,
+                          enabled: !isLoading,
+                        ),
+                        const SizedBox(height: 16),
+                        TextFormField(
+                          controller: _locationController,
+                          decoration: const InputDecoration(
+                            labelText: 'Location',
+                            border: OutlineInputBorder(),
+                            prefixIcon: Icon(Icons.location_on),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Please enter a location';
+                            }
+                            return null;
+                          },
+                          enabled: !isLoading,
+                        ),
+                        const SizedBox(height: 16),
+                        ListTile(
+                          title: const Text('Start Time'),
+                          subtitle: Text(_selectedStartTime != null
+                              ? '${_selectedStartTime!.day}/${_selectedStartTime!.month}/${_selectedStartTime!.year} at ${_selectedStartTime!.hour}:${_selectedStartTime!.minute.toString().padLeft(2, '0')}'
+                              : 'Not selected'),
+                          trailing: const Icon(Icons.calendar_today),
+                          onTap: isLoading
+                              ? null
+                              : () => _selectStartTime(context),
+                          tileColor:
+                              Theme.of(context).colorScheme.surfaceVariant,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        ListTile(
+                          title: const Text('End Time'),
+                          subtitle: Text(_selectedEndTime != null
+                              ? '${_selectedEndTime!.day}/${_selectedEndTime!.month}/${_selectedEndTime!.year} at ${_selectedEndTime!.hour}:${_selectedEndTime!.minute.toString().padLeft(2, '0')}'
+                              : 'Not selected'),
+                          trailing: const Icon(Icons.access_time),
+                          onTap: isLoading
+                              ? null
+                              : () => _selectEndTime(context),
+                          tileColor:
+                              Theme.of(context).colorScheme.surfaceVariant,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Min Participants',
+                                    style:
+                                        Theme.of(context).textTheme.bodyMedium,
+                                  ),
+                                  Slider(
+                                    value: _minParticipants.toDouble(),
+                                    min: 2,
+                                    max: 20,
+                                    divisions: 18,
+                                    label: _minParticipants.toString(),
+                                    onChanged: isLoading
+                                        ? null
+                                        : (value) {
+                                            setState(() {
+                                              _minParticipants = value.toInt();
+                                              if (_minParticipants >
+                                                  _maxParticipants) {
+                                                _maxParticipants =
+                                                    _minParticipants;
+                                              }
+                                            });
+                                          },
+                                  ),
+                                  Text('$_minParticipants',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(width: 16),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Max Participants',
+                                    style:
+                                        Theme.of(context).textTheme.bodyMedium,
+                                  ),
+                                  Slider(
+                                    value: _maxParticipants.toDouble(),
+                                    min: 2,
+                                    max: 20,
+                                    divisions: 18,
+                                    label: _maxParticipants.toString(),
+                                    onChanged: isLoading
+                                        ? null
+                                        : (value) {
+                                            setState(() {
+                                              _maxParticipants = value.toInt();
+                                              if (_maxParticipants <
+                                                  _minParticipants) {
+                                                _minParticipants =
+                                                    _maxParticipants;
+                                              }
+                                            });
+                                          },
+                                  ),
+                                  Text('$_maxParticipants',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 24),
+                        FilledButton(
+                          onPressed: isLoading
+                              ? null
+                              : () => _handleSubmit(context, authState.user.uid),
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: isLoading
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Text('Create Training Session'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/test/unit/core/data/repositories/mock_training_session_repository.dart
+++ b/test/unit/core/data/repositories/mock_training_session_repository.dart
@@ -1,0 +1,283 @@
+// Mock repository for TrainingSessionRepository used in testing
+import 'dart:async';
+
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
+import 'package:play_with_me/core/data/models/training_session_participant_model.dart';
+import 'package:play_with_me/core/domain/repositories/training_session_repository.dart';
+
+class MockTrainingSessionRepository implements TrainingSessionRepository {
+  final StreamController<List<TrainingSessionModel>> _sessionsController =
+      StreamController<List<TrainingSessionModel>>.broadcast();
+  final Map<String, StreamController<TrainingSessionModel?>>
+      _sessionStreamControllers = {};
+  final Map<String, TrainingSessionModel> _sessions = {};
+
+  MockTrainingSessionRepository() {
+    // Seed initial empty list to match real repository behavior
+    _sessionsController.add(const []);
+  }
+
+  // Helper methods for testing
+  void addSession(TrainingSessionModel session) {
+    _sessions[session.id] = session;
+    _emitSessions();
+    _emitSessionUpdate(session.id);
+  }
+
+  void clearSessions() {
+    _sessions.clear();
+    _emitSessions();
+  }
+
+  void _emitSessions() {
+    if (!_sessionsController.isClosed) {
+      _sessionsController.add(_sessions.values.toList());
+    }
+  }
+
+  void _emitSessionUpdate(String sessionId) {
+    final controller = _sessionStreamControllers[sessionId];
+    if (controller != null && !controller.isClosed) {
+      controller.add(_sessions[sessionId]);
+    }
+  }
+
+  void dispose() {
+    _sessionsController.close();
+    for (final controller in _sessionStreamControllers.values) {
+      controller.close();
+    }
+    _sessionStreamControllers.clear();
+  }
+
+  // Repository methods
+  @override
+  Future<TrainingSessionModel?> getTrainingSessionById(String sessionId) async {
+    return _sessions[sessionId];
+  }
+
+  @override
+  Stream<TrainingSessionModel?> getTrainingSessionStream(String sessionId) {
+    if (!_sessionStreamControllers.containsKey(sessionId)) {
+      late final StreamController<TrainingSessionModel?> controller;
+      controller = StreamController<TrainingSessionModel?>.broadcast(
+        onListen: () {
+          controller.add(_sessions[sessionId]);
+        },
+      );
+      _sessionStreamControllers[sessionId] = controller;
+    }
+
+    return _sessionStreamControllers[sessionId]!.stream;
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForGroup(
+      String groupId) async* {
+    // Emit current state immediately
+    yield _sessions.values
+        .where((session) => session.groupId == groupId)
+        .toList();
+
+    // Then emit future updates
+    await for (final sessions in _sessionsController.stream) {
+      yield sessions.where((session) => session.groupId == groupId).toList();
+    }
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getUpcomingTrainingSessionsForGroup(
+      String groupId) async* {
+    final now = DateTime.now();
+    await for (final sessions in getTrainingSessionsForGroup(groupId)) {
+      yield sessions
+          .where((session) =>
+              session.startTime.isAfter(now) &&
+              session.status == TrainingStatus.scheduled)
+          .toList();
+    }
+  }
+
+  @override
+  Future<List<TrainingSessionModel>> getPastTrainingSessionsForGroup(
+    String groupId, {
+    int limit = 20,
+  }) async {
+    final now = DateTime.now();
+    final pastSessions = _sessions.values
+        .where(
+            (session) => session.groupId == groupId && session.startTime.isBefore(now))
+        .toList()
+      ..sort((a, b) => b.startTime.compareTo(a.startTime));
+
+    return pastSessions.take(limit).toList();
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(String userId) {
+    return _sessionsController.stream.map((sessions) => sessions
+        .where((session) => session.isParticipant(userId))
+        .toList());
+  }
+
+  @override
+  Stream<int> getUpcomingTrainingSessionsCount(String groupId) async* {
+    await for (final sessions
+        in getUpcomingTrainingSessionsForGroup(groupId)) {
+      yield sessions.length;
+    }
+  }
+
+  @override
+  Future<String> createTrainingSession(TrainingSessionModel session) async {
+    _sessions[session.id] = session;
+    _emitSessions();
+    return session.id;
+  }
+
+  @override
+  Future<void> updateTrainingSessionInfo(
+    String sessionId, {
+    String? title,
+    String? description,
+    DateTime? startTime,
+    DateTime? endTime,
+    GameLocation? location,
+    String? notes,
+  }) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.updateInfo(
+        title: title,
+        description: description,
+        startTime: startTime,
+        endTime: endTime,
+        location: location,
+        notes: notes,
+      );
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> updateTrainingSessionSettings(
+    String sessionId, {
+    int? maxParticipants,
+    int? minParticipants,
+  }) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.updateSettings(
+        maxParticipants: maxParticipants,
+        minParticipants: minParticipants,
+      );
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> joinTrainingSession(String sessionId) async {
+    // Mock implementation - not fully implemented
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> leaveTrainingSession(String sessionId) async {
+    // Mock implementation - not fully implemented
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> addParticipant(String sessionId, String userId) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.addParticipant(userId);
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> removeParticipant(String sessionId, String userId) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.removeParticipant(userId);
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> cancelTrainingSession(String sessionId) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.cancelSession();
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> completeTrainingSession(String sessionId) async {
+    final session = _sessions[sessionId];
+    if (session != null) {
+      _sessions[sessionId] = session.completeSession();
+      _emitSessions();
+    }
+  }
+
+  @override
+  Future<void> deleteTrainingSession(String sessionId) async {
+    _sessions.remove(sessionId);
+    _emitSessions();
+  }
+
+  @override
+  Future<bool> trainingSessionExists(String sessionId) async {
+    return _sessions.containsKey(sessionId);
+  }
+
+  @override
+  Future<List<String>> getTrainingSessionParticipants(String sessionId) async {
+    final session = _sessions[sessionId];
+    return session?.participantIds ?? [];
+  }
+
+  @override
+  Stream<List<TrainingSessionParticipantModel>>
+      getTrainingSessionParticipantsStream(String sessionId) {
+    // Mock implementation - not fully implemented
+    return Stream.value([]);
+  }
+
+  @override
+  Stream<int> getTrainingSessionParticipantCount(String sessionId) {
+    return getTrainingSessionStream(sessionId).map((session) => session?.currentParticipantCount ?? 0);
+  }
+
+  @override
+  Future<bool> canUserJoinTrainingSession(String sessionId, String userId) async {
+    final session = _sessions[sessionId];
+    return session?.canUserJoin(userId) ?? false;
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getRecurringSessionInstances(
+      String parentSessionId) {
+    return Stream.value([]);
+  }
+
+  @override
+  Stream<List<TrainingSessionModel>> getUpcomingRecurringSessionInstances(
+      String parentSessionId) {
+    return Stream.value([]);
+  }
+
+  @override
+  Future<List<String>> generateRecurringInstances(String parentSessionId) async {
+    return [];
+  }
+
+  @override
+  Future<void> cancelRecurringSessionInstance(String instanceId) async {
+    // Mock implementation
+  }
+}

--- a/test/widget/features/groups/presentation/widgets/group_bottom_nav_bar_test.dart
+++ b/test/widget/features/groups/presentation/widgets/group_bottom_nav_bar_test.dart
@@ -13,6 +13,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -35,6 +36,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () => inviteTapped = true,
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -61,6 +63,7 @@ void main() {
               isAdmin: false,
               onInviteTap: () => inviteTapped = true,
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -76,17 +79,16 @@ void main() {
       expect(inviteTapped, isFalse);
     });
 
-    testWidgets('calls onCreateGameTap when second item is tapped',
+    testWidgets('shows modal with game and training options when second item is tapped',
         (tester) async {
-      bool createGameTapped = false;
-
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             bottomNavigationBar: GroupBottomNavBar(
               isAdmin: true,
               onInviteTap: () {},
-              onCreateGameTap: () => createGameTapped = true,
+              onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -98,8 +100,11 @@ void main() {
         find.byType(BottomNavigationBar).first,
       );
       bottomNavBar.onTap!(1);
+      await tester.pumpAndSettle();
 
-      expect(createGameTapped, isTrue);
+      // Verify modal sheet appears with both options
+      expect(find.text('Create Game'), findsOneWidget);
+      expect(find.text('Create Training Session'), findsOneWidget);
     });
 
     testWidgets('calls onGamesListTap when third item is tapped',
@@ -113,6 +118,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () => gamesListTapped = true,
             ),
           ),
@@ -136,6 +142,7 @@ void main() {
               isAdmin: false,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -155,6 +162,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -178,6 +186,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -201,6 +210,7 @@ void main() {
               isAdmin: false,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -223,6 +233,7 @@ void main() {
               isAdmin: true,
               onInviteTap: () {},
               onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
               onGamesListTap: () {},
             ),
           ),
@@ -247,6 +258,7 @@ void main() {
                 upcomingGamesCount: 0,
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),
@@ -272,6 +284,7 @@ void main() {
                 upcomingGamesCount: 3,
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),
@@ -300,6 +313,7 @@ void main() {
                 upcomingGamesCount: 15,
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),
@@ -327,6 +341,7 @@ void main() {
                 upcomingGamesCount: 9,
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),
@@ -354,6 +369,7 @@ void main() {
                 upcomingGamesCount: 5,
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),
@@ -379,6 +395,7 @@ void main() {
                 // upcomingGamesCount not specified, should default to 0
                 onInviteTap: () {},
                 onCreateGameTap: () {},
+              onCreateTrainingTap: () {},
                 onGamesListTap: () {},
               ),
             ),


### PR DESCRIPTION
## Summary

Implements unified activity feed showing both games and training sessions, with the ability to create training sessions from the group page.

## Changes

### Core Models & BLoC
- ✅ Created `GroupActivityItem` union type for games and training sessions
- ✅ Updated `GamesListBloc` to combine streams from `GameRepository` and `TrainingSessionRepository` using `RxDart.combineLatest2`
- ✅ Updated `GamesListState` to hold `List<GroupActivityItem>` instead of separate game lists
- ✅ All activities sorted by start time across both types

### UI Components
- ✅ Created `TrainingSessionListItem` widget with distinct visual treatment:
  - Fitness icon to distinguish from games
  - Shows participant count (not player count)
  - No scores displayed (training sessions don't affect ELO)
  - Different badge styles: "TRAINING", "JOINED", "CANCELLED"
  - Shows session duration
- ✅ Updated `GamesListPage` to render both activity types using pattern matching
- ✅ Created `TrainingSessionCreationPage` with form for creating training sessions
- ✅ Updated `GroupBottomNavBar` with modal to choose between game/training creation
- ✅ Changed button labels: "Create Game" → "Create", "Games" → "Activities"

### Infrastructure
- ✅ Added Firestore composite index for `trainingSessions` (groupId, startTime)
- ✅ Deployed index to all environments (dev, stg, prod)
- ✅ Updated service locator to inject `TrainingSessionRepository` into `GamesListBloc`

### Testing
- ✅ Created `MockTrainingSessionRepository` for testing
- ✅ Updated all `GamesListBloc` tests to inject both repositories
- ✅ Added comprehensive tests for combined activities (sorting, filtering, separation)
- ✅ All tests pass successfully (14 tests for GamesListBloc)

## User Experience

Users can now:
1. **View unified activity feed** - See games and training sessions together, sorted chronologically
2. **Create training sessions** - Tap "Create" → Choose "Create Training Session" → Fill form → Submit
3. **Visual distinction** - Training sessions have unique icons, colors, and styling
4. **Navigate seamlessly** - Activity feed shows both types with appropriate navigation

## Screenshots

### Group Details Page
- Bottom navigation now shows "Create" button with modal menu
- "Activities" tab shows count of upcoming games (will show combined count in future)

### Activity Feed
- Upcoming and past activities shown together
- Training sessions have fitness icon and distinct styling
- Games show scores/results, training sessions show participation

### Training Creation
- Simple form with title, description, location
- Date/time pickers for start and end time
- Participant min/max sliders
- Validates input before submission

## Technical Notes

- **Architecture compliance**: No violations of layered architecture
- **Backward compatibility**: Helper getters maintain compatibility with existing game-only code
- **Real-time updates**: Streams from both repositories combined reactively
- **No ELO impact**: Training sessions clearly marked as practice-only

## Related Issue

Closes #349

---

🏐 Generated for PlayWithMe - Beach Volleyball App