### PR TITLE
Story 16.3.3.1 & 16.3.3.2: Add Stats Models and TrainingSessionModel Unit Tests

### DIFF
--- a/test/unit/core/data/models/head_to_head_stats_test.dart
+++ b/test/unit/core/data/models/head_to_head_stats_test.dart
@@ -1,0 +1,1196 @@
+// Tests HeadToHeadStats and HeadToHeadGameResult models for rivalry tracking (Story 16.3.3.1).
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/head_to_head_stats.dart';
+
+void main() {
+  group('HeadToHeadStats', () {
+    final testDate = DateTime(2025, 12, 29, 10, 30);
+    final testTimestamp = Timestamp.fromDate(testDate);
+
+    group('constructor', () {
+      test('creates instance with all required fields', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          opponentName: 'John Doe',
+          opponentEmail: 'john@example.com',
+          opponentPhotoUrl: 'https://example.com/photo.jpg',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+          pointsScored: 300,
+          pointsAllowed: 280,
+          eloChange: 35.5,
+          largestVictoryMargin: 10,
+          largestDefeatMargin: 5,
+          recentMatchups: [],
+          lastUpdated: testDate,
+        );
+
+        expect(stats.userId, equals('user-123'));
+        expect(stats.opponentId, equals('opponent-456'));
+        expect(stats.opponentName, equals('John Doe'));
+        expect(stats.opponentEmail, equals('john@example.com'));
+        expect(stats.opponentPhotoUrl, equals('https://example.com/photo.jpg'));
+        expect(stats.gamesPlayed, equals(15));
+        expect(stats.gamesWon, equals(9));
+        expect(stats.gamesLost, equals(6));
+        expect(stats.pointsScored, equals(300));
+        expect(stats.pointsAllowed, equals(280));
+        expect(stats.eloChange, equals(35.5));
+        expect(stats.largestVictoryMargin, equals(10));
+        expect(stats.largestDefeatMargin, equals(5));
+        expect(stats.lastUpdated, equals(testDate));
+      });
+
+      test('creates instance with default values', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+        );
+
+        expect(stats.opponentName, isNull);
+        expect(stats.opponentEmail, isNull);
+        expect(stats.opponentPhotoUrl, isNull);
+        expect(stats.pointsScored, equals(0));
+        expect(stats.pointsAllowed, equals(0));
+        expect(stats.eloChange, equals(0.0));
+        expect(stats.largestVictoryMargin, equals(0));
+        expect(stats.largestDefeatMargin, equals(0));
+        expect(stats.recentMatchups, isEmpty);
+        expect(stats.lastUpdated, isNull);
+      });
+    });
+
+    group('winRate', () {
+      test('calculates win rate correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 20,
+          gamesWon: 14,
+          gamesLost: 6,
+        );
+
+        expect(stats.winRate, equals(70.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.winRate, equals(0.0));
+      });
+
+      test('calculates 100% win rate', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 10,
+          gamesLost: 0,
+        );
+
+        expect(stats.winRate, equals(100.0));
+      });
+
+      test('calculates 0% win rate', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 0,
+          gamesLost: 10,
+        );
+
+        expect(stats.winRate, equals(0.0));
+      });
+    });
+
+    group('lossRate', () {
+      test('calculates loss rate correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 20,
+          gamesWon: 14,
+          gamesLost: 6,
+        );
+
+        expect(stats.lossRate, equals(30.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.lossRate, equals(0.0));
+      });
+    });
+
+    group('avgPointsScored', () {
+      test('calculates average points scored correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+          pointsScored: 195,
+        );
+
+        expect(stats.avgPointsScored, equals(19.5));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.avgPointsScored, equals(0.0));
+      });
+    });
+
+    group('avgPointsAllowed', () {
+      test('calculates average points allowed correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+          pointsAllowed: 170,
+        );
+
+        expect(stats.avgPointsAllowed, equals(17.0));
+      });
+    });
+
+    group('avgPointDifferential', () {
+      test('calculates positive point differential', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          pointsScored: 200,
+          pointsAllowed: 170,
+        );
+
+        expect(stats.avgPointDifferential, equals(3.0)); // 20 - 17
+      });
+
+      test('calculates negative point differential', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 170,
+          pointsAllowed: 200,
+        );
+
+        expect(stats.avgPointDifferential, equals(-3.0)); // 17 - 20
+      });
+    });
+
+    group('avgEloChange', () {
+      test('calculates average ELO change correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+          eloChange: 40.0,
+        );
+
+        expect(stats.avgEloChange, equals(4.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.avgEloChange, equals(0.0));
+      });
+    });
+
+    group('currentStreak', () {
+      test('returns positive streak for consecutive wins', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 5,
+          gamesWon: 4,
+          gamesLost: 1,
+          recentMatchups: [
+            HeadToHeadGameResult(
+              gameId: 'g1',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 15,
+              eloChange: 10.0,
+              timestamp: testDate,
+            ),
+            HeadToHeadGameResult(
+              gameId: 'g2',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 18,
+              eloChange: 8.0,
+              timestamp: testDate.subtract(const Duration(days: 1)),
+            ),
+            HeadToHeadGameResult(
+              gameId: 'g3',
+              won: false,
+              pointsScored: 18,
+              pointsAllowed: 21,
+              eloChange: -8.0,
+              timestamp: testDate.subtract(const Duration(days: 2)),
+            ),
+          ],
+        );
+
+        expect(stats.currentStreak, equals(2));
+      });
+
+      test('returns negative streak for consecutive losses', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 4,
+          gamesWon: 1,
+          gamesLost: 3,
+          recentMatchups: [
+            HeadToHeadGameResult(
+              gameId: 'g1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: testDate,
+            ),
+            HeadToHeadGameResult(
+              gameId: 'g2',
+              won: false,
+              pointsScored: 18,
+              pointsAllowed: 21,
+              eloChange: -8.0,
+              timestamp: testDate.subtract(const Duration(days: 1)),
+            ),
+            HeadToHeadGameResult(
+              gameId: 'g3',
+              won: false,
+              pointsScored: 19,
+              pointsAllowed: 21,
+              eloChange: -7.0,
+              timestamp: testDate.subtract(const Duration(days: 2)),
+            ),
+          ],
+        );
+
+        expect(stats.currentStreak, equals(-3));
+      });
+
+      test('returns 0 when no recent matchups', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+          recentMatchups: [],
+        );
+
+        expect(stats.currentStreak, equals(0));
+      });
+    });
+
+    group('isOnWinningStreak / isOnLosingStreak', () {
+      test('isOnWinningStreak returns true for positive streak', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 2,
+          gamesWon: 2,
+          gamesLost: 0,
+          recentMatchups: [
+            HeadToHeadGameResult(
+              gameId: 'g1',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 15,
+              eloChange: 10.0,
+              timestamp: testDate,
+            ),
+          ],
+        );
+
+        expect(stats.isOnWinningStreak, isTrue);
+        expect(stats.isOnLosingStreak, isFalse);
+      });
+
+      test('isOnLosingStreak returns true for negative streak', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 2,
+          gamesWon: 0,
+          gamesLost: 2,
+          recentMatchups: [
+            HeadToHeadGameResult(
+              gameId: 'g1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: testDate,
+            ),
+          ],
+        );
+
+        expect(stats.isOnWinningStreak, isFalse);
+        expect(stats.isOnLosingStreak, isTrue);
+      });
+    });
+
+    group('recordString', () {
+      test('formats record correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+        );
+
+        expect(stats.recordString, equals('9W - 6L'));
+      });
+    });
+
+    group('formattedPointDifferential', () {
+      test('formats positive differential with plus sign', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          pointsScored: 200,
+          pointsAllowed: 170,
+        );
+
+        expect(stats.formattedPointDifferential, equals('+3.0'));
+      });
+
+      test('formats negative differential without plus sign', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 170,
+          pointsAllowed: 200,
+        );
+
+        expect(stats.formattedPointDifferential, equals('-3.0'));
+      });
+    });
+
+    group('formattedEloChange', () {
+      test('formats positive ELO change with plus sign', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          eloChange: 35.5,
+        );
+
+        expect(stats.formattedEloChange, equals('+35.5'));
+      });
+
+      test('formats negative ELO change without plus sign', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          eloChange: -25.5,
+        );
+
+        expect(stats.formattedEloChange, equals('-25.5'));
+      });
+    });
+
+    group('matchupAdvantage', () {
+      test('returns "Not enough data" for less than 5 games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 4,
+          gamesWon: 3,
+          gamesLost: 1,
+        );
+
+        expect(stats.matchupAdvantage, equals('Not enough data'));
+      });
+
+      test('returns "Strong advantage" for win rate > 60%', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+        );
+
+        expect(stats.matchupAdvantage, equals('Strong advantage'));
+      });
+
+      test('returns "Slight advantage" for win rate 50-60%', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+        );
+
+        expect(stats.matchupAdvantage, equals('Slight advantage'));
+      });
+
+      test('returns "Even matchup" for win rate 40-50%', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 4,
+          gamesLost: 6,
+        );
+
+        expect(stats.matchupAdvantage, equals('Even matchup'));
+      });
+
+      test('returns "Disadvantage" for win rate < 40%', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+        );
+
+        expect(stats.matchupAdvantage, equals('Disadvantage'));
+      });
+    });
+
+    group('isRivalry', () {
+      test('returns true for 10+ games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+        );
+
+        expect(stats.isRivalry, isTrue);
+      });
+
+      test('returns false for less than 10 games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 9,
+          gamesWon: 5,
+          gamesLost: 4,
+        );
+
+        expect(stats.isRivalry, isFalse);
+      });
+    });
+
+    group('rivalryIntensity', () {
+      test('returns "New matchup" for less than 5 games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 4,
+          gamesWon: 2,
+          gamesLost: 2,
+        );
+
+        expect(stats.rivalryIntensity, equals('New matchup'));
+      });
+
+      test('returns "Developing rivalry" for 5-9 games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 7,
+          gamesWon: 4,
+          gamesLost: 3,
+        );
+
+        expect(stats.rivalryIntensity, equals('Developing rivalry'));
+      });
+
+      test('returns "Active rivalry" for 10-19 games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 15,
+          gamesWon: 8,
+          gamesLost: 7,
+        );
+
+        expect(stats.rivalryIntensity, equals('Active rivalry'));
+      });
+
+      test('returns "Intense rivalry" for 20+ games', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 25,
+          gamesWon: 13,
+          gamesLost: 12,
+        );
+
+        expect(stats.rivalryIntensity, equals('Intense rivalry'));
+      });
+    });
+
+    group('opponentDisplayName', () {
+      test('returns opponentName when available', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          opponentName: 'John Doe',
+          opponentEmail: 'john@example.com',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+        );
+
+        expect(stats.opponentDisplayName, equals('John Doe'));
+      });
+
+      test('returns opponentEmail when name is null', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          opponentEmail: 'john@example.com',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+        );
+
+        expect(stats.opponentDisplayName, equals('john@example.com'));
+      });
+
+      test('returns "Unknown" when both name and email are null', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-1',
+          opponentId: 'opponent-1',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+        );
+
+        expect(stats.opponentDisplayName, equals('Unknown'));
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes from JSON with all fields', () {
+        final json = {
+          'userId': 'user-123',
+          'opponentId': 'opponent-456',
+          'opponentName': 'John Doe',
+          'opponentEmail': 'john@example.com',
+          'opponentPhotoUrl': 'https://example.com/photo.jpg',
+          'gamesPlayed': 15,
+          'gamesWon': 9,
+          'gamesLost': 6,
+          'pointsScored': 300,
+          'pointsAllowed': 280,
+          'eloChange': 35.5,
+          'largestVictoryMargin': 10,
+          'largestDefeatMargin': 5,
+          'recentMatchups': [],
+          'lastUpdated': testTimestamp,
+        };
+
+        final stats = HeadToHeadStats.fromJson(json);
+
+        expect(stats.userId, equals('user-123'));
+        expect(stats.opponentId, equals('opponent-456'));
+        expect(stats.opponentName, equals('John Doe'));
+        expect(stats.gamesPlayed, equals(15));
+        expect(stats.gamesWon, equals(9));
+        expect(stats.lastUpdated, equals(testDate));
+      });
+
+      test('deserializes with nested recent matchups', () {
+        final json = {
+          'userId': 'user-123',
+          'opponentId': 'opponent-456',
+          'gamesPlayed': 2,
+          'gamesWon': 1,
+          'gamesLost': 1,
+          'recentMatchups': [
+            {
+              'gameId': 'game-1',
+              'won': true,
+              'pointsScored': 21,
+              'pointsAllowed': 15,
+              'eloChange': 10.0,
+              'timestamp': testTimestamp,
+            },
+          ],
+        };
+
+        final stats = HeadToHeadStats.fromJson(json);
+
+        expect(stats.recentMatchups.length, equals(1));
+        expect(stats.recentMatchups.first.gameId, equals('game-1'));
+        expect(stats.recentMatchups.first.won, isTrue);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes to JSON correctly', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          opponentName: 'John Doe',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+          lastUpdated: testDate,
+        );
+
+        final json = stats.toJson();
+
+        expect(json['userId'], equals('user-123'));
+        expect(json['opponentId'], equals('opponent-456'));
+        expect(json['opponentName'], equals('John Doe'));
+        expect(json['gamesPlayed'], equals(15));
+      });
+
+      test('round-trip serialization preserves data', () {
+        final original = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+          lastUpdated: testDate,
+        );
+
+        final json = original.toJson();
+        final restored = HeadToHeadStats.fromJson(json);
+
+        expect(restored.userId, equals(original.userId));
+        expect(restored.opponentId, equals(original.opponentId));
+        expect(restored.gamesPlayed, equals(original.gamesPlayed));
+      });
+    });
+
+    group('toFirestore', () {
+      test('returns JSON representation for Firestore', () {
+        final stats = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+        );
+
+        final firestoreData = stats.toFirestore();
+
+        expect(firestoreData['userId'], equals('user-123'));
+        expect(firestoreData['gamesPlayed'], equals(10));
+      });
+    });
+
+    group('equality', () {
+      test('two stats with same values are equal', () {
+        final stats1 = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+          lastUpdated: testDate,
+        );
+
+        final stats2 = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+          lastUpdated: testDate,
+        );
+
+        expect(stats1, equals(stats2));
+        expect(stats1.hashCode, equals(stats2.hashCode));
+      });
+
+      test('two stats with different opponentId are not equal', () {
+        final stats1 = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+        );
+
+        final stats2 = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-789',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+        );
+
+        expect(stats1, isNot(equals(stats2)));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated gamesWon', () {
+        final original = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+        );
+
+        final copy = original.copyWith(gamesWon: 10);
+
+        expect(copy.gamesWon, equals(10));
+        expect(copy.userId, equals(original.userId));
+        expect(copy.opponentId, equals(original.opponentId));
+      });
+
+      test('creates identical copy when no parameters provided', () {
+        final original = HeadToHeadStats(
+          userId: 'user-123',
+          opponentId: 'opponent-456',
+          gamesPlayed: 15,
+          gamesWon: 9,
+          gamesLost: 6,
+        );
+
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+      });
+    });
+  });
+
+  group('HeadToHeadGameResult', () {
+    final testDate = DateTime(2025, 12, 29, 14, 30);
+    final testTimestamp = Timestamp.fromDate(testDate);
+
+    group('constructor', () {
+      test('creates instance with all required fields', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          partnerId: 'partner-1',
+          opponentPartnerId: 'opp-partner-1',
+          timestamp: testDate,
+        );
+
+        expect(result.gameId, equals('game-123'));
+        expect(result.won, isTrue);
+        expect(result.pointsScored, equals(21));
+        expect(result.pointsAllowed, equals(15));
+        expect(result.eloChange, equals(12.5));
+        expect(result.partnerId, equals('partner-1'));
+        expect(result.opponentPartnerId, equals('opp-partner-1'));
+        expect(result.timestamp, equals(testDate));
+      });
+
+      test('creates instance with optional fields as null', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: false,
+          pointsScored: 18,
+          pointsAllowed: 21,
+          eloChange: -8.0,
+          timestamp: testDate,
+        );
+
+        expect(result.partnerId, isNull);
+        expect(result.opponentPartnerId, isNull);
+      });
+    });
+
+    group('pointDifferential', () {
+      test('calculates positive differential', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(6));
+      });
+
+      test('calculates negative differential', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(-6));
+      });
+    });
+
+    group('formattedPointDifferential', () {
+      test('formats positive differential with plus sign', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedPointDifferential, equals('+6'));
+      });
+
+      test('formats negative differential without plus sign', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedPointDifferential, equals('-6'));
+      });
+    });
+
+    group('formattedEloChange', () {
+      test('formats positive ELO change', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedEloChange, equals('+12.5'));
+      });
+
+      test('formats negative ELO change', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -8.5,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedEloChange, equals('-8.5'));
+      });
+    });
+
+    group('resultLetter', () {
+      test('returns W for win', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.resultLetter, equals('W'));
+      });
+
+      test('returns L for loss', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.resultLetter, equals('L'));
+      });
+    });
+
+    group('resultDisplay', () {
+      test('returns display map for win', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final display = result.resultDisplay;
+        expect(display['text'], equals('W'));
+        expect(display['won'], isTrue);
+      });
+
+      test('returns display map for loss', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        final display = result.resultDisplay;
+        expect(display['text'], equals('L'));
+        expect(display['won'], isFalse);
+      });
+    });
+
+    group('scoreDisplay', () {
+      test('formats score correctly for win', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.scoreDisplay, equals('21-15'));
+      });
+
+      test('formats score correctly for loss', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 18,
+          pointsAllowed: 21,
+          eloChange: -8.0,
+          timestamp: testDate,
+        );
+
+        expect(result.scoreDisplay, equals('18-21'));
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes from JSON with Timestamp', () {
+        final json = {
+          'gameId': 'game-123',
+          'won': true,
+          'pointsScored': 21,
+          'pointsAllowed': 15,
+          'eloChange': 12.5,
+          'partnerId': 'partner-1',
+          'opponentPartnerId': 'opp-partner-1',
+          'timestamp': testTimestamp,
+        };
+
+        final result = HeadToHeadGameResult.fromJson(json);
+
+        expect(result.gameId, equals('game-123'));
+        expect(result.won, isTrue);
+        expect(result.partnerId, equals('partner-1'));
+        expect(result.timestamp, equals(testDate));
+      });
+
+      test('deserializes from JSON with null optional fields', () {
+        final json = {
+          'gameId': 'game-456',
+          'won': false,
+          'pointsScored': 18,
+          'pointsAllowed': 21,
+          'eloChange': -8.0,
+          'timestamp': testTimestamp,
+        };
+
+        final result = HeadToHeadGameResult.fromJson(json);
+
+        expect(result.partnerId, isNull);
+        expect(result.opponentPartnerId, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes to JSON correctly', () {
+        final result = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          timestamp: testDate,
+        );
+
+        final json = result.toJson();
+
+        expect(json['gameId'], equals('game-123'));
+        expect(json['won'], isTrue);
+        expect(json['pointsScored'], equals(21));
+      });
+
+      test('round-trip serialization preserves data', () {
+        final original = HeadToHeadGameResult(
+          gameId: 'game-789',
+          won: false,
+          pointsScored: 19,
+          pointsAllowed: 21,
+          eloChange: -5.5,
+          partnerId: 'partner-abc',
+          timestamp: testDate,
+        );
+
+        final json = original.toJson();
+        final restored = HeadToHeadGameResult.fromJson(json);
+
+        expect(restored.gameId, equals(original.gameId));
+        expect(restored.won, equals(original.won));
+        expect(restored.partnerId, equals(original.partnerId));
+      });
+    });
+
+    group('equality', () {
+      test('two results with same values are equal', () {
+        final result1 = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final result2 = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result1, equals(result2));
+        expect(result1.hashCode, equals(result2.hashCode));
+      });
+
+      test('two results with different gameId are not equal', () {
+        final result1 = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final result2 = HeadToHeadGameResult(
+          gameId: 'game-456',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result1, isNot(equals(result2)));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated won status', () {
+        final original = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final copy = original.copyWith(won: false);
+
+        expect(copy.won, isFalse);
+        expect(copy.gameId, equals(original.gameId));
+      });
+
+      test('creates identical copy when no parameters provided', () {
+        final original = HeadToHeadGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+      });
+    });
+  });
+}

