### PR TITLE
Story 16.3.4.4: Add Profile Stats Pages Widget Tests

### DIFF
--- a/test/widget/features/profile/presentation/pages/full_elo_history_page_test.dart
+++ b/test/widget/features/profile/presentation/pages/full_elo_history_page_test.dart
@@ -1,0 +1,293 @@
+// Widget tests for FullEloHistoryPage verifying UI rendering and state transitions.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/rating_history_entry.dart';
+import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/features/profile/presentation/pages/full_elo_history_page.dart';
+import 'package:play_with_me/features/profile/presentation/widgets/best_elo_highlight_card.dart';
+import 'package:play_with_me/features/profile/presentation/widgets/time_period_selector.dart';
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+void main() {
+  late MockUserRepository mockUserRepository;
+
+  const testUserId = 'test-user-123';
+
+  // Sample test data
+  final testHistoryEntry1 = RatingHistoryEntry(
+    entryId: 'entry-1',
+    gameId: 'game-1',
+    oldRating: 1600.0,
+    newRating: 1620.0,
+    ratingChange: 20.0,
+    opponentTeam: 'Alice & Bob',
+    won: true,
+    timestamp: DateTime(2024, 1, 15),
+  );
+
+  final testHistoryEntry2 = RatingHistoryEntry(
+    entryId: 'entry-2',
+    gameId: 'game-2',
+    oldRating: 1620.0,
+    newRating: 1605.0,
+    ratingChange: -15.0,
+    opponentTeam: 'Charlie & Diana',
+    won: false,
+    timestamp: DateTime(2024, 1, 10),
+  );
+
+  final testHistoryEntry3 = RatingHistoryEntry(
+    entryId: 'entry-3',
+    gameId: 'game-3',
+    oldRating: 1580.0,
+    newRating: 1600.0,
+    ratingChange: 20.0,
+    opponentTeam: 'Eve & Frank',
+    won: true,
+    timestamp: DateTime(2024, 1, 5),
+  );
+
+  final testHistory = [testHistoryEntry1, testHistoryEntry2, testHistoryEntry3];
+
+  setUp(() {
+    mockUserRepository = MockUserRepository();
+
+    // Register mock in GetIt
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+    sl.registerSingleton<UserRepository>(mockUserRepository);
+  });
+
+  tearDown(() {
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+  });
+
+  Widget createTestWidget() {
+    return const MaterialApp(
+      home: FullEloHistoryPage(userId: testUserId),
+    );
+  }
+
+  group('FullEloHistoryPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with ELO History title', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(find.text('ELO History'), findsOneWidget);
+      });
+
+      testWidgets('renders filter icon in app bar when loaded', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.filter_alt), findsOneWidget);
+      });
+    });
+
+    group('Error State', () {
+      testWidgets('shows error message when error state', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.error('Failed to load ELO history'));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.textContaining('Failed to load ELO history'), findsOneWidget);
+      });
+
+      testWidgets('error icon has red color', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.error('Network error'));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
+        expect(icon.color, Colors.red);
+      });
+    });
+
+    group('Empty State', () {
+      testWidgets('shows empty state when no history', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value([]));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.timeline), findsOneWidget);
+        expect(find.text('No ELO history yet'), findsOneWidget);
+        expect(find.text('Play some games to see your rating history'),
+            findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Stats Summary', () {
+      testWidgets('shows games count in stats summary', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 3 games in history
+        expect(find.text('3'), findsOneWidget);
+        expect(find.text('Games'), findsOneWidget);
+      });
+
+      testWidgets('shows win-loss record', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 2 wins, 1 loss
+        expect(find.text('2-1'), findsOneWidget);
+        expect(find.text('W-L'), findsOneWidget);
+      });
+
+      testWidgets('shows total rating change', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Total change: 1620 (newRating of first) - 1580 (oldRating of last) = +40
+        expect(find.text('+40'), findsOneWidget);
+        expect(find.text('Total'), findsOneWidget);
+      });
+
+      testWidgets('shows average rating change', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Avg = 40 / 3 = 13.3
+        expect(find.text('+13.3'), findsOneWidget);
+        expect(find.text('Avg'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Time Period Selector', () {
+      testWidgets('renders time period selector', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TimePeriodSelector), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Best ELO Card', () {
+      testWidgets('renders best ELO highlight card', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(BestEloHighlightCard), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - History List', () {
+      testWidgets('renders history entries', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Verify opponent names are displayed
+        expect(find.text('vs Alice & Bob'), findsOneWidget);
+        expect(find.text('vs Charlie & Diana'), findsOneWidget);
+        expect(find.text('vs Eve & Frank'), findsOneWidget);
+      });
+
+      testWidgets('shows W for wins and L for losses', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 2 wins and 1 loss
+        expect(find.text('W'), findsNWidgets(2));
+        expect(find.text('L'), findsOneWidget);
+      });
+
+      testWidgets('shows rating change for each entry', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Verify formatted changes are displayed
+        expect(find.text('+20.0'), findsNWidgets(2)); // Two +20 entries
+        expect(find.text('-15.0'), findsOneWidget);
+      });
+
+      testWidgets('shows trending up icon for gains', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.trending_up), findsNWidgets(2));
+      });
+
+      testWidgets('shows trending down icon for losses', (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.trending_down), findsOneWidget);
+      });
+    });
+
+    group('Time Period Filter', () {
+      testWidgets('time period selector displays all period options',
+          (tester) async {
+        when(() => mockUserRepository.getRatingHistory(testUserId, limit: 100))
+            .thenAnswer((_) => Stream.value(testHistory));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // The time period selector should display all period options
+        expect(find.text('30d'), findsOneWidget);
+        expect(find.text('90d'), findsOneWidget);
+        expect(find.text('1y'), findsOneWidget);
+        expect(find.text('All Time'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/widget/features/profile/presentation/pages/head_to_head_page_test.dart
+++ b/test/widget/features/profile/presentation/pages/head_to_head_page_test.dart
@@ -1,0 +1,510 @@
+// Widget tests for HeadToHeadPage verifying UI rendering and state transitions.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/head_to_head_stats.dart';
+import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/features/profile/presentation/pages/head_to_head_page.dart';
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+void main() {
+  late MockUserRepository mockUserRepository;
+
+  const testUserId = 'test-user-123';
+  const testOpponentId = 'opponent-456';
+
+  // Sample test data
+  final testMatchup1 = HeadToHeadGameResult(
+    gameId: 'game-1',
+    won: true,
+    pointsScored: 21,
+    pointsAllowed: 15,
+    eloChange: 18.5,
+    timestamp: DateTime(2024, 1, 15),
+  );
+
+  final testMatchup2 = HeadToHeadGameResult(
+    gameId: 'game-2',
+    won: false,
+    pointsScored: 18,
+    pointsAllowed: 21,
+    eloChange: -12.0,
+    timestamp: DateTime(2024, 1, 10),
+  );
+
+  final testMatchup3 = HeadToHeadGameResult(
+    gameId: 'game-3',
+    won: true,
+    pointsScored: 21,
+    pointsAllowed: 19,
+    eloChange: 10.0,
+    timestamp: DateTime(2024, 1, 5),
+  );
+
+  final testStats = HeadToHeadStats(
+    userId: testUserId,
+    opponentId: testOpponentId,
+    opponentName: 'John Doe',
+    opponentEmail: 'john@example.com',
+    opponentPhotoUrl: null,
+    gamesPlayed: 15,
+    gamesWon: 10,
+    gamesLost: 5,
+    pointsScored: 300,
+    pointsAllowed: 250,
+    eloChange: 45.0,
+    largestVictoryMargin: 8,
+    largestDefeatMargin: 5,
+    recentMatchups: [testMatchup1, testMatchup2, testMatchup3],
+  );
+
+  final testStatsNoMatchups = HeadToHeadStats(
+    userId: testUserId,
+    opponentId: testOpponentId,
+    opponentName: 'Jane Smith',
+    opponentEmail: 'jane@example.com',
+    opponentPhotoUrl: null,
+    gamesPlayed: 5,
+    gamesWon: 3,
+    gamesLost: 2,
+    pointsScored: 100,
+    pointsAllowed: 90,
+    eloChange: 15.0,
+    largestVictoryMargin: 4,
+    largestDefeatMargin: 3,
+    recentMatchups: [],
+  );
+
+  setUp(() {
+    mockUserRepository = MockUserRepository();
+
+    // Register mock in GetIt
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+    sl.registerSingleton<UserRepository>(mockUserRepository);
+  });
+
+  tearDown(() {
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+  });
+
+  Widget createTestWidget() {
+    return const MaterialApp(
+      home: HeadToHeadPage(
+        userId: testUserId,
+        opponentId: testOpponentId,
+      ),
+    );
+  }
+
+  group('HeadToHeadPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Head-to-Head title', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(find.text('Head-to-Head'), findsOneWidget);
+      });
+    });
+
+    group('Error State', () {
+      testWidgets('shows error message when stats is null', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('No head-to-head statistics found for this opponent'),
+            findsOneWidget);
+      });
+
+      testWidgets('shows error message when exception is thrown', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenThrow(Exception('Network error'));
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.textContaining('Failed to load head-to-head details'),
+            findsOneWidget);
+      });
+
+      testWidgets('error icon has red color', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
+        expect(icon.color, Colors.red);
+      });
+    });
+
+    group('Loaded State - Opponent Header', () {
+      testWidgets('shows opponent display name', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('John Doe'), findsOneWidget);
+      });
+
+      testWidgets('shows opponent email when available', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('john@example.com'), findsOneWidget);
+      });
+
+      testWidgets('shows person icon when no photo url', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.person), findsOneWidget);
+      });
+
+      testWidgets('shows rivalry indicator badge', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.sports_kabaddi), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Rivalry Card', () {
+      testWidgets('shows rivalry intensity', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 15 games = "Active rivalry"
+        expect(find.text('Active rivalry'), findsOneWidget);
+      });
+
+      testWidgets('shows matchup advantage', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 10/15 = 66.7% > 60% = "Strong advantage"
+        expect(find.text('Strong advantage'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Record Card', () {
+      testWidgets('shows Head-to-Head Record title', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Head-to-Head Record'), findsOneWidget);
+      });
+
+      testWidgets('shows games played count', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('15'), findsOneWidget);
+        expect(find.text('Matchups'), findsOneWidget);
+      });
+
+      testWidgets('shows win rate percentage', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 10/15 = 66.7%
+        expect(find.text('66.7%'), findsOneWidget);
+        expect(find.text('Win Rate'), findsOneWidget);
+      });
+
+      testWidgets('shows win-loss record string', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('10W - 5L'), findsOneWidget);
+        expect(find.text('Record'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Point Differential Card', () {
+      testWidgets('shows Point Differential title', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Point Differential'), findsOneWidget);
+      });
+
+      testWidgets('shows average point differential', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // avgPointsScored = 300/15 = 20, avgPointsAllowed = 250/15 = 16.67
+        // Avg diff = 20 - 16.67 = 3.33
+        expect(find.text('+3.3'), findsOneWidget);
+        expect(find.text('Avg Per Game'), findsOneWidget);
+      });
+
+      testWidgets('shows points scored average', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 300/15 = 20.0
+        expect(find.text('20.0'), findsOneWidget);
+        expect(find.text('Points For'), findsOneWidget);
+      });
+
+      testWidgets('shows points allowed average', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 250/15 = 16.67
+        expect(find.text('16.7'), findsOneWidget);
+        expect(find.text('Points Against'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Margins Card', () {
+      testWidgets('shows Matchup Margins title', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Matchup Margins'), findsOneWidget);
+      });
+
+      testWidgets('shows biggest victory margin', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('+8'), findsOneWidget);
+        expect(find.text('Biggest Win'), findsOneWidget);
+      });
+
+      testWidgets('shows worst defeat margin', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('-5'), findsOneWidget);
+        expect(find.text('Worst Loss'), findsOneWidget);
+      });
+
+      testWidgets('shows total ELO change against opponent', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('+45.0'), findsOneWidget);
+        expect(find.text('ELO vs Them'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Recent Matchups', () {
+      testWidgets('shows Recent Matchups title', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Recent Matchups'), findsOneWidget);
+      });
+
+      testWidgets('shows current streak badge when on streak', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // First matchup is W, so streak = 1 W Streak
+        expect(find.text('1 W Streak'), findsOneWidget);
+      });
+
+      testWidgets('shows matchup score displays', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Verify score displays from matchups
+        expect(find.text('21-15'), findsOneWidget);
+        expect(find.text('18-21'), findsOneWidget);
+        expect(find.text('21-19'), findsOneWidget);
+      });
+
+      testWidgets('shows W and L result letters', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 2 wins and 1 loss in recent matchups
+        expect(find.text('W'), findsNWidgets(2));
+        expect(find.text('L'), findsOneWidget);
+      });
+
+      testWidgets('shows ELO change for each matchup', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('ELO: +18.5'), findsOneWidget);
+        expect(find.text('ELO: -12.0'), findsOneWidget);
+        expect(find.text('ELO: +10.0'), findsOneWidget);
+      });
+
+      testWidgets('shows empty state when no recent matchups', (tester) async {
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => testStatsNoMatchups);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('No recent matchups'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Losing Streak', () {
+      testWidgets('shows losing streak badge when on losing streak',
+          (tester) async {
+        final losingStats = HeadToHeadStats(
+          userId: testUserId,
+          opponentId: testOpponentId,
+          opponentName: 'Tough Opponent',
+          opponentEmail: 'tough@example.com',
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 150,
+          pointsAllowed: 200,
+          eloChange: -25.0,
+          largestVictoryMargin: 3,
+          largestDefeatMargin: 10,
+          recentMatchups: [
+            HeadToHeadGameResult(
+              gameId: 'game-1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: DateTime(2024, 1, 15),
+            ),
+            HeadToHeadGameResult(
+              gameId: 'game-2',
+              won: false,
+              pointsScored: 18,
+              pointsAllowed: 21,
+              eloChange: -8.0,
+              timestamp: DateTime(2024, 1, 10),
+            ),
+          ],
+        );
+
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => losingStats);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('2 L Streak'), findsOneWidget);
+      });
+    });
+
+    group('Opponent Display Name Fallback', () {
+      testWidgets('shows email when name is null', (tester) async {
+        final statsWithoutName = HeadToHeadStats(
+          userId: testUserId,
+          opponentId: testOpponentId,
+          opponentName: null,
+          opponentEmail: 'anonymous@example.com',
+          gamesPlayed: 5,
+          gamesWon: 3,
+          gamesLost: 2,
+          pointsScored: 100,
+          pointsAllowed: 90,
+          eloChange: 10.0,
+          largestVictoryMargin: 4,
+          largestDefeatMargin: 3,
+          recentMatchups: [],
+        );
+
+        when(() => mockUserRepository.getHeadToHeadStats(testUserId, testOpponentId))
+            .thenAnswer((_) async => statsWithoutName);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // opponentDisplayName fallback to email - appears once in header
+        expect(find.text('anonymous@example.com'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/widget/features/profile/presentation/pages/partner_detail_page_test.dart
+++ b/test/widget/features/profile/presentation/pages/partner_detail_page_test.dart
@@ -1,0 +1,579 @@
+// Widget tests for PartnerDetailPage verifying UI rendering and state transitions.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
+import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/features/profile/presentation/pages/partner_detail_page.dart';
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+void main() {
+  late MockUserRepository mockUserRepository;
+
+  const testUserId = 'test-user-123';
+  const testPartnerId = 'partner-456';
+
+  // Sample test data
+  final testGame1 = RecentGameResult(
+    gameId: 'game-1',
+    won: true,
+    pointsScored: 21,
+    pointsAllowed: 15,
+    eloChange: 18.5,
+    timestamp: DateTime(2024, 1, 15),
+  );
+
+  final testGame2 = RecentGameResult(
+    gameId: 'game-2',
+    won: false,
+    pointsScored: 18,
+    pointsAllowed: 21,
+    eloChange: -12.0,
+    timestamp: DateTime(2024, 1, 10),
+  );
+
+  final testGame3 = RecentGameResult(
+    gameId: 'game-3',
+    won: true,
+    pointsScored: 21,
+    pointsAllowed: 19,
+    eloChange: 10.0,
+    timestamp: DateTime(2024, 1, 5),
+  );
+
+  final testStats = TeammateStats(
+    userId: testPartnerId,
+    gamesPlayed: 20,
+    gamesWon: 15,
+    gamesLost: 5,
+    pointsScored: 400,
+    pointsAllowed: 300,
+    eloChange: 60.0,
+    recentGames: [testGame1, testGame2, testGame3],
+  );
+
+  final testStatsNoGames = TeammateStats(
+    userId: testPartnerId,
+    gamesPlayed: 10,
+    gamesWon: 6,
+    gamesLost: 4,
+    pointsScored: 200,
+    pointsAllowed: 180,
+    eloChange: 20.0,
+    recentGames: [],
+  );
+
+  final testPartner = UserModel(
+    uid: testPartnerId,
+    email: 'partner@example.com',
+    displayName: 'John Partner',
+    photoUrl: null,
+    isEmailVerified: true,
+    isAnonymous: false,
+  );
+
+  final testPartnerWithoutDisplayName = UserModel(
+    uid: testPartnerId,
+    email: 'anonymous@example.com',
+    displayName: null,
+    photoUrl: null,
+    isEmailVerified: true,
+    isAnonymous: false,
+  );
+
+  setUp(() {
+    mockUserRepository = MockUserRepository();
+
+    // Register mock in GetIt
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+    sl.registerSingleton<UserRepository>(mockUserRepository);
+  });
+
+  tearDown(() {
+    final sl = GetIt.instance;
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+  });
+
+  Widget createTestWidget() {
+    return const MaterialApp(
+      home: PartnerDetailPage(
+        userId: testUserId,
+        partnerId: testPartnerId,
+      ),
+    );
+  }
+
+  group('PartnerDetailPage Widget Tests', () {
+    group('Initial UI Rendering', () {
+      testWidgets('renders app bar with Partner Details title', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(find.text('Partner Details'), findsOneWidget);
+      });
+    });
+
+    group('Error State', () {
+      testWidgets('shows error message when stats is null', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => null);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('No statistics found for this partner'), findsOneWidget);
+      });
+
+      testWidgets('shows error message when partner profile is null',
+          (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('Partner profile not found'), findsOneWidget);
+      });
+
+      testWidgets('shows error message when exception is thrown',
+          (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenThrow(Exception('Network error'));
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.textContaining('Failed to load partner details'),
+            findsOneWidget);
+      });
+
+      testWidgets('error icon has red color', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => null);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
+        expect(icon.color, Colors.red);
+      });
+    });
+
+    group('Loaded State - Partner Header', () {
+      testWidgets('shows partner display name', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('John Partner'), findsOneWidget);
+      });
+
+      testWidgets('shows partner email when display name is set',
+          (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('partner@example.com'), findsOneWidget);
+      });
+
+      testWidgets('shows email as display name when no display name',
+          (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartnerWithoutDisplayName);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // displayNameOrEmail returns email when displayName is null
+        expect(find.text('anonymous@example.com'), findsOneWidget);
+      });
+
+      testWidgets('shows person icon when no photo url', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.person), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Record Card', () {
+      testWidgets('shows Overall Record title', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Overall Record'), findsOneWidget);
+      });
+
+      testWidgets('shows games played count', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('20'), findsOneWidget);
+        expect(find.text('Games'), findsOneWidget);
+      });
+
+      testWidgets('shows win rate percentage', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 15/20 = 75%
+        expect(find.text('75.0%'), findsOneWidget);
+        expect(find.text('Win Rate'), findsOneWidget);
+      });
+
+      testWidgets('shows win-loss record string', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('15W - 5L'), findsOneWidget);
+        expect(find.text('Record'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Point Differential Card', () {
+      testWidgets('shows Point Differential title', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Point Differential'), findsOneWidget);
+      });
+
+      testWidgets('shows average point differential', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // avgPointsScored = 400/20 = 20, avgPointsAllowed = 300/20 = 15
+        // Avg diff = 20 - 15 = 5
+        expect(find.text('+5.0'), findsOneWidget);
+        // 'Avg Per Game' appears in both Point Differential and ELO cards
+        expect(find.text('Avg Per Game'), findsNWidgets(2));
+      });
+
+      testWidgets('shows points scored average', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 400/20 = 20.0
+        expect(find.text('20.0'), findsOneWidget);
+        expect(find.text('Points For'), findsOneWidget);
+      });
+
+      testWidgets('shows points allowed average', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 300/20 = 15.0
+        expect(find.text('15.0'), findsOneWidget);
+        expect(find.text('Points Against'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - ELO Card', () {
+      testWidgets('shows ELO Performance title', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('ELO Performance'), findsOneWidget);
+      });
+
+      testWidgets('shows total ELO change', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('+60.0'), findsOneWidget);
+        expect(find.text('Total Change'), findsOneWidget);
+      });
+
+      testWidgets('shows average ELO change per game', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 60/20 = 3.0
+        expect(find.text('+3.0'), findsOneWidget);
+        // 'Avg Per Game' appears twice (once in Point Differential, once in ELO)
+        expect(find.text('Avg Per Game'), findsNWidgets(2));
+      });
+    });
+
+    group('Loaded State - Recent Form', () {
+      testWidgets('shows Recent Form title', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Recent Form'), findsOneWidget);
+      });
+
+      testWidgets('shows current streak badge when on winning streak',
+          (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // First game is W, so streak = 1 W Streak
+        expect(find.text('1 W Streak'), findsOneWidget);
+      });
+
+      testWidgets('shows game score displays', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Verify score displays from games
+        expect(find.text('21-15'), findsOneWidget);
+        expect(find.text('18-21'), findsOneWidget);
+        expect(find.text('21-19'), findsOneWidget);
+      });
+
+      testWidgets('shows W and L result letters', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 2 wins and 1 loss in recent games
+        expect(find.text('W'), findsNWidgets(2));
+        expect(find.text('L'), findsOneWidget);
+      });
+
+      testWidgets('shows ELO change for each game', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('ELO: +18.5'), findsOneWidget);
+        expect(find.text('ELO: -12.0'), findsOneWidget);
+        expect(find.text('ELO: +10.0'), findsOneWidget);
+      });
+
+      testWidgets('shows empty state when no recent games', (tester) async {
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => testStatsNoGames);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('No recent games'), findsOneWidget);
+      });
+    });
+
+    group('Loaded State - Losing Streak', () {
+      testWidgets('shows losing streak badge when on losing streak',
+          (tester) async {
+        final losingStats = TeammateStats(
+          userId: testPartnerId,
+          gamesPlayed: 10,
+          gamesWon: 4,
+          gamesLost: 6,
+          pointsScored: 180,
+          pointsAllowed: 200,
+          eloChange: -15.0,
+          recentGames: [
+            RecentGameResult(
+              gameId: 'game-1',
+              won: false,
+              pointsScored: 15,
+              pointsAllowed: 21,
+              eloChange: -10.0,
+              timestamp: DateTime(2024, 1, 15),
+            ),
+            RecentGameResult(
+              gameId: 'game-2',
+              won: false,
+              pointsScored: 18,
+              pointsAllowed: 21,
+              eloChange: -8.0,
+              timestamp: DateTime(2024, 1, 10),
+            ),
+            RecentGameResult(
+              gameId: 'game-3',
+              won: false,
+              pointsScored: 19,
+              pointsAllowed: 21,
+              eloChange: -5.0,
+              timestamp: DateTime(2024, 1, 5),
+            ),
+          ],
+        );
+
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => losingStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('3 L Streak'), findsOneWidget);
+      });
+    });
+
+    group('Negative Stats Display', () {
+      testWidgets('shows negative ELO change correctly', (tester) async {
+        final negativeStats = TeammateStats(
+          userId: testPartnerId,
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 150,
+          pointsAllowed: 200,
+          eloChange: -30.0,
+          recentGames: [],
+        );
+
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => negativeStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('-30.0'), findsOneWidget);
+      });
+
+      testWidgets('shows negative point differential correctly',
+          (tester) async {
+        final negativeStats = TeammateStats(
+          userId: testPartnerId,
+          gamesPlayed: 10,
+          gamesWon: 3,
+          gamesLost: 7,
+          pointsScored: 150,
+          pointsAllowed: 200,
+          eloChange: -30.0,
+          recentGames: [],
+        );
+
+        when(() => mockUserRepository.getTeammateStats(testUserId, testPartnerId))
+            .thenAnswer((_) async => negativeStats);
+        when(() => mockUserRepository.getUserById(testPartnerId))
+            .thenAnswer((_) async => testPartner);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // 150/10 - 200/10 = 15 - 20 = -5
+        expect(find.text('-5.0'), findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add comprehensive widget tests for FullEloHistoryPage (17 tests)
- Add comprehensive widget tests for HeadToHeadPage (28 tests)
- Add comprehensive widget tests for PartnerDetailPage (31 tests)

## Test Coverage
All tests use mocktail for mocking UserRepository via GetIt service locator.

### FullEloHistoryPage Tests
- Initial UI rendering (app bar, filter icon)
- Error state handling
- Empty state when no history
- Stats summary (games count, W-L record, total change, average)
- Time period selector rendering
- Best ELO highlight card
- History list with entries, W/L markers, and trending icons

### HeadToHeadPage Tests
- Initial UI rendering
- Error state handling (null stats, exceptions)
- Opponent header (display name, email, avatar, rivalry badge)
- Rivalry card (intensity, matchup advantage)
- Record card (matchups count, win rate, W-L record)
- Point differential card
- Margins card (biggest win, worst loss, ELO vs opponent)
- Recent matchups with streak display
- Losing streak display
- Fallback display name when name is null

### PartnerDetailPage Tests
- Initial UI rendering
- Error state handling (null stats, null profile, exceptions)
- Partner header
- Record card
- Point differential card
- ELO performance card
- Recent form with streak display
- Negative stats display

## Test plan
- [x] All new widget tests pass (76 tests)
- [x] All existing unit and widget tests pass (2509 tests)
- [x] No flutter analyze warnings
- [x] Security checklist reviewed (test files only)

Closes #412