### PR TITLE
Bug #373: Fix wrong error message when leaving group

### DIFF
--- a/lib/core/presentation/bloc/group_member/group_member_bloc.dart
+++ b/lib/core/presentation/bloc/group_member/group_member_bloc.dart
@@ -154,6 +154,13 @@ class GroupMemberBloc extends Bloc<GroupMemberEvent, GroupMemberState> {
       if (errorMessage.startsWith('Exception: ')) {
         errorMessage = errorMessage.substring('Exception: '.length);
       }
+
+      // Ensure we show a group-specific error message
+      // This prevents confusion with other features (e.g., training sessions)
+      if (!errorMessage.toLowerCase().contains('group')) {
+        errorMessage = 'Failed to leave group. Please try again.';
+      }
+
       emit(GroupMemberError(errorMessage));
     }
   }


### PR DESCRIPTION
## Summary
Fix bug where users could see "Failed to leave training session" error message when attempting to leave a **group**.

## Problem
When an error occurred during the leave group operation, the error message displayed might not be contextually correct, potentially showing error messages from other features (like training sessions).

## Solution
Updated `GroupMemberBloc._onLeaveGroup` to validate error messages and ensure they contain group-specific context. If an error message doesn't contain "group", it's replaced with a user-friendly default:

> "Failed to leave group. Please try again."

This prevents confusion while preserving meaningful group-related error messages like "Cannot leave group as the last admin."

## Changes
- **`lib/core/presentation/bloc/group_member/group_member_bloc.dart`**
  - Added validation to check if error message contains "group"
  - Non-group error messages are replaced with default message

- **`test/unit/core/presentation/bloc/group_member/group_member_bloc_test.dart`**
  - Added test for replacing non-group error messages
  - Added test for preserving group-related error messages
  - Updated existing test expectations

## Test Plan
- [x] All unit tests pass (27 GroupMemberBloc tests)
- [x] All 1600+ tests pass
- [x] Flutter analyze passes

## Acceptance Criteria
- [x] Error message correctly says "Failed to leave group" when leaving a group fails
- [x] All group-related error messages are consistent and context-appropriate

Closes #373