--- a/test/unit/core/data/models/teammate_stats_test.dart
+++ b/test/unit/core/data/models/teammate_stats_test.dart
@@ -1,0 +1,1014 @@
+// Tests TeammateStats and RecentGameResult models for partner performance tracking (Story 16.3.3.1).
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
+
+void main() {
+  group('TeammateStats', () {
+    final testDate = DateTime(2025, 12, 29, 10, 30);
+    final testTimestamp = Timestamp.fromDate(testDate);
+
+    group('constructor', () {
+      test('creates instance with all required fields', () {
+        final stats = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+          pointsScored: 400,
+          pointsAllowed: 350,
+          eloChange: 45.5,
+          recentGames: [],
+          lastUpdated: testDate,
+        );
+
+        expect(stats.userId, equals('user-123'));
+        expect(stats.gamesPlayed, equals(20));
+        expect(stats.gamesWon, equals(12));
+        expect(stats.gamesLost, equals(8));
+        expect(stats.pointsScored, equals(400));
+        expect(stats.pointsAllowed, equals(350));
+        expect(stats.eloChange, equals(45.5));
+        expect(stats.recentGames, isEmpty);
+        expect(stats.lastUpdated, equals(testDate));
+      });
+
+      test('creates instance with default values', () {
+        final stats = TeammateStats(
+          userId: 'user-456',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+        );
+
+        expect(stats.pointsScored, equals(0));
+        expect(stats.pointsAllowed, equals(0));
+        expect(stats.eloChange, equals(0.0));
+        expect(stats.recentGames, isEmpty);
+        expect(stats.lastUpdated, isNull);
+      });
+    });
+
+    group('winRate', () {
+      test('calculates win rate correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        expect(stats.winRate, equals(60.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.winRate, equals(0.0));
+      });
+
+      test('calculates 100% win rate', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 10,
+          gamesLost: 0,
+        );
+
+        expect(stats.winRate, equals(100.0));
+      });
+    });
+
+    group('lossRate', () {
+      test('calculates loss rate correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        expect(stats.lossRate, equals(40.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.lossRate, equals(0.0));
+      });
+    });
+
+    group('avgPointsScored', () {
+      test('calculates average points scored correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+          pointsScored: 200,
+        );
+
+        expect(stats.avgPointsScored, equals(20.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+          pointsScored: 0,
+        );
+
+        expect(stats.avgPointsScored, equals(0.0));
+      });
+    });
+
+    group('avgPointsAllowed', () {
+      test('calculates average points allowed correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+          pointsAllowed: 180,
+        );
+
+        expect(stats.avgPointsAllowed, equals(18.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.avgPointsAllowed, equals(0.0));
+      });
+    });
+
+    group('avgPointDifferential', () {
+      test('calculates positive point differential', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          pointsScored: 200,
+          pointsAllowed: 150,
+        );
+
+        expect(stats.avgPointDifferential, equals(5.0)); // 20 - 15
+      });
+
+      test('calculates negative point differential', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 150,
+          pointsAllowed: 200,
+        );
+
+        expect(stats.avgPointDifferential, equals(-5.0)); // 15 - 20
+      });
+    });
+
+    group('avgEloChange', () {
+      test('calculates average ELO change correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+          eloChange: 50.0,
+        );
+
+        expect(stats.avgEloChange, equals(5.0));
+      });
+
+      test('returns 0 when no games played', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+        );
+
+        expect(stats.avgEloChange, equals(0.0));
+      });
+    });
+
+    group('currentStreak', () {
+      test('returns positive streak for consecutive wins', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+          recentGames: [
+            RecentGameResult(
+              gameId: 'g1',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 15,
+              eloChange: 10.0,
+              timestamp: testDate,
+            ),
+            RecentGameResult(
+              gameId: 'g2',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 18,
+              eloChange: 8.0,
+              timestamp: testDate.subtract(const Duration(days: 1)),
+            ),
+            RecentGameResult(
+              gameId: 'g3',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 19,
+              eloChange: 7.0,
+              timestamp: testDate.subtract(const Duration(days: 2)),
+            ),
+            RecentGameResult(
+              gameId: 'g4',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: testDate.subtract(const Duration(days: 3)),
+            ),
+          ],
+        );
+
+        expect(stats.currentStreak, equals(3));
+      });
+
+      test('returns negative streak for consecutive losses', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 4,
+          gamesWon: 1,
+          gamesLost: 3,
+          recentGames: [
+            RecentGameResult(
+              gameId: 'g1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: testDate,
+            ),
+            RecentGameResult(
+              gameId: 'g2',
+              won: false,
+              pointsScored: 18,
+              pointsAllowed: 21,
+              eloChange: -8.0,
+              timestamp: testDate.subtract(const Duration(days: 1)),
+            ),
+            RecentGameResult(
+              gameId: 'g3',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 15,
+              eloChange: 10.0,
+              timestamp: testDate.subtract(const Duration(days: 2)),
+            ),
+          ],
+        );
+
+        expect(stats.currentStreak, equals(-2));
+      });
+
+      test('returns 0 when no recent games', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 0,
+          gamesWon: 0,
+          gamesLost: 0,
+          recentGames: [],
+        );
+
+        expect(stats.currentStreak, equals(0));
+      });
+    });
+
+    group('isOnWinningStreak / isOnLosingStreak', () {
+      test('isOnWinningStreak returns true for positive streak', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 2,
+          gamesWon: 2,
+          gamesLost: 0,
+          recentGames: [
+            RecentGameResult(
+              gameId: 'g1',
+              won: true,
+              pointsScored: 21,
+              pointsAllowed: 15,
+              eloChange: 10.0,
+              timestamp: testDate,
+            ),
+          ],
+        );
+
+        expect(stats.isOnWinningStreak, isTrue);
+        expect(stats.isOnLosingStreak, isFalse);
+      });
+
+      test('isOnLosingStreak returns true for negative streak', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 2,
+          gamesWon: 0,
+          gamesLost: 2,
+          recentGames: [
+            RecentGameResult(
+              gameId: 'g1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: testDate,
+            ),
+          ],
+        );
+
+        expect(stats.isOnWinningStreak, isFalse);
+        expect(stats.isOnLosingStreak, isTrue);
+      });
+    });
+
+    group('recordString', () {
+      test('formats record correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        expect(stats.recordString, equals('12W - 8L'));
+      });
+
+      test('formats perfect record', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 10,
+          gamesLost: 0,
+        );
+
+        expect(stats.recordString, equals('10W - 0L'));
+      });
+    });
+
+    group('formattedPointDifferential', () {
+      test('formats positive differential with plus sign', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          pointsScored: 200,
+          pointsAllowed: 150,
+        );
+
+        expect(stats.formattedPointDifferential, equals('+5.0'));
+      });
+
+      test('formats negative differential without plus sign', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 150,
+          pointsAllowed: 200,
+        );
+
+        expect(stats.formattedPointDifferential, equals('-5.0'));
+      });
+
+      test('formats zero differential with plus sign', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 5,
+          gamesLost: 5,
+          pointsScored: 180,
+          pointsAllowed: 180,
+        );
+
+        expect(stats.formattedPointDifferential, equals('+0.0'));
+      });
+    });
+
+    group('formattedEloChange', () {
+      test('formats positive ELO change with plus sign', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+          eloChange: 45.5,
+        );
+
+        expect(stats.formattedEloChange, equals('+45.5'));
+      });
+
+      test('formats negative ELO change without plus sign', () {
+        final stats = TeammateStats(
+          userId: 'user-1',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          eloChange: -32.5,
+        );
+
+        expect(stats.formattedEloChange, equals('-32.5'));
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes from JSON with all fields', () {
+        final json = {
+          'userId': 'user-123',
+          'gamesPlayed': 20,
+          'gamesWon': 12,
+          'gamesLost': 8,
+          'pointsScored': 400,
+          'pointsAllowed': 350,
+          'eloChange': 45.5,
+          'recentGames': [],
+          'lastUpdated': testTimestamp,
+        };
+
+        final stats = TeammateStats.fromJson(json);
+
+        expect(stats.userId, equals('user-123'));
+        expect(stats.gamesPlayed, equals(20));
+        expect(stats.gamesWon, equals(12));
+        expect(stats.gamesLost, equals(8));
+        expect(stats.pointsScored, equals(400));
+        expect(stats.pointsAllowed, equals(350));
+        expect(stats.eloChange, equals(45.5));
+        expect(stats.lastUpdated, equals(testDate));
+      });
+
+      test('deserializes with nested recent games', () {
+        final json = {
+          'userId': 'user-123',
+          'gamesPlayed': 2,
+          'gamesWon': 1,
+          'gamesLost': 1,
+          'recentGames': [
+            {
+              'gameId': 'game-1',
+              'won': true,
+              'pointsScored': 21,
+              'pointsAllowed': 15,
+              'eloChange': 10.0,
+              'timestamp': testTimestamp,
+            },
+          ],
+        };
+
+        final stats = TeammateStats.fromJson(json);
+
+        expect(stats.recentGames.length, equals(1));
+        expect(stats.recentGames.first.gameId, equals('game-1'));
+        expect(stats.recentGames.first.won, isTrue);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes to JSON correctly', () {
+        final stats = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+          pointsScored: 400,
+          pointsAllowed: 350,
+          eloChange: 45.5,
+          lastUpdated: testDate,
+        );
+
+        final json = stats.toJson();
+
+        expect(json['userId'], equals('user-123'));
+        expect(json['gamesPlayed'], equals(20));
+        expect(json['gamesWon'], equals(12));
+        expect(json['gamesLost'], equals(8));
+        expect(json['pointsScored'], equals(400));
+        expect(json['pointsAllowed'], equals(350));
+        expect(json['eloChange'], equals(45.5));
+      });
+
+      test('round-trip serialization preserves data', () {
+        final original = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+          pointsScored: 400,
+          pointsAllowed: 350,
+          eloChange: 45.5,
+          lastUpdated: testDate,
+        );
+
+        final json = original.toJson();
+        final restored = TeammateStats.fromJson(json);
+
+        expect(restored.userId, equals(original.userId));
+        expect(restored.gamesPlayed, equals(original.gamesPlayed));
+        expect(restored.gamesWon, equals(original.gamesWon));
+        expect(restored.gamesLost, equals(original.gamesLost));
+      });
+    });
+
+    group('fromFirestore', () {
+      test('creates instance from Firestore data', () {
+        final data = {
+          'gamesPlayed': 15,
+          'gamesWon': 9,
+          'gamesLost': 6,
+          'pointsScored': 300,
+          'pointsAllowed': 280,
+          'eloChange': 25.0,
+          'recentGames': [],
+          'lastUpdated': testTimestamp,
+        };
+
+        final stats = TeammateStats.fromFirestore('user-abc', data);
+
+        expect(stats.userId, equals('user-abc'));
+        expect(stats.gamesPlayed, equals(15));
+        expect(stats.gamesWon, equals(9));
+      });
+    });
+
+    group('toFirestore', () {
+      test('excludes userId from output', () {
+        final stats = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+        );
+
+        final firestoreData = stats.toFirestore();
+
+        expect(firestoreData.containsKey('userId'), isFalse);
+        expect(firestoreData['gamesPlayed'], equals(10));
+      });
+    });
+
+    group('equality', () {
+      test('two stats with same values are equal', () {
+        final stats1 = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+          lastUpdated: testDate,
+        );
+
+        final stats2 = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+          lastUpdated: testDate,
+        );
+
+        expect(stats1, equals(stats2));
+        expect(stats1.hashCode, equals(stats2.hashCode));
+      });
+
+      test('two stats with different userId are not equal', () {
+        final stats1 = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        final stats2 = TeammateStats(
+          userId: 'user-456',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        expect(stats1, isNot(equals(stats2)));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated gamesWon', () {
+        final original = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        final copy = original.copyWith(gamesWon: 13);
+
+        expect(copy.gamesWon, equals(13));
+        expect(copy.userId, equals(original.userId));
+        expect(copy.gamesPlayed, equals(original.gamesPlayed));
+      });
+
+      test('creates identical copy when no parameters provided', () {
+        final original = TeammateStats(
+          userId: 'user-123',
+          gamesPlayed: 20,
+          gamesWon: 12,
+          gamesLost: 8,
+        );
+
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+      });
+    });
+  });
+
+  group('RecentGameResult', () {
+    final testDate = DateTime(2025, 12, 29, 14, 30);
+    final testTimestamp = Timestamp.fromDate(testDate);
+
+    group('constructor', () {
+      test('creates instance with all required fields', () {
+        final result = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          timestamp: testDate,
+        );
+
+        expect(result.gameId, equals('game-123'));
+        expect(result.won, isTrue);
+        expect(result.pointsScored, equals(21));
+        expect(result.pointsAllowed, equals(15));
+        expect(result.eloChange, equals(12.5));
+        expect(result.timestamp, equals(testDate));
+      });
+    });
+
+    group('pointDifferential', () {
+      test('calculates positive differential', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(6));
+      });
+
+      test('calculates negative differential', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(-6));
+      });
+    });
+
+    group('formattedPointDifferential', () {
+      test('formats positive differential with plus sign', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedPointDifferential, equals('+6'));
+      });
+
+      test('formats negative differential without plus sign', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedPointDifferential, equals('-6'));
+      });
+    });
+
+    group('formattedEloChange', () {
+      test('formats positive ELO change', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedEloChange, equals('+12.5'));
+      });
+
+      test('formats negative ELO change', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -8.5,
+          timestamp: testDate,
+        );
+
+        expect(result.formattedEloChange, equals('-8.5'));
+      });
+    });
+
+    group('resultLetter', () {
+      test('returns W for win', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.resultLetter, equals('W'));
+      });
+
+      test('returns L for loss', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        expect(result.resultLetter, equals('L'));
+      });
+    });
+
+    group('resultDisplay', () {
+      test('returns display map for win', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final display = result.resultDisplay;
+        expect(display['text'], equals('W'));
+        expect(display['won'], isTrue);
+      });
+
+      test('returns display map for loss', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: false,
+          pointsScored: 15,
+          pointsAllowed: 21,
+          eloChange: -10.0,
+          timestamp: testDate,
+        );
+
+        final display = result.resultDisplay;
+        expect(display['text'], equals('L'));
+        expect(display['won'], isFalse);
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes from JSON with Timestamp', () {
+        final json = {
+          'gameId': 'game-123',
+          'won': true,
+          'pointsScored': 21,
+          'pointsAllowed': 15,
+          'eloChange': 12.5,
+          'timestamp': testTimestamp,
+        };
+
+        final result = RecentGameResult.fromJson(json);
+
+        expect(result.gameId, equals('game-123'));
+        expect(result.won, isTrue);
+        expect(result.pointsScored, equals(21));
+        expect(result.pointsAllowed, equals(15));
+        expect(result.eloChange, equals(12.5));
+        expect(result.timestamp, equals(testDate));
+      });
+
+      test('deserializes from JSON with DateTime string', () {
+        final json = {
+          'gameId': 'game-456',
+          'won': false,
+          'pointsScored': 18,
+          'pointsAllowed': 21,
+          'eloChange': -8.0,
+          'timestamp': testDate.toIso8601String(),
+        };
+
+        final result = RecentGameResult.fromJson(json);
+
+        expect(result.gameId, equals('game-456'));
+        expect(result.won, isFalse);
+        expect(result.timestamp.year, equals(testDate.year));
+      });
+    });
+
+    group('toJson', () {
+      test('serializes to JSON correctly', () {
+        final result = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 12.5,
+          timestamp: testDate,
+        );
+
+        final json = result.toJson();
+
+        expect(json['gameId'], equals('game-123'));
+        expect(json['won'], isTrue);
+        expect(json['pointsScored'], equals(21));
+        expect(json['pointsAllowed'], equals(15));
+        expect(json['eloChange'], equals(12.5));
+      });
+
+      test('round-trip serialization preserves data', () {
+        final original = RecentGameResult(
+          gameId: 'game-789',
+          won: false,
+          pointsScored: 19,
+          pointsAllowed: 21,
+          eloChange: -5.5,
+          timestamp: testDate,
+        );
+
+        final json = original.toJson();
+        final restored = RecentGameResult.fromJson(json);
+
+        expect(restored.gameId, equals(original.gameId));
+        expect(restored.won, equals(original.won));
+        expect(restored.pointsScored, equals(original.pointsScored));
+        expect(restored.pointsAllowed, equals(original.pointsAllowed));
+        expect(restored.eloChange, equals(original.eloChange));
+      });
+    });
+
+    group('equality', () {
+      test('two results with same values are equal', () {
+        final result1 = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final result2 = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result1, equals(result2));
+        expect(result1.hashCode, equals(result2.hashCode));
+      });
+
+      test('two results with different gameId are not equal', () {
+        final result1 = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final result2 = RecentGameResult(
+          gameId: 'game-456',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        expect(result1, isNot(equals(result2)));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated won status', () {
+        final original = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final copy = original.copyWith(won: false);
+
+        expect(copy.won, isFalse);
+        expect(copy.gameId, equals(original.gameId));
+      });
+
+      test('creates identical copy when no parameters provided', () {
+        final original = RecentGameResult(
+          gameId: 'game-123',
+          won: true,
+          pointsScored: 21,
+          pointsAllowed: 15,
+          eloChange: 10.0,
+          timestamp: testDate,
+        );
+
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+      });
+    });
+
+    group('edge cases', () {
+      test('handles zero point game', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 0,
+          pointsAllowed: 0,
+          eloChange: 0.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(0));
+        expect(result.formattedPointDifferential, equals('+0'));
+      });
+
+      test('handles large scores', () {
+        final result = RecentGameResult(
+          gameId: 'g1',
+          won: true,
+          pointsScored: 35,
+          pointsAllowed: 33,
+          eloChange: 5.0,
+          timestamp: testDate,
+        );
+
+        expect(result.pointDifferential, equals(2));
+        expect(result.formattedPointDifferential, equals('+2'));
+      });
+    });
+  });
+}

