### PR TITLE
test(widget): add training pages widget tests

### DIFF
--- a/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
@@ -1,0 +1,391 @@
+// Widget tests for TrainingSessionCreationPage verifying UI rendering and user interactions.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_event.dart';
+import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_state.dart';
+import 'package:play_with_me/features/training/presentation/pages/training_session_creation_page.dart';
+
+class MockTrainingSessionCreationBloc
+    extends MockBloc<TrainingSessionCreationEvent, TrainingSessionCreationState>
+    implements TrainingSessionCreationBloc {}
+
+class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
+
+class FakeTrainingSessionCreationEvent extends Fake
+    implements TrainingSessionCreationEvent {}
+
+class FakeTrainingSessionCreationState extends Fake
+    implements TrainingSessionCreationState {}
+
+void main() {
+  late MockTrainingSessionCreationBloc mockCreationBloc;
+  late MockAuthenticationBloc mockAuthBloc;
+
+  const testUserId = 'test-user-123';
+  const testGroupId = 'test-group-123';
+  const testGroupName = 'Beach Volleyball Crew';
+
+  setUpAll(() {
+    registerFallbackValue(FakeTrainingSessionCreationEvent());
+    registerFallbackValue(FakeTrainingSessionCreationState());
+  });
+
+  setUp(() {
+    mockCreationBloc = MockTrainingSessionCreationBloc();
+    mockAuthBloc = MockAuthenticationBloc();
+
+    when(() => mockCreationBloc.state)
+        .thenReturn(const TrainingSessionCreationInitial());
+
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(
+        UserEntity(
+          uid: testUserId,
+          email: 'test@example.com',
+          displayName: 'Test User',
+          isEmailVerified: true,
+          createdAt: DateTime(2024, 1, 1),
+          lastSignInAt: DateTime(2024, 1, 1),
+          isAnonymous: false,
+        ),
+      ),
+    );
+    when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
+  });
+
+  tearDown(() {
+    mockCreationBloc.close();
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<TrainingSessionCreationBloc>.value(
+              value: mockCreationBloc),
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        ],
+        child: const TrainingSessionCreationPage(
+          groupId: testGroupId,
+          groupName: testGroupName,
+        ),
+      ),
+    );
+  }
+
+  group('TrainingSessionCreationPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Create Training Session title',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.text('Create Training Session'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders group name in the form', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text(testGroupName), findsOneWidget);
+      });
+
+      testWidgets('renders title input field', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Title'), findsOneWidget);
+        expect(find.byIcon(Icons.fitness_center), findsOneWidget);
+      });
+
+      testWidgets('renders description input field', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Description (Optional)'), findsOneWidget);
+        expect(find.byIcon(Icons.description), findsOneWidget);
+      });
+
+      testWidgets('renders location input field', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Location'), findsOneWidget);
+        expect(find.byIcon(Icons.location_on), findsOneWidget);
+      });
+
+      testWidgets('renders start time selector', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Start Time'), findsOneWidget);
+        expect(find.text('Not selected'), findsNWidgets(2)); // Start and End
+        expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+      });
+
+      testWidgets('renders end time selector', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('End Time'), findsOneWidget);
+        expect(find.byIcon(Icons.access_time), findsOneWidget);
+      });
+
+      testWidgets('renders participant sliders', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Min Participants'), findsOneWidget);
+        expect(find.text('Max Participants'), findsOneWidget);
+        expect(find.byType(Slider), findsNWidgets(2));
+      });
+
+      testWidgets('renders create button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to make button visible (find the FilledButton specifically)
+        final createButton = find.byType(FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+
+        expect(createButton, findsOneWidget);
+        // Also verify the button text
+        expect(
+          find.descendant(
+            of: createButton,
+            matching: find.text('Create Training Session'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('sends SelectTrainingGroup event on init', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        verify(
+          () => mockCreationBloc.add(
+            const SelectTrainingGroup(
+              groupId: testGroupId,
+              groupName: testGroupName,
+            ),
+          ),
+        ).called(1);
+      });
+    });
+
+    group('Title Input Field', () {
+      testWidgets('can enter title text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final titleField = find.widgetWithText(TextFormField, 'Title');
+        await tester.enterText(titleField, 'Morning Drills Session');
+        await tester.pump();
+
+        expect(find.text('Morning Drills Session'), findsOneWidget);
+      });
+
+      testWidgets('shows validation error for empty title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Fill location to avoid multiple validation errors
+        final locationField = find.widgetWithText(TextFormField, 'Location');
+        await tester.enterText(locationField, 'Venice Beach');
+        await tester.pump();
+
+        // Scroll to and tap create button (find the FilledButton specifically)
+        final createButton = find.byType(FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Please enter a title'), findsOneWidget);
+      });
+    });
+
+    group('Description Input Field', () {
+      testWidgets('can enter description text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final descriptionField =
+            find.widgetWithText(TextFormField, 'Description (Optional)');
+        await tester.enterText(
+            descriptionField, 'Practice serves and blocks today!');
+        await tester.pump();
+
+        expect(find.text('Practice serves and blocks today!'), findsOneWidget);
+      });
+    });
+
+    group('Location Input Field', () {
+      testWidgets('can enter location text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final locationField = find.widgetWithText(TextFormField, 'Location');
+        await tester.enterText(locationField, 'Beach Court 3');
+        await tester.pump();
+
+        expect(find.text('Beach Court 3'), findsOneWidget);
+      });
+
+      testWidgets('shows validation error for empty location', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Fill title to avoid multiple validation errors
+        final titleField = find.widgetWithText(TextFormField, 'Title');
+        await tester.enterText(titleField, 'Morning Drills');
+        await tester.pump();
+
+        // Scroll to and tap create button (find the FilledButton specifically)
+        final createButton = find.byType(FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pumpAndSettle();
+        await tester.tap(createButton);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Please enter a location'), findsOneWidget);
+      });
+    });
+
+    group('Time Selection', () {
+      testWidgets('start time selector is tappable', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Find the start time list tile and tap it
+        final startTimeTile = find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        );
+        expect(startTimeTile, findsOneWidget);
+
+        await tester.tap(startTimeTile);
+        await tester.pumpAndSettle();
+
+        // Date picker dialog should appear
+        expect(find.byType(DatePickerDialog), findsOneWidget);
+      });
+    });
+
+    group('Participant Sliders', () {
+      testWidgets('min participants slider shows initial value', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Initial min participants value is 2
+        expect(find.text('2'), findsWidgets);
+      });
+
+      testWidgets('max participants slider shows initial value', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Initial max participants value is 10
+        expect(find.text('10'), findsOneWidget);
+      });
+    });
+
+    group('Loading State', () {
+      testWidgets('shows loading indicator during submission', (tester) async {
+        when(() => mockCreationBloc.state)
+            .thenReturn(const TrainingSessionCreationSubmitting());
+
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to button
+        final createButton = find.byType(FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('button is disabled during loading', (tester) async {
+        when(() => mockCreationBloc.state)
+            .thenReturn(const TrainingSessionCreationSubmitting());
+
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to button
+        final createButton = find.byType(FilledButton);
+        await tester.ensureVisible(createButton);
+        await tester.pump();
+
+        final filledButton = tester.widget<FilledButton>(createButton);
+        expect(filledButton.onPressed, isNull);
+      });
+
+      testWidgets('form fields are disabled during loading', (tester) async {
+        when(() => mockCreationBloc.state)
+            .thenReturn(const TrainingSessionCreationSubmitting());
+
+        await tester.pumpWidget(createTestWidget());
+
+        final titleField = tester.widget<TextFormField>(
+          find.widgetWithText(TextFormField, 'Title'),
+        );
+        expect(titleField.enabled, isFalse);
+      });
+    });
+
+    // Note: Success handling tests that involve navigation to TrainingSessionDetailsPage
+    // require Firebase initialization which is not available in widget tests.
+    // Success flow is tested in integration tests instead.
+
+    group('Error Handling', () {
+      testWidgets('shows error snackbar on failure', (tester) async {
+        whenListen(
+          mockCreationBloc,
+          Stream.fromIterable([
+            const TrainingSessionCreationInitial(),
+            const TrainingSessionCreationSubmitting(),
+            const TrainingSessionCreationError(
+                message: 'Failed to create training session'),
+          ]),
+          initialState: const TrainingSessionCreationInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Failed to create training session'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+      });
+
+      testWidgets('error snackbar has red background', (tester) async {
+        whenListen(
+          mockCreationBloc,
+          Stream.fromIterable([
+            const TrainingSessionCreationInitial(),
+            const TrainingSessionCreationError(message: 'Error message'),
+          ]),
+          initialState: const TrainingSessionCreationInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, Colors.red);
+      });
+    });
+
+    group('Unauthenticated State', () {
+      testWidgets('shows login message when not authenticated', (tester) async {
+        when(() => mockAuthBloc.state)
+            .thenReturn(const AuthenticationUnauthenticated());
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Please log in to create a training session'),
+            findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/widget/features/training/presentation/pages/training_session_details_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_details_page_test.dart
@@ -1,0 +1,155 @@
+// Widget tests for TrainingSessionDetailsPage - SKIPPED due to direct FirebaseAuth dependency.
+//
+// NOTE: TrainingSessionDetailsPage directly accesses FirebaseAuth.instance.currentUser in initState,
+// which cannot be easily mocked in widget tests without platform channel mocking.
+//
+// Per CLAUDE.md section 4.5 "What to Test Where", tests requiring real Firebase behavior
+// should be integration tests with the Firebase Emulator, not widget tests.
+//
+// The test structure below documents the intended test coverage.
+// These tests should be run as integration tests in:
+// integration_test/training_session_details_page_integration_test.dart
+//
+// Reference: Story 16.3.4.5 (Add Training & Notification Integration Tests)
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TrainingSessionDetailsPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      test('renders app bar with session title', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: AppBar displays session.title
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows loading indicator when waiting for data', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: CircularProgressIndicator shown while stream is waiting
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows not found message when session is null', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Training session not found" text displayed
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows session title in header', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: session.title in header section
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows session description', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: session.description displayed
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows location info', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: location icon and session.location.name
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows participant count', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "X/Y participants" text
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows date and time icon', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: calendar icon displayed
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('Status Badge', () {
+      test('shows Scheduled badge for scheduled sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Scheduled" text and schedule icon
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows Completed badge for completed sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Completed" text and check_circle icon
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows Cancelled badge for cancelled sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Cancelled" text and cancel icon
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows FULL badge when session is full', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "FULL" badge displayed when participantIds.length == maxParticipants
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('Tab Navigation', () {
+      test('shows Participants and Exercises tabs for scheduled session', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Participants" and "Exercises" tabs visible
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows Feedback tab for completed sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Feedback" tab appears when status == completed && isParticipant
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('does not show Feedback tab for scheduled sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: No "Feedback" tab for scheduled sessions
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('Participants Tab', () {
+      test('shows empty state when no participants', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "No participants yet" and "Be the first to join!" text
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows participation info card', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: Current, Minimum, Maximum, Available Spots displayed
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('Floating Action Button', () {
+      test('does not show FAB for cancelled sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: No FloatingActionButton when status == cancelled
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('does not show FAB for completed sessions', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: No FloatingActionButton when status == completed
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('BlocListener State Changes - Join/Leave', () {
+      test('shows success snackbar when joined session', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Successfully joined training session!" snackbar
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows success snackbar when left session', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "You have left the training session" snackbar
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+
+      test('shows error snackbar on participation error', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: Error message in red snackbar
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('BlocListener State Changes - Cancel', () {
+      test('shows cancel snackbar when session cancelled', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "Training session cancelled" snackbar with orange background
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+
+    group('Organizer Info', () {
+      test('shows organizer label for session creator', () {
+        // Test skipped: Requires Firebase Auth initialization
+        // Should verify: "You are organizing" or "Organized by X" text
+      }, skip: 'Requires Firebase Auth - move to integration tests (Story 16.3.4.5)');
+    });
+  });
+}

--- a/test/widget/features/training/presentation/pages/training_session_feedback_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_feedback_page_test.dart
@@ -1,0 +1,418 @@
+// Widget tests for TrainingSessionFeedbackPage verifying feedback form rendering and submission.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_event.dart';
+import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_state.dart';
+import 'package:play_with_me/features/training/presentation/pages/training_session_feedback_page.dart';
+
+class MockTrainingFeedbackBloc
+    extends MockBloc<TrainingFeedbackEvent, TrainingFeedbackState>
+    implements TrainingFeedbackBloc {}
+
+class FakeTrainingFeedbackEvent extends Fake implements TrainingFeedbackEvent {}
+
+class FakeTrainingFeedbackState extends Fake implements TrainingFeedbackState {}
+
+void main() {
+  late MockTrainingFeedbackBloc mockFeedbackBloc;
+
+  const testSessionId = 'test-session-123';
+  const testSessionTitle = 'Morning Beach Drills';
+
+  setUpAll(() {
+    registerFallbackValue(FakeTrainingFeedbackEvent());
+    registerFallbackValue(FakeTrainingFeedbackState());
+  });
+
+  setUp(() {
+    mockFeedbackBloc = MockTrainingFeedbackBloc();
+
+    when(() => mockFeedbackBloc.state).thenReturn(const FeedbackInitial());
+  });
+
+  tearDown(() {
+    mockFeedbackBloc.close();
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: BlocProvider<TrainingFeedbackBloc>.value(
+        value: mockFeedbackBloc,
+        child: const TrainingSessionFeedbackPage(
+          trainingSessionId: testSessionId,
+          sessionTitle: testSessionTitle,
+        ),
+      ),
+    );
+  }
+
+  group('TrainingSessionFeedbackPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Session Feedback title',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(AppBar),
+            matching: find.text('Session Feedback'),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders anonymous feedback header', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Provide Anonymous Feedback'), findsOneWidget);
+      });
+
+      testWidgets('renders session title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text(testSessionTitle), findsOneWidget);
+      });
+
+      testWidgets('renders anonymous explanation text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text(
+              'Your feedback is anonymous and helps improve future training sessions.'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders exercises quality rating section', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Exercises Quality'), findsOneWidget);
+        expect(find.text('Were the drills effective?'), findsOneWidget);
+      });
+
+      testWidgets('renders training intensity rating section', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Training Intensity'), findsOneWidget);
+        expect(find.text('Physical demand level'), findsOneWidget);
+      });
+
+      testWidgets('renders coaching clarity rating section', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Coaching Clarity'), findsOneWidget);
+        expect(find.text('Instructions & corrections?'), findsOneWidget);
+      });
+
+      testWidgets('renders rating icons for each category', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Each rating section has 5 volleyball icons
+        // 3 categories * 5 icons = 15 volleyball icons
+        expect(find.byIcon(Icons.sports_volleyball), findsNWidgets(15));
+      });
+
+      testWidgets('renders rating labels', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // 3 categories each with "Needs work" and "Top-level training" labels
+        expect(find.text('Needs work'), findsNWidgets(3));
+        expect(find.text('Top-level training'), findsNWidgets(3));
+      });
+
+      testWidgets('renders comment section', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Additional Comments (Optional)'), findsOneWidget);
+        expect(
+          find.text(
+              'Share your thoughts about the session, exercises, or suggestions for improvement...'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders submit button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to button
+        final submitButton = find.text('Submit Feedback');
+        await tester.ensureVisible(submitButton);
+        await tester.pump();
+
+        expect(submitButton, findsOneWidget);
+      });
+
+      testWidgets('renders privacy reminder card', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll down to see privacy card
+        await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(
+              'Your feedback is completely anonymous and cannot be traced back to you.'),
+          findsOneWidget,
+        );
+        expect(find.byIcon(Icons.privacy_tip_outlined), findsOneWidget);
+      });
+
+      testWidgets('sends CheckFeedbackSubmission event on init',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        verify(
+          () => mockFeedbackBloc
+              .add(const CheckFeedbackSubmission(testSessionId)),
+        ).called(1);
+      });
+    });
+
+    group('Rating Selection', () {
+      testWidgets('can tap to select exercises quality rating', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Find all volleyball icons (15 total: 3 categories x 5 icons)
+        final volleyballIcons = find.byIcon(Icons.sports_volleyball);
+        expect(volleyballIcons, findsNWidgets(15));
+
+        // Tap the third icon (index 2) in the first category (Exercises Quality)
+        // This gives a 3-star rating
+        await tester.tap(volleyballIcons.at(2));
+        await tester.pump();
+
+        // The tap should succeed without errors
+        // Visual feedback is that the icon becomes larger (44 vs 40) and primary color
+      });
+    });
+
+    group('Comment Input', () {
+      testWidgets('can enter comment text', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to comment field
+        final commentField = find.byType(TextFormField);
+        await tester.ensureVisible(commentField);
+        await tester.pump();
+
+        await tester.enterText(commentField, 'Great session with good drills!');
+        await tester.pump();
+
+        expect(find.text('Great session with good drills!'), findsOneWidget);
+      });
+
+      testWidgets('comment field has max length counter', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to comment field
+        final commentField = find.byType(TextFormField);
+        await tester.ensureVisible(commentField);
+        await tester.pump();
+
+        // The max length is shown as a counter (0/500)
+        expect(find.text('0/500'), findsOneWidget);
+      });
+    });
+
+    group('Validation', () {
+      testWidgets('shows warning when ratings not selected', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to submit button and tap
+        final submitButton = find.text('Submit Feedback');
+        await tester.ensureVisible(submitButton);
+        await tester.pump();
+
+        await tester.tap(find.widgetWithText(ElevatedButton, 'Submit Feedback'));
+        await tester.pump();
+
+        // Should show validation snackbar
+        expect(
+          find.text('Please rate all three categories before submitting'),
+          findsOneWidget,
+        );
+        expect(find.byType(SnackBar), findsOneWidget);
+      });
+    });
+
+    group('Checking Submission State', () {
+      testWidgets('shows loading indicator when checking submission',
+          (tester) async {
+        when(() => mockFeedbackBloc.state)
+            .thenReturn(const CheckingFeedbackSubmission(testSessionId));
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+
+    group('Already Submitted State', () {
+      testWidgets('shows already submitted view', (tester) async {
+        when(() => mockFeedbackBloc.state).thenReturn(
+          const FeedbackSubmissionChecked(
+            trainingSessionId: testSessionId,
+            hasSubmitted: true,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Feedback Already Submitted'), findsOneWidget);
+        expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      });
+
+      testWidgets('shows session title in already submitted view',
+          (tester) async {
+        when(() => mockFeedbackBloc.state).thenReturn(
+          const FeedbackSubmissionChecked(
+            trainingSessionId: testSessionId,
+            hasSubmitted: true,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(
+          find.text('You have already provided feedback for "$testSessionTitle".'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows back button in already submitted view',
+          (tester) async {
+        when(() => mockFeedbackBloc.state).thenReturn(
+          const FeedbackSubmissionChecked(
+            trainingSessionId: testSessionId,
+            hasSubmitted: true,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Back to Session'), findsOneWidget);
+      });
+    });
+
+    group('Submitting State', () {
+      testWidgets('shows loading indicator during submission', (tester) async {
+        when(() => mockFeedbackBloc.state)
+            .thenReturn(const SubmittingFeedback(testSessionId));
+
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to submit button area
+        final submitButton = find.byType(ElevatedButton);
+        await tester.ensureVisible(submitButton);
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('submit button is disabled during submission', (tester) async {
+        when(() => mockFeedbackBloc.state)
+            .thenReturn(const SubmittingFeedback(testSessionId));
+
+        await tester.pumpWidget(createTestWidget());
+
+        // Scroll to submit button
+        final submitButton = find.byType(ElevatedButton);
+        await tester.ensureVisible(submitButton);
+        await tester.pump();
+
+        final elevatedButton = tester.widget<ElevatedButton>(submitButton);
+        expect(elevatedButton.onPressed, isNull);
+      });
+    });
+
+    group('Success Handling', () {
+      testWidgets('shows success snackbar after submission', (tester) async {
+        whenListen(
+          mockFeedbackBloc,
+          Stream.fromIterable([
+            const FeedbackInitial(),
+            const SubmittingFeedback(testSessionId),
+            const FeedbackSubmitted(trainingSessionId: testSessionId),
+          ]),
+          initialState: const FeedbackInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Thank you for your feedback!'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+
+        // Advance past the 2-second navigation delay to clean up pending timer
+        await tester.pump(const Duration(seconds: 3));
+      });
+
+      testWidgets('success snackbar has green background', (tester) async {
+        whenListen(
+          mockFeedbackBloc,
+          Stream.fromIterable([
+            const FeedbackInitial(),
+            const FeedbackSubmitted(trainingSessionId: testSessionId),
+          ]),
+          initialState: const FeedbackInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, Colors.green);
+
+        // Advance past the 2-second navigation delay to clean up pending timer
+        await tester.pump(const Duration(seconds: 3));
+      });
+    });
+
+    group('Error Handling', () {
+      testWidgets('shows error snackbar on failure', (tester) async {
+        whenListen(
+          mockFeedbackBloc,
+          Stream.fromIterable([
+            const FeedbackInitial(),
+            const SubmittingFeedback(testSessionId),
+            const FeedbackError(message: 'Failed to submit feedback'),
+          ]),
+          initialState: const FeedbackInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Failed to submit feedback'), findsOneWidget);
+        expect(find.byType(SnackBar), findsOneWidget);
+      });
+
+      testWidgets('error snackbar has red background', (tester) async {
+        whenListen(
+          mockFeedbackBloc,
+          Stream.fromIterable([
+            const FeedbackInitial(),
+            const FeedbackError(message: 'Error message'),
+          ]),
+          initialState: const FeedbackInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, Colors.red);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive widget tests for training feature pages (Story 16.3.4.3)
- **51 tests passing**, **24 tests skipped** (require Firebase Emulator)
- Created sub-story #431 for the skipped details page integration tests

## Test Files Created

| Page | Tests | Coverage |
|------|-------|----------|
| TrainingSessionCreationPage | 24 | UI rendering, form fields, validation, loading/error states |
| TrainingSessionFeedbackPage | 27 | UI rendering, ratings, comments, validation, submission states |
| TrainingSessionDetailsPage | 24 (skipped) | Documented for integration tests (Story #431) |

## TrainingSessionCreationPage Tests (24 passing)
- Initial UI rendering (10 tests)
- Title input field validation (2 tests)
- Description input field (1 test)
- Location input field validation (2 tests)
- Time selection (1 test)
- Participant sliders (2 tests)
- Loading state handling (3 tests)
- Error handling (2 tests)
- Unauthenticated state (1 test)

## TrainingSessionFeedbackPage Tests (27 passing)
- Initial UI rendering (13 tests)
- Rating selection (1 test)
- Comment input (2 tests)
- Validation (1 test)
- Checking submission state (1 test)
- Already submitted state (3 tests)
- Submitting state (2 tests)
- Success handling (2 tests)
- Error handling (2 tests)

## TrainingSessionDetailsPage Tests (24 skipped)
- Page directly accesses `FirebaseAuth.instance.currentUser` in `initState`
- Per CLAUDE.md section 4.5, requires integration tests with Firebase Emulator
- Test structure documented with skip reasons referencing Story 16.3.4.5
- Sub-story created: #431

## Test plan
- [x] All 51 widget tests pass locally
- [x] `flutter analyze` passes with no issues in test files
- [x] Security checklist reviewed - no sensitive files committed
- [x] Sub-story created for integration tests (#431)

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)