### PR TITLE
Story 16.3.2.2: Add FirestoreGameRepository & InvitationModel Unit Tests

### DIFF
--- a/test/unit/core/data/models/invitation_model_test.dart
+++ b/test/unit/core/data/models/invitation_model_test.dart
@@ -1,0 +1,772 @@
+// Tests InvitationModel serialization, status methods, and TimestampConverter.
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/invitation_model.dart';
+
+void main() {
+  group('InvitationModel', () {
+    final testCreatedAt = DateTime(2024, 1, 15, 10, 30);
+    final testRespondedAt = DateTime(2024, 1, 16, 14, 45);
+
+    group('constructor', () {
+      test('creates instance with required fields', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.id, 'inv-123');
+        expect(invitation.groupId, 'group-456');
+        expect(invitation.groupName, 'Beach Volleyball');
+        expect(invitation.invitedBy, 'user-789');
+        expect(invitation.inviterName, 'John Doe');
+        expect(invitation.invitedUserId, 'user-101');
+        expect(invitation.createdAt, testCreatedAt);
+      });
+
+      test('defaults status to pending', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.status, InvitationStatus.pending);
+      });
+
+      test('defaults respondedAt to null', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.respondedAt, isNull);
+      });
+
+      test('creates instance with all fields including optional', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.accepted,
+          createdAt: testCreatedAt,
+          respondedAt: testRespondedAt,
+        );
+
+        expect(invitation.status, InvitationStatus.accepted);
+        expect(invitation.respondedAt, testRespondedAt);
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes JSON with Timestamp for createdAt', () {
+        final json = {
+          'id': 'inv-123',
+          'groupId': 'group-456',
+          'groupName': 'Beach Volleyball',
+          'invitedBy': 'user-789',
+          'inviterName': 'John Doe',
+          'invitedUserId': 'user-101',
+          'status': 'pending',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+        };
+
+        final invitation = InvitationModel.fromJson(json);
+
+        expect(invitation.id, 'inv-123');
+        expect(invitation.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with int timestamp for createdAt', () {
+        final json = {
+          'id': 'inv-123',
+          'groupId': 'group-456',
+          'groupName': 'Beach Volleyball',
+          'invitedBy': 'user-789',
+          'inviterName': 'John Doe',
+          'invitedUserId': 'user-101',
+          'status': 'pending',
+          'createdAt': testCreatedAt.millisecondsSinceEpoch,
+        };
+
+        final invitation = InvitationModel.fromJson(json);
+
+        expect(invitation.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with ISO string for createdAt', () {
+        final json = {
+          'id': 'inv-123',
+          'groupId': 'group-456',
+          'groupName': 'Beach Volleyball',
+          'invitedBy': 'user-789',
+          'inviterName': 'John Doe',
+          'invitedUserId': 'user-101',
+          'status': 'pending',
+          'createdAt': testCreatedAt.toIso8601String(),
+        };
+
+        final invitation = InvitationModel.fromJson(json);
+
+        expect(invitation.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with respondedAt when present', () {
+        final json = {
+          'id': 'inv-123',
+          'groupId': 'group-456',
+          'groupName': 'Beach Volleyball',
+          'invitedBy': 'user-789',
+          'inviterName': 'John Doe',
+          'invitedUserId': 'user-101',
+          'status': 'accepted',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'respondedAt': Timestamp.fromDate(testRespondedAt),
+        };
+
+        final invitation = InvitationModel.fromJson(json);
+
+        expect(invitation.respondedAt, testRespondedAt);
+      });
+
+      test('deserializes all InvitationStatus values', () {
+        for (final status in InvitationStatus.values) {
+          final json = {
+            'id': 'inv-123',
+            'groupId': 'group-456',
+            'groupName': 'Beach Volleyball',
+            'invitedBy': 'user-789',
+            'inviterName': 'John Doe',
+            'invitedUserId': 'user-101',
+            'status': status.name,
+            'createdAt': Timestamp.fromDate(testCreatedAt),
+          };
+
+          final invitation = InvitationModel.fromJson(json);
+          expect(invitation.status, status);
+        }
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all fields to JSON', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final json = invitation.toJson();
+
+        expect(json['id'], 'inv-123');
+        expect(json['groupId'], 'group-456');
+        expect(json['groupName'], 'Beach Volleyball');
+        expect(json['invitedBy'], 'user-789');
+        expect(json['inviterName'], 'John Doe');
+        expect(json['invitedUserId'], 'user-101');
+        expect(json['status'], 'pending');
+      });
+
+      test('converts createdAt to Timestamp', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final json = invitation.toJson();
+
+        expect(json['createdAt'], isA<Timestamp>());
+        expect((json['createdAt'] as Timestamp).toDate(), testCreatedAt);
+      });
+
+      test('converts respondedAt to Timestamp when present', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+          respondedAt: testRespondedAt,
+        );
+
+        final json = invitation.toJson();
+
+        expect(json['respondedAt'], isA<Timestamp>());
+        expect((json['respondedAt'] as Timestamp).toDate(), testRespondedAt);
+      });
+
+      test('respondedAt is null when not set', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final json = invitation.toJson();
+
+        expect(json['respondedAt'], isNull);
+      });
+    });
+
+    group('toFirestore', () {
+      test('excludes id from Firestore data', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final firestoreData = invitation.toFirestore();
+
+        expect(firestoreData.containsKey('id'), isFalse);
+      });
+
+      test('includes all other fields', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final firestoreData = invitation.toFirestore();
+
+        expect(firestoreData['groupId'], 'group-456');
+        expect(firestoreData['groupName'], 'Beach Volleyball');
+        expect(firestoreData['invitedBy'], 'user-789');
+        expect(firestoreData['inviterName'], 'John Doe');
+        expect(firestoreData['invitedUserId'], 'user-101');
+        expect(firestoreData['status'], 'pending');
+        expect(firestoreData['createdAt'], isA<Timestamp>());
+      });
+
+      test('converts DateTime fields to Timestamp', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+          respondedAt: testRespondedAt,
+        );
+
+        final firestoreData = invitation.toFirestore();
+
+        expect(firestoreData['createdAt'], isA<Timestamp>());
+        expect(firestoreData['respondedAt'], isA<Timestamp>());
+        expect(
+          (firestoreData['createdAt'] as Timestamp).toDate(),
+          testCreatedAt,
+        );
+        expect(
+          (firestoreData['respondedAt'] as Timestamp).toDate(),
+          testRespondedAt,
+        );
+      });
+    });
+
+    group('status getters', () {
+      test('isPending returns true when status is pending', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.isPending, isTrue);
+        expect(invitation.isAccepted, isFalse);
+        expect(invitation.isDeclined, isFalse);
+      });
+
+      test('isAccepted returns true when status is accepted', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.accepted,
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.isPending, isFalse);
+        expect(invitation.isAccepted, isTrue);
+        expect(invitation.isDeclined, isFalse);
+      });
+
+      test('isDeclined returns true when status is declined', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.declined,
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation.isPending, isFalse);
+        expect(invitation.isAccepted, isFalse);
+        expect(invitation.isDeclined, isTrue);
+      });
+    });
+
+    group('accept', () {
+      test('returns new invitation with accepted status', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final acceptedInvitation = invitation.accept();
+
+        expect(acceptedInvitation.status, InvitationStatus.accepted);
+        expect(acceptedInvitation.isAccepted, isTrue);
+      });
+
+      test('sets respondedAt to current time', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final before = DateTime.now();
+        final acceptedInvitation = invitation.accept();
+        final after = DateTime.now();
+
+        expect(acceptedInvitation.respondedAt, isNotNull);
+        expect(acceptedInvitation.respondedAt!.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+        expect(acceptedInvitation.respondedAt!.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      });
+
+      test('preserves other fields unchanged', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final acceptedInvitation = invitation.accept();
+
+        expect(acceptedInvitation.id, invitation.id);
+        expect(acceptedInvitation.groupId, invitation.groupId);
+        expect(acceptedInvitation.groupName, invitation.groupName);
+        expect(acceptedInvitation.invitedBy, invitation.invitedBy);
+        expect(acceptedInvitation.inviterName, invitation.inviterName);
+        expect(acceptedInvitation.invitedUserId, invitation.invitedUserId);
+        expect(acceptedInvitation.createdAt, invitation.createdAt);
+      });
+
+      test('does not modify original invitation', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        invitation.accept();
+
+        expect(invitation.status, InvitationStatus.pending);
+        expect(invitation.respondedAt, isNull);
+      });
+    });
+
+    group('decline', () {
+      test('returns new invitation with declined status', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final declinedInvitation = invitation.decline();
+
+        expect(declinedInvitation.status, InvitationStatus.declined);
+        expect(declinedInvitation.isDeclined, isTrue);
+      });
+
+      test('sets respondedAt to current time', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final before = DateTime.now();
+        final declinedInvitation = invitation.decline();
+        final after = DateTime.now();
+
+        expect(declinedInvitation.respondedAt, isNotNull);
+        expect(declinedInvitation.respondedAt!.isAfter(before.subtract(const Duration(seconds: 1))), isTrue);
+        expect(declinedInvitation.respondedAt!.isBefore(after.add(const Duration(seconds: 1))), isTrue);
+      });
+
+      test('preserves other fields unchanged', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final declinedInvitation = invitation.decline();
+
+        expect(declinedInvitation.id, invitation.id);
+        expect(declinedInvitation.groupId, invitation.groupId);
+        expect(declinedInvitation.groupName, invitation.groupName);
+        expect(declinedInvitation.invitedBy, invitation.invitedBy);
+        expect(declinedInvitation.inviterName, invitation.inviterName);
+        expect(declinedInvitation.invitedUserId, invitation.invitedUserId);
+        expect(declinedInvitation.createdAt, invitation.createdAt);
+      });
+
+      test('does not modify original invitation', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        invitation.decline();
+
+        expect(invitation.status, InvitationStatus.pending);
+        expect(invitation.respondedAt, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated id', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final copy = invitation.copyWith(id: 'inv-999');
+
+        expect(copy.id, 'inv-999');
+        expect(copy.groupId, 'group-456');
+      });
+
+      test('creates copy with updated status', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final copy = invitation.copyWith(status: InvitationStatus.declined);
+
+        expect(copy.status, InvitationStatus.declined);
+        expect(copy.id, 'inv-123');
+      });
+
+      test('creates copy with multiple fields updated', () {
+        final invitation = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final copy = invitation.copyWith(
+          groupName: 'Updated Group',
+          status: InvitationStatus.accepted,
+          respondedAt: testRespondedAt,
+        );
+
+        expect(copy.groupName, 'Updated Group');
+        expect(copy.status, InvitationStatus.accepted);
+        expect(copy.respondedAt, testRespondedAt);
+        expect(copy.id, 'inv-123');
+        expect(copy.groupId, 'group-456');
+      });
+    });
+
+    group('equality', () {
+      test('two invitations with same data are equal', () {
+        final invitation1 = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final invitation2 = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation1, invitation2);
+        expect(invitation1.hashCode, invitation2.hashCode);
+      });
+
+      test('two invitations with different data are not equal', () {
+        final invitation1 = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        final invitation2 = InvitationModel(
+          id: 'inv-999',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation1, isNot(invitation2));
+      });
+
+      test('invitations with different status are not equal', () {
+        final invitation1 = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.pending,
+          createdAt: testCreatedAt,
+        );
+
+        final invitation2 = InvitationModel(
+          id: 'inv-123',
+          groupId: 'group-456',
+          groupName: 'Beach Volleyball',
+          invitedBy: 'user-789',
+          inviterName: 'John Doe',
+          invitedUserId: 'user-101',
+          status: InvitationStatus.accepted,
+          createdAt: testCreatedAt,
+        );
+
+        expect(invitation1, isNot(invitation2));
+      });
+    });
+  });
+
+  group('InvitationStatus', () {
+    test('has three values', () {
+      expect(InvitationStatus.values.length, 3);
+    });
+
+    test('values are pending, accepted, declined', () {
+      expect(InvitationStatus.values, contains(InvitationStatus.pending));
+      expect(InvitationStatus.values, contains(InvitationStatus.accepted));
+      expect(InvitationStatus.values, contains(InvitationStatus.declined));
+    });
+
+    test('pending has index 0', () {
+      expect(InvitationStatus.pending.index, 0);
+    });
+
+    test('accepted has index 1', () {
+      expect(InvitationStatus.accepted.index, 1);
+    });
+
+    test('declined has index 2', () {
+      expect(InvitationStatus.declined.index, 2);
+    });
+  });
+
+  group('TimestampConverter', () {
+    const converter = TimestampConverter();
+    final testDate = DateTime(2024, 6, 15, 12, 30, 45);
+
+    group('fromJson', () {
+      test('converts Timestamp to DateTime', () {
+        final timestamp = Timestamp.fromDate(testDate);
+        final result = converter.fromJson(timestamp);
+        expect(result, testDate);
+      });
+
+      test('converts int milliseconds to DateTime', () {
+        final millis = testDate.millisecondsSinceEpoch;
+        final result = converter.fromJson(millis);
+        expect(result, testDate);
+      });
+
+      test('converts ISO string to DateTime', () {
+        final isoString = testDate.toIso8601String();
+        final result = converter.fromJson(isoString);
+        expect(result, testDate);
+      });
+
+      test('throws exception for unknown type', () {
+        expect(
+          () => converter.fromJson(12.34),
+          throwsA(isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Unknown type for timestamp'),
+          )),
+        );
+      });
+
+      test('throws exception for list type', () {
+        expect(
+          () => converter.fromJson([1, 2, 3]),
+          throwsA(isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Unknown type for timestamp'),
+          )),
+        );
+      });
+
+      test('throws exception for map type', () {
+        expect(
+          () => converter.fromJson({'key': 'value'}),
+          throwsA(isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Unknown type for timestamp'),
+          )),
+        );
+      });
+    });
+
+    group('toJson', () {
+      test('converts DateTime to Timestamp', () {
+        final result = converter.toJson(testDate);
+        expect(result, isA<Timestamp>());
+        expect((result as Timestamp).toDate(), testDate);
+      });
+
+      test('preserves millisecond precision', () {
+        final dateWithMillis = DateTime(2024, 6, 15, 12, 30, 45, 123);
+        final result = converter.toJson(dateWithMillis);
+        expect((result as Timestamp).toDate(), dateWithMillis);
+      });
+    });
+
+    group('round trip', () {
+      test('fromJson and toJson are inverse operations', () {
+        final original = DateTime(2024, 12, 25, 18, 30, 0);
+        final timestamp = converter.toJson(original);
+        final restored = converter.fromJson(timestamp);
+        expect(restored, original);
+      });
+    });
+  });
+}

