### PR TITLE
Story 15.14: Allow training session creator to cancel session

### DIFF
--- a/functions/src/cancelTrainingSession.ts
+++ b/functions/src/cancelTrainingSession.ts
@@ -1,0 +1,136 @@
+// Cloud Function for cancelling training sessions (Story 15.14)
+// Only the session creator can cancel a session
+// Notifications are automatically triggered by onTrainingSessionUpdated
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface CancelTrainingSessionRequest {
+  sessionId: string;
+}
+
+interface CancelTrainingSessionResponse {
+  success: boolean;
+  message: string;
+}
+
+// ============================================================================
+// Main Cloud Function
+// ============================================================================
+
+export const cancelTrainingSession = functions.https.onCall(
+  async (
+    data: CancelTrainingSessionRequest,
+    context: functions.https.CallableContext
+  ): Promise<CancelTrainingSessionResponse> => {
+    // ============================================================================
+    // 1. Authentication Check
+    // ============================================================================
+
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "You must be logged in to cancel a training session"
+      );
+    }
+
+    const userId = context.auth.uid;
+
+    console.log("[cancelTrainingSession] Request from user:", {
+      userId,
+      sessionId: data.sessionId,
+    });
+
+    // ============================================================================
+    // 2. Input Validation
+    // ============================================================================
+
+    if (!data || !data.sessionId || typeof data.sessionId !== "string") {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "Session ID is required"
+      );
+    }
+
+    const db = admin.firestore();
+    const sessionRef = db.collection("trainingSessions").doc(data.sessionId);
+
+    // ============================================================================
+    // 3. Session Validation & Permission Check
+    // ============================================================================
+
+    const sessionDoc = await sessionRef.get();
+
+    if (!sessionDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "Training session not found"
+      );
+    }
+
+    const sessionData = sessionDoc.data()!;
+
+    // Check if user is the creator
+    if (sessionData.createdBy !== userId) {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "Only the session creator can cancel this training session"
+      );
+    }
+
+    // Check if session is already cancelled
+    if (sessionData.status === "cancelled") {
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This training session is already cancelled"
+      );
+    }
+
+    // Check if session is already completed
+    if (sessionData.status === "completed") {
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "Cannot cancel a completed training session"
+      );
+    }
+
+    // ============================================================================
+    // 4. Cancel Operation
+    // ============================================================================
+
+    try {
+      await sessionRef.update({
+        status: "cancelled",
+        cancelledBy: userId,
+        cancelledAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      console.log("[cancelTrainingSession] Session cancelled successfully:", {
+        userId,
+        sessionId: data.sessionId,
+        participantCount: sessionData.participantIds?.length || 0,
+      });
+
+      return {
+        success: true,
+        message: "Training session cancelled successfully",
+      };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      console.error("[cancelTrainingSession] Error cancelling session:", {
+        userId,
+        sessionId: data.sessionId,
+        error: errorMessage,
+      });
+
+      throw new functions.https.HttpsError(
+        "internal",
+        "Failed to cancel training session. Please try again later."
+      );
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,6 +25,7 @@ export {createTrainingSession} from "./createTrainingSession"; // Story 15.1 (Ep
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)
+export {cancelTrainingSession} from "./cancelTrainingSession"; // Story 15.14 (Cancel Training Session)
 export {submitTrainingFeedback} from "./submitTrainingFeedback"; // Story 15.8 (Anonymous Feedback)
 export {hasSubmittedTrainingFeedback} from "./hasSubmittedTrainingFeedback"; // Story 15.8 (Anonymous Feedback)
 export {getTrainingFeedback} from "./getTrainingFeedback"; // Story 15.11 (Display Feedback)

--- a/lib/core/data/models/training_session_model.freezed.dart
+++ b/lib/core/data/models/training_session_model.freezed.dart
@@ -46,7 +46,11 @@ mixin _$TrainingSessionModel {
       throw _privateConstructorUsedError; // Participant tracking
   List<String> get participantIds =>
       throw _privateConstructorUsedError; // Session notes
-  String? get notes => throw _privateConstructorUsedError;
+  String? get notes =>
+      throw _privateConstructorUsedError; // Cancellation tracking (Story 15.14)
+  String? get cancelledBy => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get cancelledAt => throw _privateConstructorUsedError;
 
   /// Serializes this TrainingSessionModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -83,6 +87,8 @@ abstract class $TrainingSessionModelCopyWith<$Res> {
     TrainingStatus status,
     List<String> participantIds,
     String? notes,
+    String? cancelledBy,
+    @TimestampConverter() DateTime? cancelledAt,
   });
 
   $GameLocationCopyWith<$Res> get location;
@@ -124,6 +130,8 @@ class _$TrainingSessionModelCopyWithImpl<
     Object? status = null,
     Object? participantIds = null,
     Object? notes = freezed,
+    Object? cancelledBy = freezed,
+    Object? cancelledAt = freezed,
   }) {
     return _then(
       _value.copyWith(
@@ -195,6 +203,14 @@ class _$TrainingSessionModelCopyWithImpl<
                 ? _value.notes
                 : notes // ignore: cast_nullable_to_non_nullable
                       as String?,
+            cancelledBy: freezed == cancelledBy
+                ? _value.cancelledBy
+                : cancelledBy // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            cancelledAt: freezed == cancelledAt
+                ? _value.cancelledAt
+                : cancelledAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
           )
           as $Val,
     );
@@ -252,6 +268,8 @@ abstract class _$$TrainingSessionModelImplCopyWith<$Res>
     TrainingStatus status,
     List<String> participantIds,
     String? notes,
+    String? cancelledBy,
+    @TimestampConverter() DateTime? cancelledAt,
   });
 
   @override
