### PR TITLE
Story 16.3.2.5 & 16.3.2.6: Add Group Pages Widget Tests and Creation Flow Integration Tests

### DIFF
--- a/integration_test/game_creation_flow_test.dart
+++ b/integration_test/game_creation_flow_test.dart
@@ -1,0 +1,387 @@
+// Integration test for game creation flow
+// Tests real Firebase Firestore interactions using Firebase Emulator
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/firebase_emulator_helper.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await FirebaseEmulatorHelper.initialize();
+  });
+
+  setUp(() async {
+    await FirebaseEmulatorHelper.clearFirestore();
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  tearDown(() async {
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  group('Game Creation Flow', () {
+    late String groupId;
+    late String userId;
+
+    Future<void> createTestGroupAndUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'gametest@test.com',
+        password: 'password123',
+        displayName: 'Game Tester',
+      );
+      userId = user.uid;
+
+      final firestore = FirebaseFirestore.instance;
+      final groupRef = await firestore.collection('groups').add({
+        'name': 'Test Group',
+        'createdBy': userId,
+        'createdAt': FieldValue.serverTimestamp(),
+        'memberIds': [userId],
+        'adminIds': [userId],
+        'lastActivity': FieldValue.serverTimestamp(),
+      });
+      groupId = groupRef.id;
+    }
+
+    test(
+      'User can create a game within a group',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 7));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Saturday Beach Volleyball',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {
+            'name': 'Venice Beach',
+            'address': '1500 Ocean Front Walk, Venice, CA',
+          },
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        // Verify game was created
+        final gameDoc = await gameRef.get();
+        expect(gameDoc.exists, isTrue);
+        expect(gameDoc.data()?['title'], equals('Saturday Beach Volleyball'));
+        expect(gameDoc.data()?['groupId'], equals(groupId));
+        expect(gameDoc.data()?['createdBy'], equals(userId));
+        expect(gameDoc.data()?['playerIds'], contains(userId));
+      },
+    );
+
+    test(
+      'Game creator is automatically added as a player',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 1));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Quick Match',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {'name': 'Local Court'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        final playerIds = List<String>.from(gameDoc.data()?['playerIds'] ?? []);
+
+        expect(playerIds.length, equals(1));
+        expect(playerIds.first, equals(userId));
+      },
+    );
+
+    test(
+      'Game with optional description stores correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 3));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Game With Description',
+          'description': 'Bring your own water bottle and sunscreen',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {'name': 'Beach Court'},
+          'maxPlayers': 6,
+          'minPlayers': 4,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        expect(
+          gameDoc.data()?['description'],
+          equals('Bring your own water bottle and sunscreen'),
+        );
+      },
+    );
+
+    test(
+      'Game stores location with address correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 5));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Location Test Game',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {
+            'name': 'Santa Monica Beach',
+            'address': '123 Beach Ave, Santa Monica, CA 90401',
+          },
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        final location = gameDoc.data()?['location'] as Map<String, dynamic>?;
+
+        expect(location?['name'], equals('Santa Monica Beach'));
+        expect(
+          location?['address'],
+          equals('123 Beach Ave, Santa Monica, CA 90401'),
+        );
+      },
+    );
+
+    test(
+      'Game scheduled time is stored correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime(2025, 6, 15, 14, 30);
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Scheduled Time Test',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {'name': 'Test Court'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        final storedScheduledAt =
+            (gameDoc.data()?['scheduledAt'] as Timestamp).toDate();
+
+        expect(storedScheduledAt.year, equals(2025));
+        expect(storedScheduledAt.month, equals(6));
+        expect(storedScheduledAt.day, equals(15));
+        expect(storedScheduledAt.hour, equals(14));
+        expect(storedScheduledAt.minute, equals(30));
+      },
+    );
+
+    test(
+      'Multiple games can be created in same group',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create first game
+        await firestore.collection('games').add({
+          'title': 'Morning Game',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(
+            DateTime.now().add(const Duration(days: 1)),
+          ),
+          'location': {'name': 'Court 1'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        // Create second game
+        await firestore.collection('games').add({
+          'title': 'Afternoon Game',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(
+            DateTime.now().add(const Duration(days: 1, hours: 4)),
+          ),
+          'location': {'name': 'Court 2'},
+          'maxPlayers': 6,
+          'minPlayers': 4,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        // Verify both games exist for the group
+        final games = await firestore
+            .collection('games')
+            .where('groupId', isEqualTo: groupId)
+            .get();
+
+        expect(games.docs.length, equals(2));
+      },
+    );
+
+    test(
+      'Game with player limits stores correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 2));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Large Tournament',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {'name': 'Tournament Court'},
+          'maxPlayers': 12,
+          'minPlayers': 8,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        expect(gameDoc.data()?['maxPlayers'], equals(12));
+        expect(gameDoc.data()?['minPlayers'], equals(8));
+      },
+    );
+
+    test(
+      'Game status defaults to scheduled',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final scheduledAt = DateTime.now().add(const Duration(days: 4));
+
+        final gameRef = await firestore.collection('games').add({
+          'title': 'Status Test Game',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(scheduledAt),
+          'location': {'name': 'Test Location'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        final gameDoc = await gameRef.get();
+        expect(gameDoc.data()?['status'], equals('scheduled'));
+      },
+    );
+
+    test(
+      'Games are linked to correct group',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create a second group
+        final secondGroupRef = await firestore.collection('groups').add({
+          'name': 'Second Group',
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [userId],
+          'adminIds': [userId],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        // Create game in first group
+        await firestore.collection('games').add({
+          'title': 'Game in First Group',
+          'groupId': groupId,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(
+            DateTime.now().add(const Duration(days: 1)),
+          ),
+          'location': {'name': 'Court 1'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        // Create game in second group
+        await firestore.collection('games').add({
+          'title': 'Game in Second Group',
+          'groupId': secondGroupRef.id,
+          'createdBy': userId,
+          'createdAt': FieldValue.serverTimestamp(),
+          'scheduledAt': Timestamp.fromDate(
+            DateTime.now().add(const Duration(days: 2)),
+          ),
+          'location': {'name': 'Court 2'},
+          'maxPlayers': 4,
+          'minPlayers': 2,
+          'playerIds': [userId],
+          'status': 'scheduled',
+        });
+
+        // Verify games are in correct groups
+        final firstGroupGames = await firestore
+            .collection('games')
+            .where('groupId', isEqualTo: groupId)
+            .get();
+
+        final secondGroupGames = await firestore
+            .collection('games')
+            .where('groupId', isEqualTo: secondGroupRef.id)
+            .get();
+
+        expect(firstGroupGames.docs.length, equals(1));
+        expect(
+          firstGroupGames.docs.first.data()['title'],
+          equals('Game in First Group'),
+        );
+
+        expect(secondGroupGames.docs.length, equals(1));
+        expect(
+          secondGroupGames.docs.first.data()['title'],
+          equals('Game in Second Group'),
+        );
+      },
+    );
+  });
+}

--- a/integration_test/group_creation_flow_test.dart
+++ b/integration_test/group_creation_flow_test.dart
@@ -1,0 +1,252 @@
+// Integration test for group creation flow
+// Tests real Firebase Firestore interactions using Firebase Emulator
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/firebase_emulator_helper.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await FirebaseEmulatorHelper.initialize();
+  });
+
+  setUp(() async {
+    await FirebaseEmulatorHelper.clearFirestore();
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  tearDown(() async {
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  group('Group Creation Flow', () {
+    test(
+      'User can create a new group with valid data',
+      () async {
+        // 1. Create and authenticate a test user
+        final testEmail = 'creator@test.com';
+        final testPassword = 'password123';
+
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: testEmail,
+          password: testPassword,
+          displayName: 'Group Creator',
+        );
+
+        // 2. Create a new group
+        final firestore = FirebaseFirestore.instance;
+        final groupRef = await firestore.collection('groups').add({
+          'name': 'Beach Volleyball Crew',
+          'description': 'Weekly games at the beach',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        // 3. Verify group was created
+        final groupDoc = await groupRef.get();
+        expect(groupDoc.exists, isTrue);
+        expect(groupDoc.data()?['name'], equals('Beach Volleyball Crew'));
+        expect(groupDoc.data()?['createdBy'], equals(user.uid));
+        expect(groupDoc.data()?['memberIds'], contains(user.uid));
+        expect(groupDoc.data()?['adminIds'], contains(user.uid));
+      },
+    );
+
+    test(
+      'Creator is automatically added as member and admin',
+      () async {
+        // 1. Create and authenticate a test user
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'admin@test.com',
+          password: 'password123',
+          displayName: 'Admin User',
+        );
+
+        // 2. Create a new group
+        final firestore = FirebaseFirestore.instance;
+        final groupRef = await firestore.collection('groups').add({
+          'name': 'Test Group',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        // 3. Verify creator is member and admin
+        final groupDoc = await groupRef.get();
+        final memberIds = List<String>.from(groupDoc.data()?['memberIds'] ?? []);
+        final adminIds = List<String>.from(groupDoc.data()?['adminIds'] ?? []);
+
+        expect(memberIds.length, equals(1));
+        expect(memberIds.first, equals(user.uid));
+        expect(adminIds.length, equals(1));
+        expect(adminIds.first, equals(user.uid));
+      },
+    );
+
+    test(
+      'Group with optional description stores correctly',
+      () async {
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'nodesc@test.com',
+          password: 'password123',
+          displayName: 'No Desc User',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create group without description
+        final groupRef = await firestore.collection('groups').add({
+          'name': 'Group Without Description',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        final groupDoc = await groupRef.get();
+        expect(groupDoc.data()?['description'], isNull);
+        expect(groupDoc.data()?['name'], equals('Group Without Description'));
+      },
+    );
+
+    test(
+      'Group with description stores correctly',
+      () async {
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'withdesc@test.com',
+          password: 'password123',
+          displayName: 'With Desc User',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create group with description
+        final groupRef = await firestore.collection('groups').add({
+          'name': 'Group With Description',
+          'description': 'This is a detailed description of the group',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        final groupDoc = await groupRef.get();
+        expect(
+          groupDoc.data()?['description'],
+          equals('This is a detailed description of the group'),
+        );
+      },
+    );
+
+    test(
+      'Multiple groups can be created by same user',
+      () async {
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'multigroup@test.com',
+          password: 'password123',
+          displayName: 'Multi Group User',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create first group
+        await firestore.collection('groups').add({
+          'name': 'First Group',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        // Create second group
+        await firestore.collection('groups').add({
+          'name': 'Second Group',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        // Verify both groups exist
+        final groups = await firestore
+            .collection('groups')
+            .where('createdBy', isEqualTo: user.uid)
+            .get();
+
+        expect(groups.docs.length, equals(2));
+      },
+    );
+
+    test(
+      'Group name is stored and retrieved correctly',
+      () async {
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'nametest@test.com',
+          password: 'password123',
+          displayName: 'Name Test User',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final groupName = 'Special Characters & Unicode 日本語';
+
+        final groupRef = await firestore.collection('groups').add({
+          'name': groupName,
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        final groupDoc = await groupRef.get();
+        expect(groupDoc.data()?['name'], equals(groupName));
+      },
+    );
+
+    test(
+      'Group creation sets timestamps correctly',
+      () async {
+        final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+          email: 'timestamp@test.com',
+          password: 'password123',
+          displayName: 'Timestamp User',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        final groupRef = await firestore.collection('groups').add({
+          'name': 'Timestamp Test Group',
+          'createdBy': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+          'memberIds': [user.uid],
+          'adminIds': [user.uid],
+          'lastActivity': FieldValue.serverTimestamp(),
+        });
+
+        final groupDoc = await groupRef.get();
+        final createdAt = groupDoc.data()?['createdAt'] as Timestamp?;
+        final lastActivity = groupDoc.data()?['lastActivity'] as Timestamp?;
+
+        expect(createdAt, isNotNull);
+        expect(lastActivity, isNotNull);
+        expect(
+          createdAt!.toDate().difference(DateTime.now()).inSeconds.abs(),
+          lessThan(10),
+        );
+      },
+    );
+  });
+}

--- a/test/widget/features/groups/presentation/pages/group_creation_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/group_creation_page_test.dart
@@ -1,0 +1,493 @@
+// Widget tests for GroupCreationPage verifying UI rendering and user interactions.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/group_model.dart';
+import 'package:play_with_me/core/presentation/bloc/group/group_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/group/group_event.dart';
+import 'package:play_with_me/core/presentation/bloc/group/group_state.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/groups/presentation/pages/group_creation_page.dart';
+
+class MockGroupBloc extends MockBloc<GroupEvent, GroupState>
+    implements GroupBloc {}
+
+class MockAuthenticationBloc
+    extends MockBloc<AuthenticationEvent, AuthenticationState>
+    implements AuthenticationBloc {}
+
+class FakeGroupEvent extends Fake implements GroupEvent {}
+
+class FakeGroupState extends Fake implements GroupState {}
+
+void main() {
+  late MockGroupBloc mockGroupBloc;
+  late MockAuthenticationBloc mockAuthBloc;
+
+  const testUserId = 'test-user-123';
+
+  setUpAll(() {
+    registerFallbackValue(FakeGroupEvent());
+    registerFallbackValue(FakeGroupState());
+  });
+
+  setUp(() {
+    mockGroupBloc = MockGroupBloc();
+    mockAuthBloc = MockAuthenticationBloc();
+
+    when(() => mockGroupBloc.state).thenReturn(const GroupInitial());
+
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(
+        UserEntity(
+          uid: testUserId,
+          email: 'test@example.com',
+          isEmailVerified: true,
+          createdAt: DateTime(2024, 1, 1),
+          lastSignInAt: DateTime(2024, 1, 1),
+          isAnonymous: false,
+        ),
+      ),
+    );
+  });
+
+  tearDown(() {
+    mockGroupBloc.close();
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<GroupBloc>.value(value: mockGroupBloc),
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        ],
+        child: const GroupCreationPage(),
+      ),
+    );
+  }
+
+  group('GroupCreationPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Create Group title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.text('Create Group'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders header text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text('Create a new group for organizing volleyball games'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders group name input field', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Group Name *'), findsOneWidget);
+        expect(find.byIcon(Icons.group), findsOneWidget);
+      });
+
+      testWidgets('renders description input field', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Description (Optional)'), findsOneWidget);
+        expect(find.byIcon(Icons.description), findsOneWidget);
+      });
+
+      testWidgets('renders info card', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text(
+              'You will automatically become the group admin and first member'),
+          findsOneWidget,
+        );
+        expect(find.byIcon(Icons.info_outline), findsOneWidget);
+      });
+
+      testWidgets('renders create group button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to make button visible
+        final createButton = find.text('Create Group');
+        await tester.ensureVisible(createButton.last);
+        await tester.pumpAndSettle();
+
+        // Should find "Create Group" text (in button and possibly app bar)
+        expect(createButton, findsWidgets);
+      });
+
+      testWidgets('renders cancel button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to make button visible
+        final cancelButton = find.text('Cancel');
+        await tester.ensureVisible(cancelButton);
+        await tester.pumpAndSettle();
+
+        expect(cancelButton, findsOneWidget);
+      });
+    });
+
+    group('Group Name Input Field', () {
+      testWidgets('can enter group name', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final nameField = find.widgetWithText(TextFormField, 'Group Name *');
+        await tester.enterText(nameField, 'Beach Volleyball Crew');
+        await tester.pump();
+
+        expect(find.text('Beach Volleyball Crew'), findsOneWidget);
+      });
+
+      testWidgets('shows validation error for empty name', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to and tap create group button
+        final createButton = find.byWidgetPredicate(
+          (widget) => widget is FilledButton,
+          description: 'FilledButton',
+        );
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Group name cannot be empty'), findsOneWidget);
+      });
+
+      testWidgets('shows validation error for short name', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Enter short name
+        final nameField = find.widgetWithText(TextFormField, 'Group Name *');
+        await tester.enterText(nameField, 'AB');
+        await tester.pump();
+
+        // Tap create group button
+        final createButton = find.byWidgetPredicate((widget) => widget is FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pumpAndSettle();
+
+        expect(
+            find.text('Group name must be at least 3 characters'), findsOneWidget);
+      });
+
+      testWidgets('shows character counter for max length', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // The character counter should show 0/50
+        expect(find.textContaining('/50'), findsOneWidget);
+      });
+    });
+
+    group('Description Input Field', () {
+      testWidgets('can enter description', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final descField =
+            find.widgetWithText(TextFormField, 'Description (Optional)');
+        await tester.enterText(descField, 'Weekly beach volleyball games');
+        await tester.pump();
+
+        expect(find.text('Weekly beach volleyball games'), findsOneWidget);
+      });
+
+      testWidgets('description is optional', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Enter only group name
+        final nameField = find.widgetWithText(TextFormField, 'Group Name *');
+        await tester.enterText(nameField, 'Beach Volleyball Crew');
+        await tester.pump();
+
+        // Tap create group button
+        final createButton = find.byWidgetPredicate((widget) => widget is FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pump();
+
+        // Should trigger CreateGroup event (no validation errors)
+        verify(
+          () => mockGroupBloc.add(any(that: isA<CreateGroup>())),
+        ).called(1);
+      });
+
+      testWidgets('shows character counter for max length', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // The character counter should show 0/200
+        expect(find.textContaining('/200'), findsOneWidget);
+      });
+    });
+
+    group('Create Button', () {
+      testWidgets('triggers CreateGroup event on tap with valid data',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Enter valid group name
+        final nameField = find.widgetWithText(TextFormField, 'Group Name *');
+        await tester.enterText(nameField, 'Beach Volleyball Crew');
+        await tester.pump();
+
+        // Enter optional description
+        final descField =
+            find.widgetWithText(TextFormField, 'Description (Optional)');
+        await tester.enterText(descField, 'Weekly games at the beach');
+        await tester.pump();
+
+        // Tap create group button
+        final createButton = find.byWidgetPredicate((widget) => widget is FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pump();
+
+        verify(
+          () => mockGroupBloc.add(any(that: isA<CreateGroup>())),
+        ).called(1);
+      });
+
+      testWidgets('does not trigger event with invalid form', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Tap create group button without entering data
+        final createButton = find.byWidgetPredicate((widget) => widget is FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pump();
+
+        verifyNever(
+          () => mockGroupBloc.add(any(that: isA<CreateGroup>())),
+        );
+      });
+    });
+
+    group('Loading State', () {
+      testWidgets('shows loading indicator during creation', (tester) async {
+        when(() => mockGroupBloc.state).thenReturn(const GroupLoading());
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('Creating...'), findsOneWidget);
+      });
+
+      testWidgets('button is disabled during loading', (tester) async {
+        when(() => mockGroupBloc.state).thenReturn(const GroupLoading());
+
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to button
+        final createButton = find.byWidgetPredicate((widget) => widget is FilledButton).first;
+        await tester.ensureVisible(createButton);
+        await tester.pump();
+
+        final filledButton = tester.widget<FilledButton>(createButton);
+        expect(filledButton.onPressed, isNull);
+      });
+
+      testWidgets('form fields are disabled during loading', (tester) async {
+        when(() => mockGroupBloc.state).thenReturn(const GroupLoading());
+
+        await tester.pumpWidget(createTestWidget());
+
+        final nameField = tester.widget<TextFormField>(
+          find.widgetWithText(TextFormField, 'Group Name *'),
+        );
+        expect(nameField.enabled, isFalse);
+      });
+    });
+
+    group('Success Handling', () {
+      testWidgets('shows success snackbar on group creation', (tester) async {
+        final createdGroup = GroupModel(
+          id: 'new-group-id',
+          name: 'Beach Volleyball Crew',
+          createdBy: testUserId,
+          createdAt: DateTime.now(),
+          memberIds: [testUserId],
+          adminIds: [testUserId],
+          lastActivity: DateTime.now(),
+        );
+
+        whenListen(
+          mockGroupBloc,
+          Stream.fromIterable([
+            const GroupInitial(),
+            const GroupLoading(),
+            GroupCreated(groupId: 'new-group-id', group: createdGroup),
+          ]),
+          initialState: const GroupInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Group created successfully!'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+
+        // Complete the pending timer from Future.delayed in the source
+        await tester.pump(const Duration(milliseconds: 600));
+      });
+
+      testWidgets('success snackbar has green background', (tester) async {
+        final createdGroup = GroupModel(
+          id: 'new-group-id',
+          name: 'Beach Volleyball Crew',
+          createdBy: testUserId,
+          createdAt: DateTime.now(),
+          memberIds: [testUserId],
+          adminIds: [testUserId],
+          lastActivity: DateTime.now(),
+        );
+
+        whenListen(
+          mockGroupBloc,
+          Stream.fromIterable([
+            const GroupInitial(),
+            GroupCreated(groupId: 'new-group-id', group: createdGroup),
+          ]),
+          initialState: const GroupInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, Colors.green);
+
+        // Complete the pending timer
+        await tester.pump(const Duration(milliseconds: 600));
+      });
+    });
+
+    group('Error Handling', () {
+      testWidgets('shows error snackbar on failure', (tester) async {
+        whenListen(
+          mockGroupBloc,
+          Stream.fromIterable([
+            const GroupInitial(),
+            const GroupLoading(),
+            const GroupError(message: 'Failed to create group'),
+          ]),
+          initialState: const GroupInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+            find.textContaining('Failed to create group'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+      });
+
+      testWidgets('error snackbar has red background', (tester) async {
+        whenListen(
+          mockGroupBloc,
+          Stream.fromIterable([
+            const GroupInitial(),
+            const GroupError(message: 'Error message'),
+          ]),
+          initialState: const GroupInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, Colors.red);
+      });
+    });
+
+    group('Cancel Button', () {
+      testWidgets('cancel button navigates back', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => MultiBlocProvider(
+                          providers: [
+                            BlocProvider<GroupBloc>.value(value: mockGroupBloc),
+                            BlocProvider<AuthenticationBloc>.value(
+                                value: mockAuthBloc),
+                          ],
+                          child: const GroupCreationPage(),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Go to Create Group'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Navigate to group creation page
+        await tester.tap(find.text('Go to Create Group'));
+        await tester.pumpAndSettle();
+
+        // Verify we're on group creation page
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.text('Create Group'),
+          ),
+          findsOneWidget,
+        );
+
+        // Scroll to and tap Cancel
+        final cancelButton = find.text('Cancel');
+        await tester.ensureVisible(cancelButton);
+        await tester.pumpAndSettle();
+        await tester.tap(cancelButton);
+        await tester.pumpAndSettle();
+
+        // Should navigate back
+        expect(find.text('Go to Create Group'), findsOneWidget);
+      });
+    });
+
+    group('Unauthenticated State', () {
+      testWidgets('shows login message when not authenticated', (tester) async {
+        when(() => mockAuthBloc.state)
+            .thenReturn(const AuthenticationUnauthenticated());
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+            find.text('You must be logged in to create a group'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/widget/features/groups/presentation/pages/group_details_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/group_details_page_test.dart
@@ -1,0 +1,434 @@
+// Widget tests for GroupDetailsPage verifying UI rendering and user interactions.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/group_model.dart';
+import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/domain/repositories/group_repository.dart';
+import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/group_member/group_member_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/group_member/group_member_event.dart';
+import 'package:play_with_me/core/presentation/bloc/group_member/group_member_state.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/groups/presentation/pages/group_details_page.dart';
+
+class MockGroupMemberBloc
+    extends MockBloc<GroupMemberEvent, GroupMemberState>
+    implements GroupMemberBloc {}
+
+class MockAuthenticationBloc
+    extends MockBloc<AuthenticationEvent, AuthenticationState>
+    implements AuthenticationBloc {}
+
+class MockGroupRepository extends Mock implements GroupRepository {}
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+class MockGameRepository extends Mock implements GameRepository {}
+
+class MockFriendRepository extends Mock implements FriendRepository {}
+
+class FakeGroupMemberEvent extends Fake implements GroupMemberEvent {}
+
+class FakeGroupMemberState extends Fake implements GroupMemberState {}
+
+void main() {
+  late MockGroupMemberBloc mockGroupMemberBloc;
+  late MockAuthenticationBloc mockAuthBloc;
+  late MockGroupRepository mockGroupRepository;
+  late MockUserRepository mockUserRepository;
+  late MockGameRepository mockGameRepository;
+  late MockFriendRepository mockFriendRepository;
+
+  const testUserId = 'test-user-123';
+  const testGroupId = 'test-group-123';
+
+  final testGroup = GroupModel(
+    id: testGroupId,
+    name: 'Beach Volleyball Crew',
+    description: 'Weekly games at the beach',
+    createdBy: testUserId,
+    createdAt: DateTime(2024, 1, 1),
+    memberIds: [testUserId, 'member-2', 'member-3'],
+    adminIds: [testUserId],
+    lastActivity: DateTime(2024, 1, 1),
+  );
+
+  final List<UserModel> testMembers = [
+    UserModel(
+      uid: testUserId,
+      email: 'owner@example.com',
+      displayName: 'Group Owner',
+      createdAt: DateTime(2024, 1, 1),
+      isEmailVerified: true,
+      isAnonymous: false,
+    ),
+    UserModel(
+      uid: 'member-2',
+      email: 'member2@example.com',
+      displayName: 'Member Two',
+      createdAt: DateTime(2024, 1, 1),
+      isEmailVerified: true,
+      isAnonymous: false,
+    ),
+    UserModel(
+      uid: 'member-3',
+      email: 'member3@example.com',
+      displayName: 'Member Three',
+      createdAt: DateTime(2024, 1, 1),
+      isEmailVerified: true,
+      isAnonymous: false,
+    ),
+  ];
+
+  setUpAll(() {
+    registerFallbackValue(FakeGroupMemberEvent());
+    registerFallbackValue(FakeGroupMemberState());
+  });
+
+  setUp(() {
+    mockGroupMemberBloc = MockGroupMemberBloc();
+    mockAuthBloc = MockAuthenticationBloc();
+    mockGroupRepository = MockGroupRepository();
+    mockUserRepository = MockUserRepository();
+    mockGameRepository = MockGameRepository();
+    mockFriendRepository = MockFriendRepository();
+
+    when(() => mockGroupMemberBloc.state)
+        .thenReturn(const GroupMemberInitial());
+
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(
+        UserEntity(
+          uid: testUserId,
+          email: 'test@example.com',
+          isEmailVerified: true,
+          createdAt: DateTime(2024, 1, 1),
+          lastSignInAt: DateTime(2024, 1, 1),
+          isAnonymous: false,
+        ),
+      ),
+    );
+
+    // Setup default repository responses
+    when(() => mockGroupRepository.getGroupById(testGroupId))
+        .thenAnswer((_) async => testGroup);
+    when(() => mockUserRepository.getUsersByIds(any()))
+        .thenAnswer((_) async => testMembers);
+    when(() => mockGameRepository.getUpcomingGamesCount(testGroupId))
+        .thenAnswer((_) => Stream.value(2));
+    when(() => mockFriendRepository.batchCheckFriendship(any()))
+        .thenAnswer((_) async => {'member-2': true, 'member-3': false});
+    when(() => mockFriendRepository.batchCheckFriendRequestStatus(any()))
+        .thenAnswer((_) async => {'member-3': FriendRequestStatus.none});
+
+    // Register service locator mocks
+    if (sl.isRegistered<GroupMemberBloc>()) {
+      sl.unregister<GroupMemberBloc>();
+    }
+    sl.registerFactory<GroupMemberBloc>(() => mockGroupMemberBloc);
+
+    if (sl.isRegistered<FriendRepository>()) {
+      sl.unregister<FriendRepository>();
+    }
+    sl.registerSingleton<FriendRepository>(mockFriendRepository);
+  });
+
+  tearDown(() {
+    mockGroupMemberBloc.close();
+    mockAuthBloc.close();
+
+    if (sl.isRegistered<GroupMemberBloc>()) {
+      sl.unregister<GroupMemberBloc>();
+    }
+    if (sl.isRegistered<FriendRepository>()) {
+      sl.unregister<FriendRepository>();
+    }
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        ],
+        child: GroupDetailsPage(
+          groupId: testGroupId,
+          groupRepositoryOverride: mockGroupRepository,
+          userRepositoryOverride: mockUserRepository,
+          gameRepositoryOverride: mockGameRepository,
+        ),
+      ),
+    );
+  }
+
+  group('GroupDetailsPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Group Details title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.text('Group Details'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows loading indicator initially', (tester) async {
+        // Delay the group loading - use a completer so we can control when it completes
+        when(() => mockGroupRepository.getGroupById(testGroupId))
+            .thenAnswer((_) async {
+          await Future.delayed(const Duration(seconds: 1));
+          return testGroup;
+        });
+
+        await tester.pumpWidget(createTestWidget());
+        // Pump frames but don't settle (async still running)
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Now complete the future to avoid pending timer warnings
+        await tester.pumpAndSettle(const Duration(seconds: 2));
+      });
+
+      testWidgets('shows group name after loading', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Beach Volleyball Crew'), findsOneWidget);
+      });
+
+      testWidgets('shows group description after loading', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Weekly games at the beach'), findsOneWidget);
+      });
+
+      testWidgets('shows member count after loading', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('3 members'), findsOneWidget);
+      });
+
+      testWidgets('shows members section header', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Members (3)'), findsOneWidget);
+      });
+    });
+
+    group('Members List', () {
+      testWidgets('shows all member names', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Group Owner'), findsOneWidget);
+        expect(find.text('Member Two'), findsOneWidget);
+        expect(find.text('Member Three'), findsOneWidget);
+      });
+    });
+
+    group('Error State', () {
+      testWidgets('shows error message when group not found', (tester) async {
+        when(() => mockGroupRepository.getGroupById(testGroupId))
+            .thenAnswer((_) async => null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Group not found'), findsOneWidget);
+      });
+
+      testWidgets('shows error state with retry button on load failure',
+          (tester) async {
+        when(() => mockGroupRepository.getGroupById(testGroupId))
+            .thenThrow(Exception('Network error'));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('Error'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      });
+
+      testWidgets('retry button reloads group details', (tester) async {
+        // First call throws error, second call returns data
+        var callCount = 0;
+        when(() => mockGroupRepository.getGroupById(testGroupId)).thenAnswer(
+          (_) async {
+            callCount++;
+            if (callCount == 1) {
+              throw Exception('Network error');
+            }
+            return testGroup;
+          },
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Should show error state
+        expect(find.text('Retry'), findsOneWidget);
+
+        // Tap retry
+        await tester.tap(find.text('Retry'));
+        await tester.pumpAndSettle();
+
+        // Should now show group name
+        expect(find.text('Beach Volleyball Crew'), findsOneWidget);
+      });
+    });
+
+    group('Unauthenticated State', () {
+      testWidgets('shows login message when not authenticated', (tester) async {
+        when(() => mockAuthBloc.state)
+            .thenReturn(const AuthenticationUnauthenticated());
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(
+            find.text('Please log in to view group details'), findsOneWidget);
+      });
+    });
+
+    group('Leave Group Menu', () {
+      testWidgets('shows more menu button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.more_vert), findsOneWidget);
+      });
+
+      testWidgets('shows Leave Group option in menu', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Tap the more menu
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Leave Group'), findsOneWidget);
+        expect(find.byIcon(Icons.exit_to_app), findsOneWidget);
+      });
+    });
+
+    group('Bottom Navigation Bar', () {
+      testWidgets('shows bottom navigation bar after loading', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // GroupBottomNavBar uses BottomNavigationBar internally
+        expect(find.byType(BottomNavigationBar), findsOneWidget);
+      });
+    });
+
+    group('Pull to Refresh', () {
+      testWidgets('has RefreshIndicator', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(RefreshIndicator), findsOneWidget);
+      });
+    });
+
+    group('BlocListener State Changes', () {
+      testWidgets('shows success message when member is promoted',
+          (tester) async {
+        whenListen(
+          mockGroupMemberBloc,
+          Stream.fromIterable([
+            const GroupMemberInitial(),
+            const MemberPromotedSuccess(groupId: testGroupId, userId: 'member-2'),
+          ]),
+          initialState: const GroupMemberInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Member promoted to admin'), findsOneWidget);
+      });
+
+      testWidgets('shows success message when member is demoted',
+          (tester) async {
+        whenListen(
+          mockGroupMemberBloc,
+          Stream.fromIterable([
+            const GroupMemberInitial(),
+            const MemberDemotedSuccess(groupId: testGroupId, userId: 'member-2'),
+          ]),
+          initialState: const GroupMemberInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Member demoted to regular member'), findsOneWidget);
+      });
+
+      testWidgets('shows success message when member is removed',
+          (tester) async {
+        whenListen(
+          mockGroupMemberBloc,
+          Stream.fromIterable([
+            const GroupMemberInitial(),
+            const MemberRemovedSuccess(groupId: testGroupId, userId: 'member-2'),
+          ]),
+          initialState: const GroupMemberInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Member removed from group'), findsOneWidget);
+      });
+
+      testWidgets('shows error message on GroupMemberError', (tester) async {
+        whenListen(
+          mockGroupMemberBloc,
+          Stream.fromIterable([
+            const GroupMemberInitial(),
+            const GroupMemberError('Failed to update member'),
+          ]),
+          initialState: const GroupMemberInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Failed to update member'), findsOneWidget);
+      });
+    });
+
+    group('People Icon', () {
+      testWidgets('shows people icon next to member count', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.people), findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add comprehensive widget tests for GroupCreationPage (25 tests) covering UI rendering, form validation, loading/success/error states, and navigation
- Add widget tests for GroupDetailsPage (20 tests) covering member list rendering, BLoC state changes, error handling, and menu interactions
- Add integration tests for group creation flow (7 tests) testing Firestore interactions via Firebase Emulator
- Add integration tests for game creation flow (9 tests) testing game creation within groups

## Test Coverage
**GroupCreationPage Widget Tests (25 tests):**
- Initial UI rendering (app bar, form fields, buttons)
- Group name validation (empty, too short, max length)
- Description field (optional, max length)
- Create button behavior and event triggering
- Loading, success, and error state handling
- Cancel button navigation
- Unauthenticated state

**GroupDetailsPage Widget Tests (20 tests):**
- Initial UI rendering (app bar, loading state)
- Group info display (name, description, member count)
- Members list rendering
- Error state with retry button
- Leave group menu
- Bottom navigation bar
- BLoC listener state changes (promote, demote, remove)

**Group Creation Integration Tests (7 tests):**
- Create group with valid data
- Creator as member and admin
- Optional description handling
- Multiple groups per user
- Unicode character support
- Timestamp verification

**Game Creation Integration Tests (9 tests):**
- Create game within a group
- Creator as player
- Optional description
- Location with address
- Scheduled time storage
- Multiple games per group
- Games linked to correct groups

## Closes
- Closes #402 (Story 16.3.2.5: Add Group Pages Widget Tests)
- Closes #403 (Story 16.3.2.6: Add Group & Game Creation Integration Tests)

## Test plan
- [x] All 45 new widget tests pass locally
- [x] All 16 new integration tests created (require Firebase Emulator to run)
- [x] Flutter analyze passes for new test files
- [x] No regression in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)