### PR TITLE
Bug #373: Fix leave training session INTERNAL error

### DIFF
--- a/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart
+++ b/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart
@@ -91,9 +91,17 @@ class TrainingSessionParticipationBloc extends Bloc<
         errorCode: e.code,
       ));
     } catch (e) {
-      emit(ParticipationError(
-        message: 'Failed to join training session. Please try again.',
-      ));
+      // Extract message from Exception if available
+      String errorMessage = e.toString();
+      if (errorMessage.startsWith('Exception: ')) {
+        errorMessage = errorMessage.substring('Exception: '.length);
+      }
+      // Use extracted message if it's meaningful, otherwise use fallback
+      final message = errorMessage.isNotEmpty &&
+              !errorMessage.contains('Instance of')
+          ? errorMessage
+          : 'Failed to join training session. Please try again.';
+      emit(ParticipationError(message: message));
     }
   }
 
@@ -121,9 +129,17 @@ class TrainingSessionParticipationBloc extends Bloc<
         errorCode: e.code,
       ));
     } catch (e) {
-      emit(ParticipationError(
-        message: 'Failed to leave training session. Please try again.',
-      ));
+      // Extract message from Exception if available
+      String errorMessage = e.toString();
+      if (errorMessage.startsWith('Exception: ')) {
+        errorMessage = errorMessage.substring('Exception: '.length);
+      }
+      // Use extracted message if it's meaningful, otherwise use fallback
+      final message = errorMessage.isNotEmpty &&
+              !errorMessage.contains('Instance of')
+          ? errorMessage
+          : 'Failed to leave training session. Please try again.';
+      emit(ParticipationError(message: message));
     }
   }
 

--- a/test/unit/features/training/presentation/bloc/training_session_participation_bloc_test.dart
+++ b/test/unit/features/training/presentation/bloc/training_session_participation_bloc_test.dart
@@ -258,8 +258,9 @@ void main() {
         act: (bloc) => bloc.add(const JoinTrainingSession(testSessionId)),
         expect: () => [
           const JoiningSession(testSessionId),
+          // Now correctly extracts the exception message
           const ParticipationError(
-            message: 'Failed to join training session. Please try again.',
+            message: 'Unknown error',
           ),
         ],
       );
@@ -366,8 +367,9 @@ void main() {
         act: (bloc) => bloc.add(const LeaveTrainingSession(testSessionId)),
         expect: () => [
           const LeavingSession(testSessionId),
+          // Now correctly extracts the exception message
           const ParticipationError(
-            message: 'Failed to leave training session. Please try again.',
+            message: 'Unknown error',
           ),
         ],
       );


### PR DESCRIPTION
## Summary

- Fixed Firestore transaction read/write order violation in `leaveTrainingSession` Cloud Function
- Improved error message handling in `TrainingSessionParticipationBloc` to show meaningful errors

## Root Cause

The `leaveTrainingSession` Cloud Function was violating Firestore's transaction rules:

```
Before (broken):
1. READ participant doc
2. WRITE participant status → "left"   ← Write happens here
3. READ all participants               ← This read AFTER write causes INTERNAL error!
4. WRITE session participantIds

After (fixed):
1. READ participant doc
2. READ all participants              ← Moved before writes
3. WRITE participant status → "left"
4. WRITE session participantIds
```

## Test plan

- [x] Cloud Functions tests pass (277 tests)
- [x] Flutter unit tests pass (17 participation bloc tests)
- [x] Manually tested in iOS simulator - leaving training session works

## Files Changed

- `functions/src/leaveTrainingSession.ts` - Fixed transaction read/write order
- `lib/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart` - Improved error message extraction
- `test/unit/features/training/presentation/bloc/training_session_participation_bloc_test.dart` - Updated tests

Fixes #373

🤖 Generated with [Claude Code](https://claude.ai/code)