@@ -291,6 +309,8 @@ class __$$TrainingSessionModelImplCopyWithImpl<$Res>
     Object? status = null,
     Object? participantIds = null,
     Object? notes = freezed,
+    Object? cancelledBy = freezed,
+    Object? cancelledAt = freezed,
   }) {
     return _then(
       _$TrainingSessionModelImpl(
@@ -362,6 +382,14 @@ class __$$TrainingSessionModelImplCopyWithImpl<$Res>
             ? _value.notes
             : notes // ignore: cast_nullable_to_non_nullable
                   as String?,
+        cancelledBy: freezed == cancelledBy
+            ? _value.cancelledBy
+            : cancelledBy // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        cancelledAt: freezed == cancelledAt
+            ? _value.cancelledAt
+            : cancelledAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
       ),
     );
   }
@@ -388,6 +416,8 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
     this.status = TrainingStatus.scheduled,
     final List<String> participantIds = const [],
     this.notes,
+    this.cancelledBy,
+    @TimestampConverter() this.cancelledAt,
   }) : _participantIds = participantIds,
        super._();
 
@@ -447,10 +477,16 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
   // Session notes
   @override
   final String? notes;
+  // Cancellation tracking (Story 15.14)
+  @override
+  final String? cancelledBy;
+  @override
+  @TimestampConverter()
+  final DateTime? cancelledAt;
 
   @override
   String toString() {
-    return 'TrainingSessionModel(id: $id, groupId: $groupId, title: $title, description: $description, location: $location, startTime: $startTime, endTime: $endTime, minParticipants: $minParticipants, maxParticipants: $maxParticipants, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, recurrenceRule: $recurrenceRule, parentSessionId: $parentSessionId, status: $status, participantIds: $participantIds, notes: $notes)';
+    return 'TrainingSessionModel(id: $id, groupId: $groupId, title: $title, description: $description, location: $location, startTime: $startTime, endTime: $endTime, minParticipants: $minParticipants, maxParticipants: $maxParticipants, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, recurrenceRule: $recurrenceRule, parentSessionId: $parentSessionId, status: $status, participantIds: $participantIds, notes: $notes, cancelledBy: $cancelledBy, cancelledAt: $cancelledAt)';
   }
 
   @override
@@ -487,12 +523,16 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
               other._participantIds,
               _participantIds,
             ) &&
-            (identical(other.notes, notes) || other.notes == notes));
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.cancelledBy, cancelledBy) ||
+                other.cancelledBy == cancelledBy) &&
+            (identical(other.cancelledAt, cancelledAt) ||
+                other.cancelledAt == cancelledAt));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     runtimeType,
     id,
     groupId,
@@ -511,7 +551,9 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
     status,
     const DeepCollectionEquality().hash(_participantIds),
     notes,
-  );
+    cancelledBy,
+    cancelledAt,
+  ]);
 
   /// Create a copy of TrainingSessionModel
   /// with the given fields replaced by the non-null parameter values.
@@ -550,6 +592,8 @@ abstract class _TrainingSessionModel extends TrainingSessionModel {
     final TrainingStatus status,
     final List<String> participantIds,
     final String? notes,
+    final String? cancelledBy,
+    @TimestampConverter() final DateTime? cancelledAt,
   }) = _$TrainingSessionModelImpl;
   const _TrainingSessionModel._() : super._();
 