--- a/test/unit/core/data/models/training_session_model_test.dart
+++ b/test/unit/core/data/models/training_session_model_test.dart
@@ -1,0 +1,784 @@
+// Tests TrainingSessionModel for training session functionality (Story 16.3.3.2).
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/data/models/recurrence_rule_model.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
+
+void main() {
+  group('TrainingSessionModel', () {
+    late DateTime now;
+    late DateTime futureStart;
+    late DateTime futureEnd;
+    late DateTime pastStart;
+    late DateTime pastEnd;
+    late DateTime createdAt;
+    late TrainingSessionModel baseSession;
+
+    const testLocation = GameLocation(name: 'Beach Court 1', address: '123 Beach Rd');
+
+    setUp(() {
+      now = DateTime.now();
+      futureStart = now.add(const Duration(days: 1));
+      futureEnd = now.add(const Duration(days: 1, hours: 2));
+      pastStart = now.subtract(const Duration(days: 1));
+      pastEnd = now.subtract(const Duration(days: 1)).add(const Duration(hours: 2));
+      createdAt = now.subtract(const Duration(days: 7));
+
+      baseSession = TrainingSessionModel(
+        id: 'session-123',
+        groupId: 'group-456',
+        title: 'Morning Practice',
+        description: 'Beach volleyball drills',
+        location: testLocation,
+        startTime: futureStart,
+        endTime: futureEnd,
+        minParticipants: 4,
+        maxParticipants: 8,
+        createdBy: 'creator-user',
+        createdAt: createdAt,
+        participantIds: ['user-1', 'user-2', 'user-3'],
+      );
+    });
+
+    group('constructor', () {
+      test('creates instance with all required fields', () {
+        expect(baseSession.id, equals('session-123'));
+        expect(baseSession.groupId, equals('group-456'));
+        expect(baseSession.title, equals('Morning Practice'));
+        expect(baseSession.description, equals('Beach volleyball drills'));
+        expect(baseSession.location, equals(testLocation));
+        expect(baseSession.startTime, equals(futureStart));
+        expect(baseSession.endTime, equals(futureEnd));
+        expect(baseSession.minParticipants, equals(4));
+        expect(baseSession.maxParticipants, equals(8));
+        expect(baseSession.createdBy, equals('creator-user'));
+        expect(baseSession.createdAt, equals(createdAt));
+        expect(baseSession.participantIds.length, equals(3));
+      });
+
+      test('creates instance with default values', () {
+        final session = TrainingSessionModel(
+          id: 'session-1',
+          groupId: 'group-1',
+          title: 'Test Session',
+          location: testLocation,
+          startTime: futureStart,
+          endTime: futureEnd,
+          minParticipants: 2,
+          maxParticipants: 4,
+          createdBy: 'creator',
+          createdAt: createdAt,
+        );
+
+        expect(session.description, isNull);
+        expect(session.updatedAt, isNull);
+        expect(session.recurrenceRule, isNull);
+        expect(session.parentSessionId, isNull);
+        expect(session.status, equals(TrainingStatus.scheduled));
+        expect(session.participantIds, isEmpty);
+        expect(session.notes, isNull);
+        expect(session.cancelledBy, isNull);
+        expect(session.cancelledAt, isNull);
+      });
+    });
+
+    group('isParticipant', () {
+      test('returns true for existing participant', () {
+        expect(baseSession.isParticipant('user-1'), isTrue);
+        expect(baseSession.isParticipant('user-2'), isTrue);
+      });
+
+      test('returns false for non-participant', () {
+        expect(baseSession.isParticipant('user-99'), isFalse);
+      });
+    });
+
+    group('isCreator', () {
+      test('returns true for creator', () {
+        expect(baseSession.isCreator('creator-user'), isTrue);
+      });
+
+      test('returns false for non-creator', () {
+        expect(baseSession.isCreator('other-user'), isFalse);
+      });
+    });
+
+    group('canManage', () {
+      test('returns true for creator', () {
+        expect(baseSession.canManage('creator-user'), isTrue);
+      });
+
+      test('returns false for non-creator', () {
+        expect(baseSession.canManage('other-user'), isFalse);
+      });
+    });
+
+    group('isFull', () {
+      test('returns false when not at max capacity', () {
+        expect(baseSession.isFull, isFalse); // 3 of 8
+      });
+
+      test('returns true when at max capacity', () {
+        final fullSession = baseSession.copyWith(
+          participantIds: ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'],
+        );
+        expect(fullSession.isFull, isTrue);
+      });
+    });
+
+    group('hasMinimumParticipants', () {
+      test('returns false when below minimum', () {
+        expect(baseSession.hasMinimumParticipants, isFalse); // 3 of 4 minimum
+      });
+
+      test('returns true when at or above minimum', () {
+        final session = baseSession.copyWith(
+          participantIds: ['u1', 'u2', 'u3', 'u4'],
+        );
+        expect(session.hasMinimumParticipants, isTrue);
+      });
+    });
+
+    group('availableSpots', () {
+      test('calculates available spots correctly', () {
+        expect(baseSession.availableSpots, equals(5)); // 8 - 3
+      });
+
+      test('returns 0 when full', () {
+        final fullSession = baseSession.copyWith(
+          participantIds: ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'],
+        );
+        expect(fullSession.availableSpots, equals(0));
+      });
+    });
+
+    group('currentParticipantCount', () {
+      test('returns correct count', () {
+        expect(baseSession.currentParticipantCount, equals(3));
+      });
+
+      test('returns 0 for empty session', () {
+        final emptySession = baseSession.copyWith(participantIds: []);
+        expect(emptySession.currentParticipantCount, equals(0));
+      });
+    });
+
+    group('isPast', () {
+      test('returns false for future session', () {
+        expect(baseSession.isPast, isFalse);
+      });
+
+      test('returns true for past session', () {
+        final pastSession = baseSession.copyWith(startTime: pastStart);
+        expect(pastSession.isPast, isTrue);
+      });
+    });
+
+    group('isToday', () {
+      test('returns true for session starting today', () {
+        final todaySession = baseSession.copyWith(
+          startTime: DateTime(now.year, now.month, now.day, 18, 0),
+        );
+        expect(todaySession.isToday, isTrue);
+      });
+
+      test('returns false for session not today', () {
+        expect(baseSession.isToday, isFalse); // Tomorrow
+      });
+    });
+
+    group('isThisWeek', () {
+      test('returns true for session this week', () {
+        // Create a session in the middle of this week
+        final midWeek = now.add(Duration(days: (7 - now.weekday) ~/ 2));
+        final thisWeekSession = baseSession.copyWith(startTime: midWeek);
+        expect(thisWeekSession.isThisWeek, isTrue);
+      });
+    });
+
+    group('duration', () {
+      test('calculates duration correctly', () {
+        expect(baseSession.duration, equals(const Duration(hours: 2)));
+      });
+
+      test('handles different durations', () {
+        final longSession = baseSession.copyWith(
+          endTime: futureStart.add(const Duration(hours: 4)),
+        );
+        expect(longSession.duration, equals(const Duration(hours: 4)));
+      });
+    });
+
+    group('canUserJoin', () {
+      test('returns true for eligible user', () {
+        expect(baseSession.canUserJoin('new-user'), isTrue);
+      });
+
+      test('returns false for existing participant', () {
+        expect(baseSession.canUserJoin('user-1'), isFalse);
+      });
+
+      test('returns false when session is full', () {
+        final fullSession = baseSession.copyWith(
+          participantIds: ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'],
+        );
+        expect(fullSession.canUserJoin('new-user'), isFalse);
+      });
+
+      test('returns false when session is cancelled', () {
+        final cancelledSession = baseSession.copyWith(
+          status: TrainingStatus.cancelled,
+        );
+        expect(cancelledSession.canUserJoin('new-user'), isFalse);
+      });
+
+      test('returns false when session is completed', () {
+        final completedSession = baseSession.copyWith(
+          status: TrainingStatus.completed,
+        );
+        expect(completedSession.canUserJoin('new-user'), isFalse);
+      });
+
+      test('returns false when session is past', () {
+        final pastSession = baseSession.copyWith(startTime: pastStart);
+        expect(pastSession.canUserJoin('new-user'), isFalse);
+      });
+    });
+
+    group('canUserLeave', () {
+      test('returns true for participant in scheduled session', () {
+        expect(baseSession.canUserLeave('user-1'), isTrue);
+      });
+
+      test('returns false for non-participant', () {
+        expect(baseSession.canUserLeave('non-participant'), isFalse);
+      });
+
+      test('returns false when session is cancelled', () {
+        final cancelledSession = baseSession.copyWith(
+          status: TrainingStatus.cancelled,
+        );
+        expect(cancelledSession.canUserLeave('user-1'), isFalse);
+      });
+
+      test('returns false when session is completed', () {
+        final completedSession = baseSession.copyWith(
+          status: TrainingStatus.completed,
+        );
+        expect(completedSession.canUserLeave('user-1'), isFalse);
+      });
+    });
+
+    group('hasValidTiming', () {
+      test('returns true for valid future session', () {
+        expect(baseSession.hasValidTiming, isTrue);
+      });
+
+      test('returns false for past session', () {
+        final pastSession = baseSession.copyWith(
+          startTime: pastStart,
+          endTime: pastEnd,
+        );
+        expect(pastSession.hasValidTiming, isFalse);
+      });
+
+      test('returns false when endTime is before startTime', () {
+        final invalidSession = baseSession.copyWith(
+          startTime: futureStart,
+          endTime: futureStart.subtract(const Duration(hours: 1)),
+        );
+        expect(invalidSession.hasValidTiming, isFalse);
+      });
+    });
+
+    group('hasValidParticipantLimits', () {
+      test('returns true for valid limits', () {
+        expect(baseSession.hasValidParticipantLimits, isTrue);
+      });
+
+      test('returns false when min > max', () {
+        final invalidSession = baseSession.copyWith(
+          minParticipants: 10,
+          maxParticipants: 5,
+        );
+        expect(invalidSession.hasValidParticipantLimits, isFalse);
+      });
+
+      test('returns false when min < 2', () {
+        final invalidSession = baseSession.copyWith(
+          minParticipants: 1,
+          maxParticipants: 4,
+        );
+        expect(invalidSession.hasValidParticipantLimits, isFalse);
+      });
+
+      test('returns true when min equals max', () {
+        final session = baseSession.copyWith(
+          minParticipants: 4,
+          maxParticipants: 4,
+        );
+        expect(session.hasValidParticipantLimits, isTrue);
+      });
+    });
+
+    group('updateInfo', () {
+      test('updates title', () {
+        final updated = baseSession.updateInfo(title: 'New Title');
+        expect(updated.title, equals('New Title'));
+        expect(updated.updatedAt, isNotNull);
+      });
+
+      test('updates description', () {
+        final updated = baseSession.updateInfo(description: 'New description');
+        expect(updated.description, equals('New description'));
+      });
+
+      test('updates startTime and endTime', () {
+        final newStart = now.add(const Duration(days: 3));
+        final newEnd = now.add(const Duration(days: 3, hours: 3));
+        final updated = baseSession.updateInfo(startTime: newStart, endTime: newEnd);
+        expect(updated.startTime, equals(newStart));
+        expect(updated.endTime, equals(newEnd));
+      });
+
+      test('updates location', () {
+        const newLocation = GameLocation(name: 'New Court', address: '456 New Rd');
+        final updated = baseSession.updateInfo(location: newLocation);
+        expect(updated.location, equals(newLocation));
+      });
+
+      test('updates notes', () {
+        final updated = baseSession.updateInfo(notes: 'Bring sunscreen');
+        expect(updated.notes, equals('Bring sunscreen'));
+      });
+
+      test('preserves unchanged fields', () {
+        final updated = baseSession.updateInfo(title: 'New Title');
+        expect(updated.groupId, equals(baseSession.groupId));
+        expect(updated.createdBy, equals(baseSession.createdBy));
+        expect(updated.participantIds, equals(baseSession.participantIds));
+      });
+    });
+
+    group('updateSettings', () {
+      test('updates maxParticipants', () {
+        final updated = baseSession.updateSettings(maxParticipants: 12);
+        expect(updated.maxParticipants, equals(12));
+        expect(updated.updatedAt, isNotNull);
+      });
+
+      test('updates minParticipants', () {
+        final updated = baseSession.updateSettings(minParticipants: 6);
+        expect(updated.minParticipants, equals(6));
+      });
+
+      test('updates both settings', () {
+        final updated = baseSession.updateSettings(
+          minParticipants: 6,
+          maxParticipants: 12,
+        );
+        expect(updated.minParticipants, equals(6));
+        expect(updated.maxParticipants, equals(12));
+      });
+    });
+
+    group('addParticipant', () {
+      test('adds new participant', () {
+        final updated = baseSession.addParticipant('new-user');
+        expect(updated.participantIds.contains('new-user'), isTrue);
+        expect(updated.participantIds.length, equals(4));
+        expect(updated.updatedAt, isNotNull);
+      });
+
+      test('does not add existing participant', () {
+        final updated = baseSession.addParticipant('user-1');
+        expect(updated.participantIds.length, equals(3)); // No change
+      });
+
+      test('does not add when full', () {
+        final fullSession = baseSession.copyWith(
+          participantIds: ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'],
+        );
+        final updated = fullSession.addParticipant('new-user');
+        expect(updated.participantIds.length, equals(8)); // No change
+      });
+    });
+
+    group('removeParticipant', () {
+      test('removes existing participant', () {
+        final updated = baseSession.removeParticipant('user-1');
+        expect(updated.participantIds.contains('user-1'), isFalse);
+        expect(updated.participantIds.length, equals(2));
+        expect(updated.updatedAt, isNotNull);
+      });
+
+      test('handles removing non-existent participant', () {
+        final updated = baseSession.removeParticipant('non-existent');
+        expect(updated.participantIds.length, equals(3)); // No change
+      });
+    });
+
+    group('completeSession', () {
+      test('sets status to completed when scheduled', () {
+        final completed = baseSession.completeSession();
+        expect(completed.status, equals(TrainingStatus.completed));
+        expect(completed.updatedAt, isNotNull);
+      });
+
+      test('does not change already cancelled session', () {
+        final cancelledSession = baseSession.copyWith(
+          status: TrainingStatus.cancelled,
+        );
+        final result = cancelledSession.completeSession();
+        expect(result.status, equals(TrainingStatus.cancelled));
+      });
+
+      test('does not change already completed session', () {
+        final completedSession = baseSession.copyWith(
+          status: TrainingStatus.completed,
+        );
+        final result = completedSession.completeSession();
+        expect(result.status, equals(TrainingStatus.completed));
+      });
+    });
+
+    group('getTimeUntilSession', () {
+      test('returns "Past" for past session', () {
+        final pastSession = baseSession.copyWith(startTime: pastStart);
+        expect(pastSession.getTimeUntilSession(), equals('Past'));
+      });
+
+      test('returns formatted days and hours for far future', () {
+        final farFuture = now.add(const Duration(days: 5, hours: 12));
+        final session = baseSession.copyWith(startTime: farFuture);
+        final result = session.getTimeUntilSession();
+        expect(result, contains('d'));
+        expect(result, contains('h'));
+      });
+
+      test('returns formatted hours and minutes for same day', () {
+        final soonStart = now.add(const Duration(hours: 3, minutes: 30));
+        final session = baseSession.copyWith(startTime: soonStart);
+        final result = session.getTimeUntilSession();
+        expect(result, contains('h'));
+        expect(result, contains('m'));
+      });
+
+      test('returns formatted minutes for very soon', () {
+        final verySoon = now.add(const Duration(minutes: 45));
+        final session = baseSession.copyWith(startTime: verySoon);
+        final result = session.getTimeUntilSession();
+        expect(result, contains('m'));
+      });
+    });
+
+    group('recurrence-related getters', () {
+      test('isRecurring returns false when no recurrence rule', () {
+        expect(baseSession.isRecurring, isFalse);
+      });
+
+      test('isRecurring returns true when has valid recurrence rule', () {
+        final recurringSession = baseSession.copyWith(
+          recurrenceRule: RecurrenceRuleModel.weekly(count: 10),
+        );
+        expect(recurringSession.isRecurring, isTrue);
+      });
+
+      test('isRecurring returns false when recurrence is none', () {
+        final session = baseSession.copyWith(
+          recurrenceRule: RecurrenceRuleModel.none(),
+        );
+        expect(session.isRecurring, isFalse);
+      });
+
+      test('isRecurrenceInstance returns false when no parent', () {
+        expect(baseSession.isRecurrenceInstance, isFalse);
+      });
+
+      test('isRecurrenceInstance returns true when has parent', () {
+        final childSession = baseSession.copyWith(
+          parentSessionId: 'parent-session-123',
+        );
+        expect(childSession.isRecurrenceInstance, isTrue);
+      });
+
+      test('isParentRecurringSession returns true for parent', () {
+        final parentSession = baseSession.copyWith(
+          recurrenceRule: RecurrenceRuleModel.weekly(count: 10),
+        );
+        expect(parentSession.isParentRecurringSession, isTrue);
+      });
+
+      test('isParentRecurringSession returns false for child', () {
+        final childSession = baseSession.copyWith(
+          recurrenceRule: RecurrenceRuleModel.weekly(count: 10),
+          parentSessionId: 'parent-session-123',
+        );
+        expect(childSession.isParentRecurringSession, isFalse);
+      });
+
+      test('recurrenceDescription returns null when no rule', () {
+        expect(baseSession.recurrenceDescription, isNull);
+      });
+
+      test('recurrenceDescription returns description when has rule', () {
+        final recurringSession = baseSession.copyWith(
+          recurrenceRule: RecurrenceRuleModel.weekly(count: 10),
+        );
+        expect(recurringSession.recurrenceDescription, isNotNull);
+        expect(recurringSession.recurrenceDescription, contains('weekly'));
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes from JSON with all fields', () {
+        // Note: fromJson expects ISO8601 strings for DateTime fields
+        // Timestamps are handled by fromFirestore method
+        final json = {
+          'id': 'session-123',
+          'groupId': 'group-456',
+          'title': 'Morning Practice',
+          'description': 'Beach volleyball drills',
+          'location': {'name': 'Beach Court 1', 'address': '123 Beach Rd'},
+          'startTime': futureStart.toIso8601String(),
+          'endTime': futureEnd.toIso8601String(),
+          'minParticipants': 4,
+          'maxParticipants': 8,
+          'createdBy': 'creator-user',
+          'createdAt': createdAt.toIso8601String(),
+          'participantIds': ['user-1', 'user-2'],
+          'status': 'scheduled',
+        };
+
+        final session = TrainingSessionModel.fromJson(json);
+
+        expect(session.id, equals('session-123'));
+        expect(session.groupId, equals('group-456'));
+        expect(session.title, equals('Morning Practice'));
+        expect(session.description, equals('Beach volleyball drills'));
+        expect(session.location.name, equals('Beach Court 1'));
+        expect(session.minParticipants, equals(4));
+        expect(session.maxParticipants, equals(8));
+        expect(session.createdBy, equals('creator-user'));
+        expect(session.participantIds.length, equals(2));
+        expect(session.status, equals(TrainingStatus.scheduled));
+      });
+
+      test('deserializes with ISO string dates', () {
+        final json = {
+          'id': 'session-123',
+          'groupId': 'group-456',
+          'title': 'Morning Practice',
+          'location': {'name': 'Beach Court 1'},
+          'startTime': futureStart.toIso8601String(),
+          'endTime': futureEnd.toIso8601String(),
+          'minParticipants': 4,
+          'maxParticipants': 8,
+          'createdBy': 'creator-user',
+          'createdAt': createdAt.toIso8601String(),
+          'status': 'scheduled',
+        };
+
+        final session = TrainingSessionModel.fromJson(json);
+
+        expect(session.startTime.year, equals(futureStart.year));
+        expect(session.startTime.month, equals(futureStart.month));
+        expect(session.startTime.day, equals(futureStart.day));
+      });
+
+      test('deserializes with recurrence rule', () {
+        final json = {
+          'id': 'session-123',
+          'groupId': 'group-456',
+          'title': 'Recurring Session',
+          'location': {'name': 'Beach Court 1'},
+          'startTime': futureStart.toIso8601String(),
+          'endTime': futureEnd.toIso8601String(),
+          'minParticipants': 4,
+          'maxParticipants': 8,
+          'createdBy': 'creator-user',
+          'createdAt': createdAt.toIso8601String(),
+          'recurrenceRule': {
+            'frequency': 'weekly',
+            'interval': 1,
+            'count': 10,
+          },
+          'status': 'scheduled',
+        };
+
+        final session = TrainingSessionModel.fromJson(json);
+
+        expect(session.recurrenceRule, isNotNull);
+        expect(session.recurrenceRule!.frequency, equals(RecurrenceFrequency.weekly));
+      });
+    });
+
+    group('toJson', () {
+      test('serializes to JSON correctly', () {
+        final json = baseSession.toJson();
+
+        expect(json['id'], equals('session-123'));
+        expect(json['groupId'], equals('group-456'));
+        expect(json['title'], equals('Morning Practice'));
+        expect(json['minParticipants'], equals(4));
+        expect(json['maxParticipants'], equals(8));
+        expect(json['participantIds'], equals(['user-1', 'user-2', 'user-3']));
+        expect(json['status'], equals('scheduled'));
+      });
+
+      test('round-trip serialization preserves data', () {
+        // Note: Nested freezed objects require explicit JSON conversion
+        // This tests the values directly
+        final json = baseSession.toJson();
+
+        // Verify the JSON has correct structure
+        expect(json['id'], equals(baseSession.id));
+        expect(json['groupId'], equals(baseSession.groupId));
+        expect(json['title'], equals(baseSession.title));
+        expect(json['minParticipants'], equals(baseSession.minParticipants));
+        expect(json['maxParticipants'], equals(baseSession.maxParticipants));
+        expect(json['participantIds'], equals(baseSession.participantIds));
+        expect(json['status'], equals('scheduled'));
+
+        // Verify we can deserialize from a properly formatted JSON
+        final properJson = {
+          'id': baseSession.id,
+          'groupId': baseSession.groupId,
+          'title': baseSession.title,
+          'location': baseSession.location.toJson(),
+          'startTime': baseSession.startTime.toIso8601String(),
+          'endTime': baseSession.endTime.toIso8601String(),
+          'minParticipants': baseSession.minParticipants,
+          'maxParticipants': baseSession.maxParticipants,
+          'createdBy': baseSession.createdBy,
+          'createdAt': baseSession.createdAt.toIso8601String(),
+          'participantIds': baseSession.participantIds,
+          'status': 'scheduled',
+        };
+
+        final restored = TrainingSessionModel.fromJson(properJson);
+        expect(restored.id, equals(baseSession.id));
+        expect(restored.title, equals(baseSession.title));
+        expect(restored.participantIds, equals(baseSession.participantIds));
+      });
+    });
+
+    group('toFirestore', () {
+      test('excludes id from output', () {
+        final firestoreData = baseSession.toFirestore();
+        expect(firestoreData.containsKey('id'), isFalse);
+      });
+
+      test('converts DateTime to Timestamp', () {
+        final firestoreData = baseSession.toFirestore();
+        expect(firestoreData['startTime'], isA<Timestamp>());
+        expect(firestoreData['endTime'], isA<Timestamp>());
+        expect(firestoreData['createdAt'], isA<Timestamp>());
+      });
+
+      test('includes all other fields', () {
+        final firestoreData = baseSession.toFirestore();
+        expect(firestoreData['groupId'], equals('group-456'));
+        expect(firestoreData['title'], equals('Morning Practice'));
+        expect(firestoreData['minParticipants'], equals(4));
+      });
+    });
+
+    group('equality', () {
+      test('two sessions with same values are equal', () {
+        final session1 = TrainingSessionModel(
+          id: 'session-1',
+          groupId: 'group-1',
+          title: 'Test',
+          location: testLocation,
+          startTime: futureStart,
+          endTime: futureEnd,
+          minParticipants: 4,
+          maxParticipants: 8,
+          createdBy: 'creator',
+          createdAt: createdAt,
+        );
+
+        final session2 = TrainingSessionModel(
+          id: 'session-1',
+          groupId: 'group-1',
+          title: 'Test',
+          location: testLocation,
+          startTime: futureStart,
+          endTime: futureEnd,
+          minParticipants: 4,
+          maxParticipants: 8,
+          createdBy: 'creator',
+          createdAt: createdAt,
+        );
+
+        expect(session1, equals(session2));
+        expect(session1.hashCode, equals(session2.hashCode));
+      });
+
+      test('two sessions with different id are not equal', () {
+        final session1 = TrainingSessionModel(
+          id: 'session-1',
+          groupId: 'group-1',
+          title: 'Test',
+          location: testLocation,
+          startTime: futureStart,
+          endTime: futureEnd,
+          minParticipants: 4,
+          maxParticipants: 8,
+          createdBy: 'creator',
+          createdAt: createdAt,
+        );
+
+        final session2 = TrainingSessionModel(
+          id: 'session-2',
+          groupId: 'group-1',
+          title: 'Test',
+          location: testLocation,
+          startTime: futureStart,
+          endTime: futureEnd,
+          minParticipants: 4,
+          maxParticipants: 8,
+          createdBy: 'creator',
+          createdAt: createdAt,
+        );
+
+        expect(session1, isNot(equals(session2)));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated title', () {
+        final copy = baseSession.copyWith(title: 'New Title');
+        expect(copy.title, equals('New Title'));
+        expect(copy.id, equals(baseSession.id));
+        expect(copy.groupId, equals(baseSession.groupId));
+      });
+
+      test('creates copy with updated status', () {
+        final copy = baseSession.copyWith(status: TrainingStatus.completed);
+        expect(copy.status, equals(TrainingStatus.completed));
+      });
+
+      test('creates copy with updated participantIds', () {
+        final copy = baseSession.copyWith(participantIds: ['user-a', 'user-b']);
+        expect(copy.participantIds, equals(['user-a', 'user-b']));
+      });
+
+      test('creates identical copy when no parameters provided', () {
+        final copy = baseSession.copyWith();
+        expect(copy, equals(baseSession));
+      });
+    });
+  });
+
+  group('TrainingStatus enum', () {
+    test('has correct JSON values', () {
+      expect(TrainingStatus.scheduled.name, equals('scheduled'));
+      expect(TrainingStatus.completed.name, equals('completed'));
+      expect(TrainingStatus.cancelled.name, equals('cancelled'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive unit tests for stats models (TeammateStats, HeadToHeadStats, RecentGameResult, HeadToHeadGameResult)
- Adds comprehensive unit tests for TrainingSessionModel
- Total: 213 new test cases covering serialization, computed properties, and edge cases

## Changes
### Story 16.3.3.1: Stats Models Unit Tests
- `teammate_stats_test.dart` (58 tests): Win rate, loss rate, streaks, point differentials, ELO changes, serialization
- `head_to_head_stats_test.dart` (70 tests): Rivalry tracking, matchup advantage, serialization

### Story 16.3.3.2: TrainingSessionModel Unit Tests
- `training_session_model_test.dart` (85 tests): Participant management, timing validation, recurrence, serialization

## Test plan
- [x] All 213 new test cases pass
- [x] Existing unit tests still pass
- [x] No new analyzer issues in test files
- [x] Tests cover constructor, computed properties, serialization, and edge cases

Closes #404
Closes #405