--- a/test/unit/core/data/repositories/firestore_game_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_game_repository_test.dart
@@ -1,0 +1,1314 @@
+// Tests FirestoreGameRepository methods with fake Firestore
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/repositories/firestore_game_repository.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+
+void main() {
+  group('FirestoreGameRepository', () {
+    late FakeFirebaseFirestore fakeFirestore;
+    late FirestoreGameRepository repository;
+
+    GameModel createTestGame({
+      String id = '',
+      String title = 'Test Game',
+      String groupId = 'group-123',
+      String createdBy = 'user-123',
+      DateTime? createdAt,
+      DateTime? scheduledAt,
+      GameStatus status = GameStatus.scheduled,
+      List<String> playerIds = const [],
+      List<String> waitlistIds = const [],
+      int maxPlayers = 4,
+      int minPlayers = 2,
+    }) {
+      return GameModel(
+        id: id,
+        title: title,
+        groupId: groupId,
+        createdBy: createdBy,
+        createdAt: createdAt ?? DateTime(2024, 1, 1),
+        scheduledAt: scheduledAt ?? DateTime.now().add(const Duration(days: 1)),
+        location: const GameLocation(name: 'Beach Court'),
+        status: status,
+        playerIds: playerIds,
+        waitlistIds: waitlistIds,
+        maxPlayers: maxPlayers,
+        minPlayers: minPlayers,
+      );
+    }
+
+    setUp(() {
+      fakeFirestore = FakeFirebaseFirestore();
+      repository = FirestoreGameRepository(firestore: fakeFirestore);
+    });
+
+    group('constructor', () {
+      test('creates repository with custom Firestore instance', () {
+        final customFirestore = FakeFirebaseFirestore();
+        final repo = FirestoreGameRepository(firestore: customFirestore);
+        expect(repo, isNotNull);
+      });
+
+      // Note: Cannot test default Firestore without Firebase.initializeApp()
+      // The default constructor uses FirebaseFirestore.instance which requires
+      // Firebase to be initialized. This is tested in integration tests.
+    });
+
+    group('createGame', () {
+      test('creates game successfully and returns document ID', () async {
+        final testGame = createTestGame();
+
+        final gameId = await repository.createGame(testGame);
+
+        expect(gameId, isNotEmpty);
+        final doc = await fakeFirestore.collection('games').doc(gameId).get();
+        expect(doc.exists, true);
+        expect(doc.data()!['title'], 'Test Game');
+        expect(doc.data()!['groupId'], 'group-123');
+        expect(doc.data()!['createdBy'], 'user-123');
+      });
+
+      test('creates game without id field in Firestore document', () async {
+        final testGame = createTestGame(id: 'should-be-ignored');
+
+        final gameId = await repository.createGame(testGame);
+
+        final doc = await fakeFirestore.collection('games').doc(gameId).get();
+        expect(doc.data()!.containsKey('id'), false);
+      });
+
+      test('creates game with all fields', () async {
+        final testGame = GameModel(
+          id: '',
+          title: 'Full Game',
+          description: 'A complete game',
+          groupId: 'group-123',
+          createdBy: 'user-123',
+          createdAt: DateTime(2024, 1, 1),
+          scheduledAt: DateTime(2024, 2, 1),
+          location: const GameLocation(
+            name: 'Beach Court',
+            address: '123 Beach St',
+            latitude: 34.0,
+            longitude: -118.0,
+          ),
+          status: GameStatus.scheduled,
+          maxPlayers: 8,
+          minPlayers: 4,
+          playerIds: const ['user-123', 'user-456'],
+          allowWaitlist: true,
+          notes: 'Bring sunscreen',
+          equipment: const ['Ball', 'Net'],
+        );
+
+        final gameId = await repository.createGame(testGame);
+
+        final doc = await fakeFirestore.collection('games').doc(gameId).get();
+        final data = doc.data()!;
+        expect(data['description'], 'A complete game');
+        expect(data['maxPlayers'], 8);
+        expect(data['minPlayers'], 4);
+        expect(data['playerIds'], ['user-123', 'user-456']);
+        expect(data['notes'], 'Bring sunscreen');
+        expect(data['equipment'], ['Ball', 'Net']);
+      });
+    });
+
+    group('getGameById', () {
+      test('returns game when it exists', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        final retrievedGame = await repository.getGameById(gameId);
+
+        expect(retrievedGame, isNotNull);
+        expect(retrievedGame!.id, gameId);
+        expect(retrievedGame.title, 'Test Game');
+        expect(retrievedGame.groupId, 'group-123');
+      });
+
+      test('returns null when game does not exist', () async {
+        final game = await repository.getGameById('non-existent-id');
+        expect(game, isNull);
+      });
+    });
+
+    group('getGamesByIds', () {
+      test('returns empty list when gameIds is empty', () async {
+        final games = await repository.getGamesByIds([]);
+        expect(games, isEmpty);
+      });
+
+      test('returns games for valid IDs', () async {
+        final game1 = createTestGame(title: 'Game 1');
+        final game2 = createTestGame(title: 'Game 2');
+        final id1 = await repository.createGame(game1);
+        final id2 = await repository.createGame(game2);
+
+        final games = await repository.getGamesByIds([id1, id2]);
+
+        expect(games.length, 2);
+        expect(games.any((g) => g.title == 'Game 1'), true);
+        expect(games.any((g) => g.title == 'Game 2'), true);
+      });
+
+      test('handles more than 10 IDs by batching', () async {
+        final gameIds = <String>[];
+        for (int i = 0; i < 15; i++) {
+          final game = createTestGame(title: 'Game $i');
+          final id = await repository.createGame(game);
+          gameIds.add(id);
+        }
+
+        final games = await repository.getGamesByIds(gameIds);
+
+        expect(games.length, 15);
+      });
+
+      test('ignores non-existent IDs', () async {
+        final game = createTestGame(title: 'Existing Game');
+        final existingId = await repository.createGame(game);
+
+        final games =
+            await repository.getGamesByIds([existingId, 'non-existent-id']);
+
+        expect(games.length, 1);
+        expect(games.first.title, 'Existing Game');
+      });
+    });
+
+    group('getGamesForUser', () {
+      test('returns stream of games for user', () async {
+        final game1 = createTestGame(
+          title: 'User Game',
+          playerIds: const ['user-123', 'user-456'],
+        );
+        final game2 = createTestGame(
+          title: 'Other Game',
+          playerIds: const ['user-789'],
+        );
+        await repository.createGame(game1);
+        await repository.createGame(game2);
+
+        final stream = repository.getGamesForUser('user-123');
+        final games = await stream.first;
+
+        expect(games.length, 1);
+        expect(games.first.title, 'User Game');
+      });
+
+      test('returns empty list when user has no games', () async {
+        final game = createTestGame(playerIds: const ['other-user']);
+        await repository.createGame(game);
+
+        final stream = repository.getGamesForUser('user-123');
+        final games = await stream.first;
+
+        expect(games, isEmpty);
+      });
+    });
+
+    group('getGamesForGroup', () {
+      test('returns stream of games for group', () async {
+        final game1 = createTestGame(title: 'Group Game', groupId: 'group-123');
+        final game2 =
+            createTestGame(title: 'Other Group', groupId: 'group-456');
+        await repository.createGame(game1);
+        await repository.createGame(game2);
+
+        final stream = repository.getGamesForGroup('group-123');
+        final games = await stream.first;
+
+        expect(games.length, 1);
+        expect(games.first.title, 'Group Game');
+      });
+
+      test('returns empty list when group has no games', () async {
+        final game = createTestGame(groupId: 'other-group');
+        await repository.createGame(game);
+
+        final stream = repository.getGamesForGroup('group-123');
+        final games = await stream.first;
+
+        expect(games, isEmpty);
+      });
+    });
+
+    group('updateGameInfo', () {
+      test('updates game info successfully', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        await repository.updateGameInfo(
+          gameId,
+          title: 'Updated Title',
+          description: 'New description',
+          notes: 'Updated notes',
+        );
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.title, 'Updated Title');
+        expect(updatedGame.description, 'New description');
+        expect(updatedGame.notes, 'Updated notes');
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.updateGameInfo('non-existent', title: 'New Title'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('updates location', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        await repository.updateGameInfo(
+          gameId,
+          location: const GameLocation(
+            name: 'New Court',
+            address: '456 New St',
+          ),
+        );
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.location.name, 'New Court');
+        expect(updatedGame.location.address, '456 New St');
+      });
+    });
+
+    group('updateGameSettings', () {
+      test('updates game settings successfully', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        await repository.updateGameSettings(
+          gameId,
+          maxPlayers: 10,
+          minPlayers: 4,
+          allowWaitlist: false,
+        );
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.maxPlayers, 10);
+        expect(updatedGame.minPlayers, 4);
+        expect(updatedGame.allowWaitlist, false);
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.updateGameSettings('non-existent', maxPlayers: 10),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('updates visibility and game type', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        await repository.updateGameSettings(
+          gameId,
+          visibility: GameVisibility.public,
+          gameType: GameType.beachVolleyball,
+          skillLevel: GameSkillLevel.advanced,
+        );
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.visibility, GameVisibility.public);
+        expect(updatedGame.gameType, GameType.beachVolleyball);
+        expect(updatedGame.skillLevel, GameSkillLevel.advanced);
+      });
+    });
+
+    group('addPlayer', () {
+      test('adds player to game', () async {
+        final testGame = createTestGame(playerIds: const ['user-123']);
+        final gameId = await repository.createGame(testGame);
+
+        await repository.addPlayer(gameId, 'user-456');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.playerIds, contains('user-456'));
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.addPlayer('non-existent', 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('adds player to waitlist when game is full', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2', 'user-3', 'user-4'],
+          maxPlayers: 4,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.addPlayer(gameId, 'user-5');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.waitlistIds, contains('user-5'));
+        expect(updatedGame.playerIds, isNot(contains('user-5')));
+      });
+
+      test('does not add player if already in game', () async {
+        final testGame = createTestGame(playerIds: const ['user-123']);
+        final gameId = await repository.createGame(testGame);
+
+        await repository.addPlayer(gameId, 'user-123');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(
+            updatedGame!.playerIds.where((id) => id == 'user-123').length, 1);
+      });
+    });
+
+    group('removePlayer', () {
+      test('removes player from game', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-123', 'user-456'],
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.removePlayer(gameId, 'user-456');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.playerIds, isNot(contains('user-456')));
+        expect(updatedGame.playerIds, contains('user-123'));
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.removePlayer('non-existent', 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('promotes waitlisted player when spot opens', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2', 'user-3', 'user-4'],
+          waitlistIds: const ['user-5'],
+          maxPlayers: 4,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.removePlayer(gameId, 'user-1');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.playerIds, contains('user-5'));
+        expect(updatedGame.waitlistIds, isNot(contains('user-5')));
+      });
+    });
+
+    group('startGame', () {
+      test('starts game successfully', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2'],
+          minPlayers: 2,
+          status: GameStatus.scheduled,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.startGame(gameId);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.inProgress);
+        expect(updatedGame.startedAt, isNotNull);
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.startGame('non-existent'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('does not start game without minimum players', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1'],
+          minPlayers: 2,
+          status: GameStatus.scheduled,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.startGame(gameId);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.scheduled);
+      });
+    });
+
+    group('endGame', () {
+      test('ends game successfully', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2'],
+          status: GameStatus.inProgress,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.endGame(gameId, winnerId: 'user-1');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.completed);
+        expect(updatedGame.winnerId, 'user-1');
+        expect(updatedGame.endedAt, isNotNull);
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.endGame('non-existent'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('does not end game if not in progress', () async {
+        final testGame = createTestGame(status: GameStatus.scheduled);
+        final gameId = await repository.createGame(testGame);
+
+        await repository.endGame(gameId);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.scheduled);
+      });
+
+      test('ends game with final scores', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2'],
+          status: GameStatus.inProgress,
+        );
+        final gameId = await repository.createGame(testGame);
+        final scores = [
+          const GameScore(playerId: 'user-1', score: 21),
+          const GameScore(playerId: 'user-2', score: 15),
+        ];
+
+        await repository.endGame(gameId, finalScores: scores);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.scores.length, 2);
+      });
+    });
+
+    group('cancelGame', () {
+      test('cancels game successfully', () async {
+        final testGame = createTestGame(status: GameStatus.scheduled);
+        final gameId = await repository.createGame(testGame);
+
+        await repository.cancelGame(gameId);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.cancelled);
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.cancelGame('non-existent'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('does not cancel already completed game', () async {
+        final testGame = createTestGame(status: GameStatus.completed);
+        final gameId = await repository.createGame(testGame);
+
+        await repository.cancelGame(gameId);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.completed);
+      });
+    });
+
+    group('markGameAsCompleted', () {
+      test('marks game as completed when user is creator', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          status: GameStatus.inProgress,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await repository.markGameAsCompleted(gameId, 'user-123');
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.status, GameStatus.completed);
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.markGameAsCompleted('non-existent', 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('throws GameException when user is not creator', () async {
+        final testGame = createTestGame(createdBy: 'user-123');
+        final gameId = await repository.createGame(testGame);
+
+        await expectLater(
+          repository.markGameAsCompleted(gameId, 'user-456'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'permission-denied',
+          )),
+        );
+      });
+
+      test('throws GameException when game already completed', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          status: GameStatus.completed,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await expectLater(
+          repository.markGameAsCompleted(gameId, 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'already-completed',
+          )),
+        );
+      });
+
+      test('throws GameException when game is cancelled', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          status: GameStatus.cancelled,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        await expectLater(
+          repository.markGameAsCompleted(gameId, 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'invalid-state',
+          )),
+        );
+      });
+    });
+
+    group('updateGameTeams', () {
+      test('updates teams when user is participant', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2', 'user-3', 'user-4'],
+          status: GameStatus.scheduled,
+        );
+        final gameId = await repository.createGame(testGame);
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1', 'user-2'],
+          teamBPlayerIds: ['user-3', 'user-4'],
+        );
+
+        await repository.updateGameTeams(gameId, 'user-123', teams);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.teams, isNotNull);
+        expect(updatedGame.teams!.teamAPlayerIds, ['user-1', 'user-2']);
+        expect(updatedGame.teams!.teamBPlayerIds, ['user-3', 'user-4']);
+      });
+
+      test('throws GameException when game not found', () async {
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-2'],
+        );
+
+        await expectLater(
+          repository.updateGameTeams('non-existent', 'user-123', teams),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('throws GameException when user is not participant or creator',
+          () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2'],
+        );
+        final gameId = await repository.createGame(testGame);
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-2'],
+        );
+
+        await expectLater(
+          repository.updateGameTeams(gameId, 'user-999', teams),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'permission-denied',
+          )),
+        );
+      });
+
+      test('throws GameException when player on both teams', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2'],
+        );
+        final gameId = await repository.createGame(testGame);
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-1', 'user-2'],
+        );
+
+        await expectLater(
+          repository.updateGameTeams(gameId, 'user-123', teams),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'invalid-argument',
+          )),
+        );
+      });
+
+      test('throws GameException when not all players assigned', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2', 'user-3', 'user-4'],
+        );
+        final gameId = await repository.createGame(testGame);
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-2'],
+        );
+
+        await expectLater(
+          repository.updateGameTeams(gameId, 'user-123', teams),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'invalid-argument',
+          )),
+        );
+      });
+
+      test('throws GameException when game is cancelled', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2'],
+          status: GameStatus.cancelled,
+        );
+        final gameId = await repository.createGame(testGame);
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-2'],
+        );
+
+        await expectLater(
+          repository.updateGameTeams(gameId, 'user-123', teams),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'invalid-state',
+          )),
+        );
+      });
+    });
+
+    group('updateScores', () {
+      test('updates scores successfully', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2'],
+          status: GameStatus.inProgress,
+        );
+        final gameId = await repository.createGame(testGame);
+        final scores = [
+          const GameScore(playerId: 'user-1', score: 10),
+          const GameScore(playerId: 'user-2', score: 8),
+        ];
+
+        await repository.updateScores(gameId, scores);
+
+        final updatedGame = await repository.getGameById(gameId);
+        expect(updatedGame!.scores.length, 2);
+      });
+
+      test('throws GameException when game not found', () async {
+        final scores = [const GameScore(playerId: 'user-1', score: 10)];
+
+        await expectLater(
+          repository.updateScores('non-existent', scores),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+    });
+
+    group('getGamesByStatus', () {
+      test('returns games with matching status', () async {
+        final scheduledGame =
+            createTestGame(title: 'Scheduled', status: GameStatus.scheduled);
+        final completedGame =
+            createTestGame(title: 'Completed', status: GameStatus.completed);
+        await repository.createGame(scheduledGame);
+        await repository.createGame(completedGame);
+
+        final games = await repository.getGamesByStatus(GameStatus.scheduled);
+
+        expect(games.length, 1);
+        expect(games.first.title, 'Scheduled');
+      });
+
+      test('returns empty list when no games match status', () async {
+        final game = createTestGame(status: GameStatus.scheduled);
+        await repository.createGame(game);
+
+        final games = await repository.getGamesByStatus(GameStatus.cancelled);
+
+        expect(games, isEmpty);
+      });
+
+      test('respects limit parameter', () async {
+        for (int i = 0; i < 5; i++) {
+          final game = createTestGame(
+            title: 'Game $i',
+            status: GameStatus.scheduled,
+          );
+          await repository.createGame(game);
+        }
+
+        final games =
+            await repository.getGamesByStatus(GameStatus.scheduled, limit: 3);
+
+        expect(games.length, 3);
+      });
+    });
+
+    group('searchGames', () {
+      test('returns empty list for empty query', () async {
+        final game = createTestGame(title: 'Beach Volleyball');
+        await repository.createGame(game);
+
+        final results = await repository.searchGames('');
+
+        expect(results, isEmpty);
+      });
+
+      test('returns empty list for whitespace query', () async {
+        final game = createTestGame(title: 'Beach Volleyball');
+        await repository.createGame(game);
+
+        final results = await repository.searchGames('   ');
+
+        expect(results, isEmpty);
+      });
+
+      test('finds games by title', () async {
+        final game1 = createTestGame(title: 'beach volleyball');
+        final game2 = createTestGame(title: 'soccer game');
+        await repository.createGame(game1);
+        await repository.createGame(game2);
+
+        final results = await repository.searchGames('beach');
+
+        expect(results.length, 1);
+        expect(results.first.title, 'beach volleyball');
+      });
+    });
+
+    group('getGameParticipants', () {
+      test('returns participants for existing game', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2', 'user-3'],
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final participants = await repository.getGameParticipants(gameId);
+
+        expect(participants, ['user-1', 'user-2', 'user-3']);
+      });
+
+      test('returns empty list when game does not exist', () async {
+        final participants =
+            await repository.getGameParticipants('non-existent');
+        expect(participants, isEmpty);
+      });
+    });
+
+    group('getGameWaitlist', () {
+      test('returns waitlist for existing game', () async {
+        final testGame = createTestGame(
+          waitlistIds: const ['user-5', 'user-6'],
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final waitlist = await repository.getGameWaitlist(gameId);
+
+        expect(waitlist, ['user-5', 'user-6']);
+      });
+
+      test('returns empty list when game does not exist', () async {
+        final waitlist = await repository.getGameWaitlist('non-existent');
+        expect(waitlist, isEmpty);
+      });
+    });
+
+    group('canUserJoinGame', () {
+      test('returns true when user can join', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1'],
+          maxPlayers: 4,
+          status: GameStatus.scheduled,
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final canJoin = await repository.canUserJoinGame(gameId, 'user-2');
+
+        expect(canJoin, true);
+      });
+
+      test('returns false when game does not exist', () async {
+        final canJoin =
+            await repository.canUserJoinGame('non-existent', 'user-1');
+        expect(canJoin, false);
+      });
+
+      test('returns false when user already in game', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1'],
+          maxPlayers: 4,
+          status: GameStatus.scheduled,
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final canJoin = await repository.canUserJoinGame(gameId, 'user-1');
+
+        expect(canJoin, false);
+      });
+
+      test('returns false when game is not scheduled', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1'],
+          maxPlayers: 4,
+          status: GameStatus.cancelled,
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final canJoin = await repository.canUserJoinGame(gameId, 'user-2');
+
+        expect(canJoin, false);
+      });
+    });
+
+    group('deleteGame', () {
+      test('deletes game successfully', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        await repository.deleteGame(gameId);
+
+        final deletedGame = await repository.getGameById(gameId);
+        expect(deletedGame, isNull);
+      });
+
+      test('does not throw when deleting non-existent game', () async {
+        await expectLater(
+          repository.deleteGame('non-existent'),
+          completes,
+        );
+      });
+    });
+
+    group('gameExists', () {
+      test('returns true when game exists', () async {
+        final testGame = createTestGame();
+        final gameId = await repository.createGame(testGame);
+
+        final exists = await repository.gameExists(gameId);
+
+        expect(exists, true);
+      });
+
+      test('returns false when game does not exist', () async {
+        final exists = await repository.gameExists('non-existent');
+        expect(exists, false);
+      });
+    });
+
+    group('getGameStats', () {
+      test('returns stats for existing game', () async {
+        final testGame = createTestGame(
+          playerIds: const ['user-1', 'user-2'],
+          waitlistIds: const ['user-3'],
+          maxPlayers: 4,
+          minPlayers: 2,
+          status: GameStatus.scheduled,
+        );
+        final gameId = await repository.createGame(testGame);
+
+        final stats = await repository.getGameStats(gameId);
+
+        expect(stats['currentPlayerCount'], 2);
+        expect(stats['availableSpots'], 2);
+        expect(stats['waitlistCount'], 1);
+        expect(stats['isFull'], false);
+        expect(stats['hasMinimumPlayers'], true);
+        expect(stats['status'], 'scheduled');
+      });
+
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.getGameStats('non-existent'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+    });
+
+    group('getGameStream', () {
+      test('returns stream of game updates', () async {
+        final testGame = createTestGame(title: 'Original Title');
+        final gameId = await repository.createGame(testGame);
+
+        final stream = repository.getGameStream(gameId);
+        final firstGame = await stream.first;
+
+        expect(firstGame, isNotNull);
+        expect(firstGame!.title, 'Original Title');
+      });
+
+      test('returns null for non-existent game', () async {
+        final stream = repository.getGameStream('non-existent');
+        final game = await stream.first;
+
+        expect(game, isNull);
+      });
+    });
+
+    group('getGamesToday', () {
+      test('returns games scheduled for today', () async {
+        final now = DateTime.now();
+        final todayGame = createTestGame(
+          title: 'Today Game',
+          scheduledAt:
+              DateTime(now.year, now.month, now.day, 14, 0), // Today at 2pm
+        );
+        final tomorrowGame = createTestGame(
+          title: 'Tomorrow Game',
+          scheduledAt: DateTime(now.year, now.month, now.day)
+              .add(const Duration(days: 1, hours: 10)),
+        );
+        await repository.createGame(todayGame);
+        await repository.createGame(tomorrowGame);
+
+        final games = await repository.getGamesToday();
+
+        expect(games.length, 1);
+        expect(games.first.title, 'Today Game');
+      });
+    });
+
+    group('getGamesThisWeek', () {
+      test('returns games scheduled for this week', () async {
+        final now = DateTime.now();
+        // Calculate start of current week (Monday)
+        final startOfWeek = now.subtract(Duration(days: now.weekday - 1));
+
+        final thisWeekGame = createTestGame(
+          title: 'This Week Game',
+          scheduledAt: startOfWeek.add(const Duration(days: 2, hours: 10)),
+        );
+        final nextWeekGame = createTestGame(
+          title: 'Next Week Game',
+          scheduledAt: startOfWeek.add(const Duration(days: 10)),
+        );
+        await repository.createGame(thisWeekGame);
+        await repository.createGame(nextWeekGame);
+
+        final games = await repository.getGamesThisWeek();
+
+        expect(games.any((g) => g.title == 'This Week Game'), true);
+        expect(games.any((g) => g.title == 'Next Week Game'), false);
+      });
+    });
+
+    group('getGamesByLocation', () {
+      test('returns games within radius', () async {
+        final nearbyGame = GameModel(
+          id: '',
+          title: 'Nearby Game',
+          groupId: 'group-123',
+          createdBy: 'user-123',
+          createdAt: DateTime(2024, 1, 1),
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+          location: const GameLocation(
+            name: 'Beach Court',
+            latitude: 34.0195,
+            longitude: -118.4912,
+          ),
+        );
+        final farGame = GameModel(
+          id: '',
+          title: 'Far Game',
+          groupId: 'group-123',
+          createdBy: 'user-123',
+          createdAt: DateTime(2024, 1, 1),
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+          location: const GameLocation(
+            name: 'Mountain Court',
+            latitude: 40.0,
+            longitude: -100.0,
+          ),
+        );
+        await repository.createGame(nearbyGame);
+        await repository.createGame(farGame);
+
+        final games = await repository.getGamesByLocation(
+          34.0, // Search near Santa Monica
+          -118.5,
+          50, // 50km radius
+        );
+
+        expect(games.any((g) => g.title == 'Nearby Game'), true);
+        expect(games.any((g) => g.title == 'Far Game'), false);
+      });
+
+      test('excludes games without coordinates', () async {
+        final gameWithCoords = GameModel(
+          id: '',
+          title: 'Has Coords',
+          groupId: 'group-123',
+          createdBy: 'user-123',
+          createdAt: DateTime(2024, 1, 1),
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+          location: const GameLocation(
+            name: 'Beach Court',
+            latitude: 34.0195,
+            longitude: -118.4912,
+          ),
+        );
+        final gameWithoutCoords = GameModel(
+          id: '',
+          title: 'No Coords',
+          groupId: 'group-123',
+          createdBy: 'user-123',
+          createdAt: DateTime(2024, 1, 1),
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+          location: const GameLocation(name: 'Unknown Location'),
+        );
+        await repository.createGame(gameWithCoords);
+        await repository.createGame(gameWithoutCoords);
+
+        final games = await repository.getGamesByLocation(34.0, -118.5, 50);
+
+        expect(games.any((g) => g.title == 'Has Coords'), true);
+        expect(games.any((g) => g.title == 'No Coords'), false);
+      });
+    });
+
+    group('getPastGamesForUser', () {
+      test('returns past games for user', () async {
+        final pastGame = createTestGame(
+          title: 'Past Game',
+          playerIds: const ['user-123'],
+          scheduledAt: DateTime.now().subtract(const Duration(days: 1)),
+        );
+        final futureGame = createTestGame(
+          title: 'Future Game',
+          playerIds: const ['user-123'],
+          scheduledAt: DateTime.now().add(const Duration(days: 1)),
+        );
+        await repository.createGame(pastGame);
+        await repository.createGame(futureGame);
+
+        final games = await repository.getPastGamesForUser('user-123');
+
+        expect(games.any((g) => g.title == 'Past Game'), true);
+        expect(games.any((g) => g.title == 'Future Game'), false);
+      });
+
+      test('respects limit parameter', () async {
+        for (int i = 0; i < 5; i++) {
+          final game = createTestGame(
+            title: 'Past Game $i',
+            playerIds: const ['user-123'],
+            scheduledAt:
+                DateTime.now().subtract(Duration(days: i + 1)),
+          );
+          await repository.createGame(game);
+        }
+
+        final games =
+            await repository.getPastGamesForUser('user-123', limit: 3);
+
+        expect(games.length, 3);
+      });
+    });
+
+    group('updateGameResult', () {
+      test('throws GameException when game not found', () async {
+        const result = GameResult(
+          games: [],
+          overallWinner: 'teamA',
+        );
+
+        await expectLater(
+          repository.updateGameResult('non-existent', 'user-123', result),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+
+      test('throws GameException when user is not participant or creator',
+          () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-1', 'user-2'],
+        );
+        final gameId = await repository.createGame(testGame);
+        const result = GameResult(
+          games: [],
+          overallWinner: 'teamA',
+        );
+
+        await expectLater(
+          repository.updateGameResult(gameId, 'user-999', result),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'permission-denied',
+          )),
+        );
+      });
+
+      test('throws GameException when game is cancelled', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-123'],
+          status: GameStatus.cancelled,
+        );
+        final gameId = await repository.createGame(testGame);
+        const result = GameResult(
+          games: [],
+          overallWinner: 'teamA',
+        );
+
+        await expectLater(
+          repository.updateGameResult(gameId, 'user-123', result),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'invalid-state',
+          )),
+        );
+      });
+
+      test('throws GameException when teams not assigned', () async {
+        final testGame = createTestGame(
+          createdBy: 'user-123',
+          playerIds: const ['user-123'],
+          status: GameStatus.inProgress,
+        );
+        final gameId = await repository.createGame(testGame);
+        const result = GameResult(
+          games: [],
+          overallWinner: 'teamA',
+        );
+
+        await expectLater(
+          repository.updateGameResult(gameId, 'user-123', result),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'failed-precondition',
+          )),
+        );
+      });
+    });
+
+    group('confirmGameResult', () {
+      test('throws GameException when game not found', () async {
+        await expectLater(
+          repository.confirmGameResult('non-existent', 'user-123'),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+    });
+
+    group('saveGameResult', () {
+      test('throws GameException when game not found', () async {
+        const teams = GameTeams(
+          teamAPlayerIds: ['user-1'],
+          teamBPlayerIds: ['user-2'],
+        );
+        const result = GameResult(
+          games: [],
+          overallWinner: 'teamA',
+        );
+
+        await expectLater(
+          repository.saveGameResult(
+            gameId: 'non-existent',
+            userId: 'user-123',
+            teams: teams,
+            result: result,
+          ),
+          throwsA(isA<GameException>().having(
+            (e) => e.code,
+            'code',
+            'not-found',
+          )),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add comprehensive **InvitationModel unit tests** (47 tests) covering:
  - Constructor with required/optional fields and defaults
  - JSON serialization with Timestamp handling (Firestore Timestamps, int, ISO strings)
  - `toFirestore()` method properly excludes id field
  - Status getters (`isPending`, `isAccepted`, `isDeclined`)
  - `accept()` and `decline()` methods with immutability verification
  - `copyWith()` and equality testing
  - `TimestampConverter` edge cases and error handling

- Add comprehensive **FirestoreGameRepository unit tests** (84 tests) covering:
  - CRUD operations: `createGame`, `getGameById`, `getGamesByIds`
  - Stream-based queries: `getGamesForUser`, `getGamesForGroup`
  - Update operations: `updateGameInfo`, `updateGameSettings`
  - Player management: `addPlayer`, `removePlayer` with waitlist promotion
  - Game lifecycle: `startGame`, `endGame`, `cancelGame`
  - Permission checks: `markGameAsCompleted`, `updateGameTeams`
  - Validation: Teams assignment, player on both teams detection
  - Utility methods: `canUserJoinGame`, `deleteGame`, `gameExists`, `getGameStats`
  - Query methods: `searchGames`, `getGamesByStatus`, `getGamesToday`, `getGamesThisWeek`, `getGamesByLocation`
  - Error handling with `GameException`

## Test Plan

- [x] Run `flutter test test/unit/core/data/models/invitation_model_test.dart` - 47 tests pass
- [x] Run `flutter test test/unit/core/data/repositories/firestore_game_repository_test.dart` - 84 tests pass
- [x] Run `flutter test test/unit/` - All 1642 unit tests pass
- [x] Verify no test regressions

## Related Issue

Closes #399

---

Authored-by: Babas10 <etienne.dubois91@gmail.com>