@@ -594,7 +638,12 @@ abstract class _TrainingSessionModel extends TrainingSessionModel {
   @override
   List<String> get participantIds; // Session notes
   @override
-  String? get notes;
+  String? get notes; // Cancellation tracking (Story 15.14)
+  @override
+  String? get cancelledBy;
+  @override
+  @TimestampConverter()
+  DateTime? get cancelledAt;
 
   /// Create a copy of TrainingSessionModel
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/core/data/models/training_session_model.g.dart
+++ b/lib/core/data/models/training_session_model.g.dart
@@ -36,6 +36,8 @@ _$TrainingSessionModelImpl _$$TrainingSessionModelImplFromJson(
           .toList() ??
       const [],
   notes: json['notes'] as String?,
+  cancelledBy: json['cancelledBy'] as String?,
+  cancelledAt: const TimestampConverter().fromJson(json['cancelledAt']),
 );
 
 Map<String, dynamic> _$$TrainingSessionModelImplToJson(
@@ -58,6 +60,8 @@ Map<String, dynamic> _$$TrainingSessionModelImplToJson(
   'status': _$TrainingStatusEnumMap[instance.status]!,
   'participantIds': instance.participantIds,
   'notes': instance.notes,
+  'cancelledBy': instance.cancelledBy,
+  'cancelledAt': const TimestampConverter().toJson(instance.cancelledAt),
 };
 
 const _$TrainingStatusEnumMap = {

--- a/lib/core/domain/repositories/training_session_repository.dart
+++ b/lib/core/domain/repositories/training_session_repository.dart
@@ -121,9 +121,18 @@ abstract class TrainingSessionRepository {
   @Deprecated('Use leaveTrainingSession() instead for atomic operations')
   Future<void> removeParticipant(String sessionId, String userId);
 
-  /// Cancel training session
+  /// Cancel training session (via Cloud Function for permission validation)
   ///
-  /// Only the creator can cancel a training session
+  /// Uses Cloud Function to:
+  /// - Validate user is authenticated
+  /// - Validate user is the session creator (permission check)
+  /// - Set status to 'cancelled' with cancelledBy and cancelledAt tracking
+  ///
+  /// Throws:
+  /// - [Exception] if user is not authenticated
+  /// - [Exception] if user is not the session creator
+  /// - [Exception] if session is already cancelled or completed
+  /// - [Exception] if session not found
   Future<void> cancelTrainingSession(String sessionId);
 
   /// Complete training session

--- a/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_event.dart
+++ b/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_event.dart
@@ -38,3 +38,14 @@ class LeaveTrainingSession extends TrainingSessionParticipationEvent {
   @override
   List<Object?> get props => [sessionId];
 }
+
+/// Event to cancel a training session (Story 15.14)
+/// Only the session creator can cancel
+class CancelTrainingSession extends TrainingSessionParticipationEvent {
+  final String sessionId;
+
+  const CancelTrainingSession(this.sessionId);
+
+  @override
+  List<Object?> get props => [sessionId];
+}

--- a/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_state.dart
+++ b/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_state.dart
@@ -83,6 +83,30 @@ class LeftSession extends TrainingSessionParticipationState {
   List<Object?> get props => [sessionId, message];
 }
 
+/// State when the session is being cancelled (Story 15.14)
+class CancellingSession extends TrainingSessionParticipationState {
+  final String sessionId;
+
+  const CancellingSession(this.sessionId);
+
+  @override
+  List<Object?> get props => [sessionId];
+}
+
+/// State when session has been successfully cancelled (Story 15.14)
+class CancelledSession extends TrainingSessionParticipationState {
+  final String sessionId;
+  final String message;
+
+  const CancelledSession({
+    required this.sessionId,
+    this.message = 'Training session cancelled successfully',
+  });
+
+  @override
+  List<Object?> get props => [sessionId, message];
+}
+
 /// State when an error occurs during participation operations
 class ParticipationError extends TrainingSessionParticipationState {
   final String message;

--- a/test/unit/core/data/models/training_session_model_cancel_test.dart
+++ b/test/unit/core/data/models/training_session_model_cancel_test.dart
@@ -1,0 +1,154 @@
+// Tests for TrainingSessionModel cancel-related functionality (Story 15.14)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
+
+void main() {
+  group('TrainingSessionModel - Cancel functionality', () {
+    late TrainingSessionModel scheduledSession;
+    late TrainingSessionModel completedSession;
+    late TrainingSessionModel cancelledSession;
+
+    const creatorUserId = 'creator-123';
+    const otherUserId = 'other-456';
+
+    setUp(() {
+      scheduledSession = TrainingSessionModel(
+        id: 'session-1',
+        groupId: 'group-1',
+        title: 'Test Training',
+        location: const GameLocation(name: 'Beach Court 1', address: '123 Beach Rd'),
+        startTime: DateTime.now().add(const Duration(days: 1)),
+        endTime: DateTime.now().add(const Duration(days: 1, hours: 2)),
+        minParticipants: 4,
+        maxParticipants: 8,
+        createdBy: creatorUserId,
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        status: TrainingStatus.scheduled,
+        participantIds: ['user1', 'user2'],
+      );
+
+      completedSession = scheduledSession.copyWith(
+        status: TrainingStatus.completed,
+      );
+
+      cancelledSession = scheduledSession.copyWith(
+        status: TrainingStatus.cancelled,
+        cancelledBy: creatorUserId,
+        cancelledAt: DateTime.now(),
+      );
+    });
+
+    group('canUserCancel', () {
+      test('returns true when user is creator and session is scheduled', () {
+        expect(scheduledSession.canUserCancel(creatorUserId), isTrue);
+      });
+
+      test('returns false when user is not the creator', () {
+        expect(scheduledSession.canUserCancel(otherUserId), isFalse);
+      });
+
+      test('returns false when session is already completed', () {
+        expect(completedSession.canUserCancel(creatorUserId), isFalse);
+      });
+
+      test('returns false when session is already cancelled', () {
+        expect(cancelledSession.canUserCancel(creatorUserId), isFalse);
+      });
+
+      test('returns false when user is not creator and session is completed', () {
+        expect(completedSession.canUserCancel(otherUserId), isFalse);
+      });
+
+      test('returns false when user is not creator and session is cancelled', () {
+        expect(cancelledSession.canUserCancel(otherUserId), isFalse);
+      });
+    });
+
+    group('cancelSession', () {
+      test('sets status to cancelled when session is scheduled', () {
+        final result = scheduledSession.cancelSession(creatorUserId);
+
+        expect(result.status, equals(TrainingStatus.cancelled));
+      });
+
+      test('sets cancelledBy to the user who cancelled', () {
+        final result = scheduledSession.cancelSession(creatorUserId);
+
+        expect(result.cancelledBy, equals(creatorUserId));
+      });
+
+      test('sets cancelledAt to current time', () {
+        final before = DateTime.now();
+        final result = scheduledSession.cancelSession(creatorUserId);
+        final after = DateTime.now();
+
+        expect(result.cancelledAt, isNotNull);
+        expect(result.cancelledAt!.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+        expect(result.cancelledAt!.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      });
+
+      test('sets updatedAt to current time', () {
+        final before = DateTime.now();
+        final result = scheduledSession.cancelSession(creatorUserId);
+        final after = DateTime.now();
+
+        expect(result.updatedAt, isNotNull);
+        expect(result.updatedAt!.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+        expect(result.updatedAt!.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      });
+
+      test('returns same session when already completed (no-op)', () {
+        final result = completedSession.cancelSession(creatorUserId);
+
+        // Should return the same session without changes
+        expect(result.status, equals(TrainingStatus.completed));
+        expect(result.cancelledBy, isNull);
+        expect(result.cancelledAt, isNull);
+      });
+
+      test('returns same session when already cancelled (no-op)', () {
+        final originalCancelledAt = cancelledSession.cancelledAt;
+        final result = cancelledSession.cancelSession(creatorUserId);
+
+        // Should return the same session without changes
+        expect(result.status, equals(TrainingStatus.cancelled));
+        expect(result.cancelledAt, equals(originalCancelledAt));
+      });
+
+      test('allows cancellation without userId for system-triggered cancellations', () {
+        final result = scheduledSession.cancelSession();
+
+        expect(result.status, equals(TrainingStatus.cancelled));
+        expect(result.cancelledBy, isNull); // No user specified for system cancellation
+        expect(result.cancelledAt, isNotNull);
+      });
+
+      test('preserves other session properties when cancelling', () {
+        final result = scheduledSession.cancelSession(creatorUserId);
+
+        expect(result.id, equals(scheduledSession.id));
+        expect(result.groupId, equals(scheduledSession.groupId));
+        expect(result.title, equals(scheduledSession.title));
+        expect(result.location, equals(scheduledSession.location));
+        expect(result.startTime, equals(scheduledSession.startTime));
+        expect(result.endTime, equals(scheduledSession.endTime));
+        expect(result.minParticipants, equals(scheduledSession.minParticipants));
+        expect(result.maxParticipants, equals(scheduledSession.maxParticipants));
+        expect(result.createdBy, equals(scheduledSession.createdBy));
+        expect(result.participantIds, equals(scheduledSession.participantIds));
+      });
+    });
+
+    group('isCreator', () {
+      test('returns true for the creator', () {
+        expect(scheduledSession.isCreator(creatorUserId), isTrue);
+      });
+
+      test('returns false for non-creator', () {
+        expect(scheduledSession.isCreator(otherUserId), isFalse);
+      });
+    });
+  });
+}

--- a/test/unit/features/training/presentation/bloc/training_session_participation_bloc_test.dart
+++ b/test/unit/features/training/presentation/bloc/training_session_participation_bloc_test.dart
@@ -375,6 +375,190 @@ void main() {
       );
     });
 
+    // Story 15.14: Cancel Training Session tests
+    group('CancelTrainingSession', () {
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, CancelledSession] when cancel succeeds',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenAnswer((_) async => {});
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const CancelledSession(sessionId: testSessionId),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.cancelTrainingSession(testSessionId))
+              .called(1);
+        },
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with unauthenticated error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'unauthenticated',
+            'Not authenticated',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'You must be logged in to cancel a training session',
+            errorCode: 'unauthenticated',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with permission-denied error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'permission-denied',
+            'Only creator can cancel',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'Only the session creator can cancel this training session',
+            errorCode: 'permission-denied',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with not-found error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'not-found',
+            'Session not found',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'Training session not found',
+            errorCode: 'not-found',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with failed-precondition (already cancelled)',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'failed-precondition',
+            'This training session is already cancelled',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'This training session is already cancelled',
+            errorCode: 'failed-precondition',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with failed-precondition (completed)',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'failed-precondition',
+            'Cannot cancel a completed training session',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'Cannot cancel a completed training session',
+            errorCode: 'failed-precondition',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with internal error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(FakeFirebaseFunctionsException(
+            'internal',
+            'Server error',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'An error occurred. Please try again later',
+            errorCode: 'internal',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with Firestore error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(
+                  FakeFirebaseException('unavailable', 'Service unavailable'));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'Service temporarily unavailable. Please try again',
+            errorCode: 'unavailable',
+          ),
+        ],
+      );
+
+      blocTest<TrainingSessionParticipationBloc,
+          TrainingSessionParticipationState>(
+        'emits [CancellingSession, ParticipationError] when cancel fails with generic error',
+        build: () {
+          when(() => mockRepository.cancelTrainingSession(testSessionId))
+              .thenThrow(Exception('Unknown error'));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const CancelTrainingSession(testSessionId)),
+        expect: () => [
+          const CancellingSession(testSessionId),
+          const ParticipationError(
+            message: 'Unknown error',
+          ),
+        ],
+      );
+    });
+
     group('Error handling', () {
       blocTest<TrainingSessionParticipationBloc,
           TrainingSessionParticipationState>(


### PR DESCRIPTION
## Summary
- Add ability for training session creator to cancel a scheduled session
- Add "Cancel Session" option in app bar menu (visible only to organizer)
- Show confirmation dialog before cancellation
- Track who cancelled and when via cancelledBy/cancelledAt fields
- Participants are automatically notified via existing notification system

## Changes Made
- **Model**: Added `cancelledBy` and `cancelledAt` fields to `TrainingSessionModel`, added `canUserCancel()` method
- **Cloud Function**: Created `cancelTrainingSession` with permission validation (only creator can cancel)
- **Repository**: Updated to call Cloud Function for cancellation with proper error handling
- **BLoC**: Added `CancelTrainingSession` event and `CancellingSession`/`CancelledSession` states
- **UI**: Added cancel button in app bar (PopupMenuButton) for organizer when session is scheduled
- **Tests**: Added 25 unit tests covering BLoC cancel functionality and model cancel methods

## Test Plan
- [x] Cancel button visible only to session creator on scheduled sessions
- [x] Cancel button hidden for completed/cancelled sessions
- [x] Cancel button hidden for non-creators
- [x] Confirmation dialog shown before cancellation
- [x] Session status updated to "cancelled" after confirmation
- [x] Navigation back to previous page after successful cancellation
- [x] Error messages displayed for failed cancellation attempts
- [x] All 1317 unit tests pass

## Closes
Closes #374