### PR TITLE
Story 16.3.4.5: Add Training & Notification Integration Tests

### DIFF
--- a/integration_test/notification_settings_test.dart
+++ b/integration_test/notification_settings_test.dart
@@ -1,0 +1,570 @@
+// Integration test for notification settings
+// Tests real Firebase Firestore interactions for notification preferences using Firebase Emulator
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/firebase_emulator_helper.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await FirebaseEmulatorHelper.initialize();
+  });
+
+  setUp(() async {
+    await FirebaseEmulatorHelper.clearFirestore();
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  tearDown(() async {
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  group('Notification Preferences Reading', () {
+    late String userId;
+
+    Future<void> createTestUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'notiftest@test.com',
+        password: 'password123',
+        displayName: 'Notification Tester',
+      );
+      userId = user.uid;
+    }
+
+    test(
+      'User without notification preferences gets default values',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final userDoc = await firestore.collection('users').doc(userId).get();
+
+        // User document exists but may not have notification preferences yet
+        expect(userDoc.exists, isTrue);
+
+        // notificationPreferences should be null or not exist
+        final prefs = userDoc.data()?['notificationPreferences'];
+        expect(prefs, isNull);
+      },
+    );
+
+    test(
+      'User can read their notification preferences',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Set initial notification preferences
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'groupInvitations': true,
+            'invitationAccepted': true,
+            'gameCreated': true,
+            'memberJoined': false,
+            'memberLeft': false,
+            'roleChanged': true,
+            'friendRequestReceived': true,
+            'friendRequestAccepted': true,
+            'friendRemoved': false,
+            'quietHoursEnabled': false,
+            'trainingSessionCreated': true,
+            'trainingMinParticipantsReached': true,
+            'trainingFeedbackReceived': true,
+            'trainingSessionCancelled': true,
+          },
+        });
+
+        // Read preferences
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['groupInvitations'], isTrue);
+        expect(prefs['memberJoined'], isFalse);
+        expect(prefs['trainingSessionCreated'], isTrue);
+      },
+    );
+  });
+
+  group('Notification Preferences Toggling', () {
+    late String userId;
+
+    Future<void> createTestUserWithPreferences() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'toggletest@test.com',
+        password: 'password123',
+        displayName: 'Toggle Tester',
+      );
+      userId = user.uid;
+
+      // Set initial preferences
+      final firestore = FirebaseFirestore.instance;
+      await firestore.collection('users').doc(userId).update({
+        'notificationPreferences': {
+          'groupInvitations': true,
+          'invitationAccepted': true,
+          'gameCreated': true,
+          'memberJoined': false,
+          'memberLeft': false,
+          'roleChanged': true,
+          'friendRequestReceived': true,
+          'friendRequestAccepted': true,
+          'friendRemoved': false,
+          'quietHoursEnabled': false,
+          'trainingSessionCreated': true,
+          'trainingMinParticipantsReached': true,
+          'trainingFeedbackReceived': true,
+          'trainingSessionCancelled': true,
+        },
+      });
+    }
+
+    test(
+      'User can toggle groupInvitations preference',
+      () async {
+        await createTestUserWithPreferences();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Toggle groupInvitations to false
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.groupInvitations': false,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['groupInvitations'], isFalse);
+      },
+    );
+
+    test(
+      'User can toggle gameCreated preference',
+      () async {
+        await createTestUserWithPreferences();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Toggle gameCreated to false
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.gameCreated': false,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['gameCreated'], isFalse);
+      },
+    );
+
+    test(
+      'User can toggle memberJoined preference',
+      () async {
+        await createTestUserWithPreferences();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Toggle memberJoined to true (was false)
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.memberJoined': true,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['memberJoined'], isTrue);
+      },
+    );
+
+    test(
+      'User can toggle training session notification preferences',
+      () async {
+        await createTestUserWithPreferences();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Toggle training notification preferences
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.trainingSessionCreated': false,
+          'notificationPreferences.trainingMinParticipantsReached': false,
+          'notificationPreferences.trainingFeedbackReceived': false,
+          'notificationPreferences.trainingSessionCancelled': false,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['trainingSessionCreated'], isFalse);
+        expect(prefs['trainingMinParticipantsReached'], isFalse);
+        expect(prefs['trainingFeedbackReceived'], isFalse);
+        expect(prefs['trainingSessionCancelled'], isFalse);
+      },
+    );
+
+    test(
+      'Toggling one preference does not affect others',
+      () async {
+        await createTestUserWithPreferences();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Toggle only gameCreated
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.gameCreated': false,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        // gameCreated should be false
+        expect(prefs['gameCreated'], isFalse);
+
+        // Other preferences should remain unchanged
+        expect(prefs['groupInvitations'], isTrue);
+        expect(prefs['invitationAccepted'], isTrue);
+        expect(prefs['friendRequestReceived'], isTrue);
+      },
+    );
+  });
+
+  group('Notification Preferences Persistence', () {
+    late String userId;
+
+    Future<void> createTestUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'persisttest@test.com',
+        password: 'password123',
+        displayName: 'Persist Tester',
+      );
+      userId = user.uid;
+    }
+
+    test(
+      'Notification preferences are saved to Firestore correctly',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Save complete preferences
+        final prefsToSave = {
+          'groupInvitations': true,
+          'invitationAccepted': false,
+          'gameCreated': true,
+          'memberJoined': true,
+          'memberLeft': false,
+          'roleChanged': true,
+          'friendRequestReceived': false,
+          'friendRequestAccepted': true,
+          'friendRemoved': true,
+          'quietHoursEnabled': true,
+          'quietHoursStart': '22:00',
+          'quietHoursEnd': '08:00',
+          'trainingSessionCreated': true,
+          'trainingMinParticipantsReached': false,
+          'trainingFeedbackReceived': true,
+          'trainingSessionCancelled': false,
+          'groupSpecific': {
+            'group-123': true,
+            'group-456': false,
+          },
+        };
+
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': prefsToSave,
+        });
+
+        // Read back and verify
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['groupInvitations'], isTrue);
+        expect(prefs['invitationAccepted'], isFalse);
+        expect(prefs['quietHoursEnabled'], isTrue);
+        expect(prefs['quietHoursStart'], equals('22:00'));
+        expect(prefs['quietHoursEnd'], equals('08:00'));
+        expect(prefs['trainingSessionCreated'], isTrue);
+        expect(prefs['trainingMinParticipantsReached'], isFalse);
+      },
+    );
+
+    test(
+      'Preferences persist after sign out and sign in',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Save preferences
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'groupInvitations': false,
+            'gameCreated': false,
+            'quietHoursEnabled': true,
+          },
+        });
+
+        // Sign out
+        await FirebaseEmulatorHelper.signOut();
+
+        // Sign back in
+        await FirebaseEmulatorHelper.signIn(
+          email: 'persisttest@test.com',
+          password: 'password123',
+        );
+
+        // Read preferences
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        // Verify preferences persisted
+        expect(prefs['groupInvitations'], isFalse);
+        expect(prefs['gameCreated'], isFalse);
+        expect(prefs['quietHoursEnabled'], isTrue);
+      },
+    );
+
+    test(
+      'Group-specific notification settings are saved correctly',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create a group
+        final groupId = await FirebaseEmulatorHelper.createTestGroup(
+          createdBy: userId,
+          name: 'Notification Test Group',
+        );
+
+        // Save group-specific preferences
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'groupSpecific': {
+              groupId: false,
+            },
+          },
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+        final groupSpecific = prefs['groupSpecific'] as Map<String, dynamic>?;
+
+        expect(groupSpecific?[groupId], isFalse);
+      },
+    );
+  });
+
+  group('Quiet Hours Settings', () {
+    late String userId;
+
+    Future<void> createTestUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'quiettest@test.com',
+        password: 'password123',
+        displayName: 'Quiet Hours Tester',
+      );
+      userId = user.uid;
+    }
+
+    test(
+      'User can enable quiet hours',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'quietHoursEnabled': true,
+            'quietHoursStart': '22:00',
+            'quietHoursEnd': '07:00',
+          },
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['quietHoursEnabled'], isTrue);
+        expect(prefs['quietHoursStart'], equals('22:00'));
+        expect(prefs['quietHoursEnd'], equals('07:00'));
+      },
+    );
+
+    test(
+      'User can disable quiet hours',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Enable quiet hours first
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'quietHoursEnabled': true,
+            'quietHoursStart': '22:00',
+            'quietHoursEnd': '07:00',
+          },
+        });
+
+        // Disable quiet hours
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.quietHoursEnabled': false,
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['quietHoursEnabled'], isFalse);
+        // Time values may still exist but quiet hours is disabled
+      },
+    );
+
+    test(
+      'User can update quiet hours time range',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Set initial quiet hours
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'quietHoursEnabled': true,
+            'quietHoursStart': '22:00',
+            'quietHoursEnd': '07:00',
+          },
+        });
+
+        // Update time range
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences.quietHoursStart': '23:00',
+          'notificationPreferences.quietHoursEnd': '06:00',
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['quietHoursStart'], equals('23:00'));
+        expect(prefs['quietHoursEnd'], equals('06:00'));
+      },
+    );
+  });
+
+  group('Complete Notification Preferences Update', () {
+    late String userId;
+
+    Future<void> createTestUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'completetest@test.com',
+        password: 'password123',
+        displayName: 'Complete Update Tester',
+      );
+      userId = user.uid;
+    }
+
+    test(
+      'User can save complete notification preferences object',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Save complete preferences (as the app would do)
+        final completePrefs = {
+          'groupInvitations': true,
+          'invitationAccepted': true,
+          'gameCreated': true,
+          'memberJoined': false,
+          'memberLeft': false,
+          'roleChanged': true,
+          'friendRequestReceived': true,
+          'friendRequestAccepted': true,
+          'friendRemoved': false,
+          'quietHoursEnabled': false,
+          'quietHoursStart': null,
+          'quietHoursEnd': null,
+          'groupSpecific': <String, bool>{},
+          'trainingSessionCreated': true,
+          'trainingMinParticipantsReached': true,
+          'trainingFeedbackReceived': true,
+          'trainingSessionCancelled': true,
+        };
+
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': completePrefs,
+        });
+
+        // Verify all fields saved
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['groupInvitations'], isTrue);
+        expect(prefs['invitationAccepted'], isTrue);
+        expect(prefs['gameCreated'], isTrue);
+        expect(prefs['memberJoined'], isFalse);
+        expect(prefs['memberLeft'], isFalse);
+        expect(prefs['roleChanged'], isTrue);
+        expect(prefs['friendRequestReceived'], isTrue);
+        expect(prefs['friendRequestAccepted'], isTrue);
+        expect(prefs['friendRemoved'], isFalse);
+        expect(prefs['quietHoursEnabled'], isFalse);
+        expect(prefs['trainingSessionCreated'], isTrue);
+        expect(prefs['trainingMinParticipantsReached'], isTrue);
+        expect(prefs['trainingFeedbackReceived'], isTrue);
+        expect(prefs['trainingSessionCancelled'], isTrue);
+      },
+    );
+
+    test(
+      'Updating preferences replaces existing values',
+      () async {
+        await createTestUser();
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Set initial preferences
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'groupInvitations': true,
+            'gameCreated': true,
+          },
+        });
+
+        // Update with new preferences (replaces entire object)
+        await firestore.collection('users').doc(userId).update({
+          'notificationPreferences': {
+            'groupInvitations': false,
+            'gameCreated': false,
+            'memberJoined': true,
+          },
+        });
+
+        final userDoc = await firestore.collection('users').doc(userId).get();
+        final prefs =
+            userDoc.data()?['notificationPreferences'] as Map<String, dynamic>;
+
+        expect(prefs['groupInvitations'], isFalse);
+        expect(prefs['gameCreated'], isFalse);
+        expect(prefs['memberJoined'], isTrue);
+      },
+    );
+  });
+}

--- a/integration_test/training_session_flow_test.dart
+++ b/integration_test/training_session_flow_test.dart
@@ -1,0 +1,770 @@
+// Integration test for training session flow
+// Tests real Firebase Firestore interactions for training sessions using Firebase Emulator
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/firebase_emulator_helper.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await FirebaseEmulatorHelper.initialize();
+  });
+
+  setUp(() async {
+    await FirebaseEmulatorHelper.clearFirestore();
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  tearDown(() async {
+    await FirebaseEmulatorHelper.signOut();
+  });
+
+  group('Training Session Creation', () {
+    late String groupId;
+    late String userId;
+
+    Future<void> createTestGroupAndUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'trainingtest@test.com',
+        password: 'password123',
+        displayName: 'Training Tester',
+      );
+      userId = user.uid;
+
+      groupId = await FirebaseEmulatorHelper.createTestGroup(
+        createdBy: userId,
+        name: 'Training Group',
+        memberIds: [userId],
+      );
+    }
+
+    test(
+      'User can create a training session within a group',
+      () async {
+        await createTestGroupAndUser();
+
+        final firestore = FirebaseFirestore.instance;
+        final startTime = DateTime.now().add(const Duration(days: 1));
+        final endTime = startTime.add(const Duration(hours: 2));
+
+        final sessionRef = await firestore.collection('trainingSessions').add({
+          'groupId': groupId,
+          'createdBy': userId,
+          'title': 'Morning Training',
+          'description': 'Practice drills and warm-up',
+          'startTime': Timestamp.fromDate(startTime),
+          'endTime': Timestamp.fromDate(endTime),
+          'location': {
+            'name': 'Beach Court 1',
+            'address': '123 Beach Blvd',
+          },
+          'minParticipants': 4,
+          'maxParticipants': 12,
+          'participantIds': [userId],
+          'status': 'scheduled',
+          'createdAt': FieldValue.serverTimestamp(),
+        });
+
+        // Verify session was created
+        final sessionDoc = await sessionRef.get();
+        expect(sessionDoc.exists, isTrue);
+        expect(sessionDoc.data()?['title'], equals('Morning Training'));
+        expect(sessionDoc.data()?['groupId'], equals(groupId));
+        expect(sessionDoc.data()?['createdBy'], equals(userId));
+        expect(sessionDoc.data()?['status'], equals('scheduled'));
+      },
+    );
+
+    test(
+      'Training session stores location correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Location Test Session',
+          locationName: 'Venice Beach Court',
+          locationAddress: '456 Ocean Ave, Venice, CA',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        final location = sessionDoc.data()?['location'] as Map<String, dynamic>?;
+        expect(location?['name'], equals('Venice Beach Court'));
+        expect(location?['address'], equals('456 Ocean Ave, Venice, CA'));
+      },
+    );
+
+    test(
+      'Training session stores participant limits correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Limited Session',
+          minParticipants: 6,
+          maxParticipants: 20,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        expect(sessionDoc.data()?['minParticipants'], equals(6));
+        expect(sessionDoc.data()?['maxParticipants'], equals(20));
+      },
+    );
+
+    test(
+      'Training session time is stored correctly',
+      () async {
+        await createTestGroupAndUser();
+
+        final startTime = DateTime(2026, 3, 15, 9, 0);
+        final endTime = DateTime(2026, 3, 15, 11, 0);
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Timed Session',
+          startTime: startTime,
+          endTime: endTime,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        final storedStartTime =
+            (sessionDoc.data()?['startTime'] as Timestamp).toDate();
+        final storedEndTime =
+            (sessionDoc.data()?['endTime'] as Timestamp).toDate();
+
+        expect(storedStartTime.year, equals(2026));
+        expect(storedStartTime.month, equals(3));
+        expect(storedStartTime.day, equals(15));
+        expect(storedStartTime.hour, equals(9));
+
+        expect(storedEndTime.hour, equals(11));
+      },
+    );
+
+    test(
+      'Multiple training sessions can be created in same group',
+      () async {
+        await createTestGroupAndUser();
+
+        // Create first session
+        await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Morning Training',
+        );
+
+        // Create second session
+        await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Evening Training',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final sessions = await firestore
+            .collection('trainingSessions')
+            .where('groupId', isEqualTo: groupId)
+            .get();
+
+        expect(sessions.docs.length, equals(2));
+      },
+    );
+  });
+
+  group('Training Session Participation', () {
+    late String groupId;
+    late String creatorId;
+    late String participantId;
+
+    Future<void> createTestUsersAndGroup() async {
+      // Create session creator
+      final creator = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'creator@test.com',
+        password: 'password123',
+        displayName: 'Session Creator',
+      );
+      creatorId = creator.uid;
+
+      // Sign out and create participant
+      await FirebaseEmulatorHelper.signOut();
+      final participant = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'participant@test.com',
+        password: 'password123',
+        displayName: 'Session Participant',
+      );
+      participantId = participant.uid;
+
+      // Create group with both members
+      groupId = await FirebaseEmulatorHelper.createTestGroup(
+        createdBy: creatorId,
+        name: 'Participation Test Group',
+        memberIds: [creatorId, participantId],
+      );
+    }
+
+    test(
+      'User can join a training session',
+      () async {
+        await createTestUsersAndGroup();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: creatorId,
+          title: 'Join Test Session',
+          participantIds: [creatorId],
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Simulate joining by adding participant
+        await firestore.collection('trainingSessions').doc(sessionId).update({
+          'participantIds': FieldValue.arrayUnion([participantId]),
+        });
+
+        // Also create participant subcollection entry
+        await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('participants')
+            .doc(participantId)
+            .set({
+          'userId': participantId,
+          'joinedAt': FieldValue.serverTimestamp(),
+          'status': 'joined',
+        });
+
+        // Verify participant was added
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+        final participantIds =
+            List<String>.from(sessionDoc.data()?['participantIds'] ?? []);
+
+        expect(participantIds, contains(participantId));
+        expect(participantIds.length, equals(2));
+
+        // Verify participant subcollection
+        final participantDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('participants')
+            .doc(participantId)
+            .get();
+
+        expect(participantDoc.exists, isTrue);
+        expect(participantDoc.data()?['status'], equals('joined'));
+      },
+    );
+
+    test(
+      'User can leave a training session',
+      () async {
+        await createTestUsersAndGroup();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: creatorId,
+          title: 'Leave Test Session',
+          participantIds: [creatorId, participantId],
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Create participant entry first
+        await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('participants')
+            .doc(participantId)
+            .set({
+          'userId': participantId,
+          'joinedAt': FieldValue.serverTimestamp(),
+          'status': 'joined',
+        });
+
+        // Simulate leaving by removing participant
+        await firestore.collection('trainingSessions').doc(sessionId).update({
+          'participantIds': FieldValue.arrayRemove([participantId]),
+        });
+
+        // Update participant status
+        await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('participants')
+            .doc(participantId)
+            .update({
+          'status': 'left',
+          'leftAt': FieldValue.serverTimestamp(),
+        });
+
+        // Verify participant was removed from main array
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+        final participantIds =
+            List<String>.from(sessionDoc.data()?['participantIds'] ?? []);
+
+        expect(participantIds, isNot(contains(participantId)));
+        expect(participantIds.length, equals(1));
+
+        // Verify participant status updated
+        final participantDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('participants')
+            .doc(participantId)
+            .get();
+
+        expect(participantDoc.data()?['status'], equals('left'));
+      },
+    );
+
+    test(
+      'Creator remains in participant list after creation',
+      () async {
+        await createTestUsersAndGroup();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: creatorId,
+          title: 'Creator Participation Test',
+          participantIds: [creatorId],
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        final participantIds =
+            List<String>.from(sessionDoc.data()?['participantIds'] ?? []);
+
+        expect(participantIds, contains(creatorId));
+      },
+    );
+  });
+
+  group('Exercise Management', () {
+    late String groupId;
+    late String userId;
+    late String sessionId;
+
+    Future<void> createTestSessionWithGroup() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'exercisetest@test.com',
+        password: 'password123',
+        displayName: 'Exercise Tester',
+      );
+      userId = user.uid;
+
+      groupId = await FirebaseEmulatorHelper.createTestGroup(
+        createdBy: userId,
+        name: 'Exercise Test Group',
+      );
+
+      sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+        groupId: groupId,
+        createdBy: userId,
+        title: 'Exercise Test Session',
+      );
+    }
+
+    test(
+      'User can add exercise to training session',
+      () async {
+        await createTestSessionWithGroup();
+
+        final exerciseId = await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'Passing Drills',
+          description: 'Practice basic passing techniques',
+          durationMinutes: 15,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final exerciseDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .get();
+
+        expect(exerciseDoc.exists, isTrue);
+        expect(exerciseDoc.data()?['name'], equals('Passing Drills'));
+        expect(exerciseDoc.data()?['description'],
+            equals('Practice basic passing techniques'));
+        expect(exerciseDoc.data()?['durationMinutes'], equals(15));
+      },
+    );
+
+    test(
+      'Multiple exercises can be added to session',
+      () async {
+        await createTestSessionWithGroup();
+
+        // Add multiple exercises
+        await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'Warm-up',
+          durationMinutes: 10,
+        );
+
+        await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'Serving Practice',
+          durationMinutes: 20,
+        );
+
+        await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'Scrimmage',
+          durationMinutes: 30,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final exercises = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .get();
+
+        expect(exercises.docs.length, equals(3));
+      },
+    );
+
+    test(
+      'Exercise can be updated',
+      () async {
+        await createTestSessionWithGroup();
+
+        final exerciseId = await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'Original Name',
+          durationMinutes: 10,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Update exercise
+        await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .update({
+          'name': 'Updated Name',
+          'durationMinutes': 20,
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+
+        final exerciseDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .get();
+
+        expect(exerciseDoc.data()?['name'], equals('Updated Name'));
+        expect(exerciseDoc.data()?['durationMinutes'], equals(20));
+      },
+    );
+
+    test(
+      'Exercise can be deleted',
+      () async {
+        await createTestSessionWithGroup();
+
+        final exerciseId = await FirebaseEmulatorHelper.createTestExercise(
+          trainingSessionId: sessionId,
+          name: 'To Be Deleted',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Verify exercise exists
+        var exerciseDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .get();
+        expect(exerciseDoc.exists, isTrue);
+
+        // Delete exercise
+        await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .delete();
+
+        // Verify exercise is deleted
+        exerciseDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('exercises')
+            .doc(exerciseId)
+            .get();
+        expect(exerciseDoc.exists, isFalse);
+      },
+    );
+  });
+
+  group('Feedback Submission', () {
+    late String groupId;
+    late String userId;
+    late String sessionId;
+
+    Future<void> createTestSessionWithGroup() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'feedbacktest@test.com',
+        password: 'password123',
+        displayName: 'Feedback Tester',
+      );
+      userId = user.uid;
+
+      groupId = await FirebaseEmulatorHelper.createTestGroup(
+        createdBy: userId,
+        name: 'Feedback Test Group',
+      );
+
+      sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+        groupId: groupId,
+        createdBy: userId,
+        title: 'Feedback Test Session',
+        participantIds: [userId],
+        status: 'completed',
+      );
+    }
+
+    test(
+      'User can submit feedback for a training session',
+      () async {
+        await createTestSessionWithGroup();
+
+        // Generate a participant hash (simulating what the Cloud Function would do)
+        final participantHash = 'hash_${sessionId}_$userId';
+
+        final feedbackId = await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 4,
+          trainingIntensity: 5,
+          coachingClarity: 4,
+          comment: 'Great session!',
+          participantHash: participantHash,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final feedbackDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('feedback')
+            .doc(feedbackId)
+            .get();
+
+        expect(feedbackDoc.exists, isTrue);
+        expect(feedbackDoc.data()?['exercisesQuality'], equals(4));
+        expect(feedbackDoc.data()?['trainingIntensity'], equals(5));
+        expect(feedbackDoc.data()?['coachingClarity'], equals(4));
+        expect(feedbackDoc.data()?['comment'], equals('Great session!'));
+        expect(feedbackDoc.data()?['participantHash'], equals(participantHash));
+      },
+    );
+
+    test(
+      'Feedback is anonymous (no direct user ID stored)',
+      () async {
+        await createTestSessionWithGroup();
+
+        final participantHash = 'anonymous_hash_123';
+
+        final feedbackId = await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 3,
+          trainingIntensity: 4,
+          coachingClarity: 5,
+          participantHash: participantHash,
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final feedbackDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('feedback')
+            .doc(feedbackId)
+            .get();
+
+        // Verify no userId field exists
+        expect(feedbackDoc.data()?.containsKey('userId'), isFalse);
+        // Verify only hash is stored
+        expect(feedbackDoc.data()?['participantHash'], equals(participantHash));
+      },
+    );
+
+    test(
+      'Multiple feedback entries can be submitted for same session',
+      () async {
+        await createTestSessionWithGroup();
+
+        // Submit feedback from different "participants" (simulated with different hashes)
+        await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 5,
+          trainingIntensity: 5,
+          coachingClarity: 5,
+          participantHash: 'hash_participant_1',
+        );
+
+        await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 4,
+          trainingIntensity: 4,
+          coachingClarity: 4,
+          participantHash: 'hash_participant_2',
+        );
+
+        await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 3,
+          trainingIntensity: 3,
+          coachingClarity: 3,
+          participantHash: 'hash_participant_3',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final feedbackList = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('feedback')
+            .get();
+
+        expect(feedbackList.docs.length, equals(3));
+      },
+    );
+
+    test(
+      'Feedback ratings are within valid range',
+      () async {
+        await createTestSessionWithGroup();
+
+        final feedbackId = await FirebaseEmulatorHelper.createTestFeedback(
+          trainingSessionId: sessionId,
+          exercisesQuality: 1,
+          trainingIntensity: 3,
+          coachingClarity: 5,
+          participantHash: 'test_hash',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+        final feedbackDoc = await firestore
+            .collection('trainingSessions')
+            .doc(sessionId)
+            .collection('feedback')
+            .doc(feedbackId)
+            .get();
+
+        final exercisesQuality = feedbackDoc.data()?['exercisesQuality'] as int;
+        final trainingIntensity = feedbackDoc.data()?['trainingIntensity'] as int;
+        final coachingClarity = feedbackDoc.data()?['coachingClarity'] as int;
+
+        // Verify ratings are within 1-5 range
+        expect(exercisesQuality, greaterThanOrEqualTo(1));
+        expect(exercisesQuality, lessThanOrEqualTo(5));
+        expect(trainingIntensity, greaterThanOrEqualTo(1));
+        expect(trainingIntensity, lessThanOrEqualTo(5));
+        expect(coachingClarity, greaterThanOrEqualTo(1));
+        expect(coachingClarity, lessThanOrEqualTo(5));
+      },
+    );
+  });
+
+  group('Training Session Status', () {
+    late String groupId;
+    late String userId;
+
+    Future<void> createTestGroupAndUser() async {
+      final user = await FirebaseEmulatorHelper.createCompleteTestUser(
+        email: 'statustest@test.com',
+        password: 'password123',
+        displayName: 'Status Tester',
+      );
+      userId = user.uid;
+
+      groupId = await FirebaseEmulatorHelper.createTestGroup(
+        createdBy: userId,
+        name: 'Status Test Group',
+      );
+    }
+
+    test(
+      'Training session status can be updated to cancelled',
+      () async {
+        await createTestGroupAndUser();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Cancellation Test',
+          status: 'scheduled',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Cancel the session
+        await firestore.collection('trainingSessions').doc(sessionId).update({
+          'status': 'cancelled',
+          'cancelledBy': userId,
+          'cancelledAt': FieldValue.serverTimestamp(),
+        });
+
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        expect(sessionDoc.data()?['status'], equals('cancelled'));
+        expect(sessionDoc.data()?['cancelledBy'], equals(userId));
+      },
+    );
+
+    test(
+      'Training session status can be updated to completed',
+      () async {
+        await createTestGroupAndUser();
+
+        final sessionId = await FirebaseEmulatorHelper.createTestTrainingSession(
+          groupId: groupId,
+          createdBy: userId,
+          title: 'Completion Test',
+          status: 'scheduled',
+        );
+
+        final firestore = FirebaseFirestore.instance;
+
+        // Complete the session
+        await firestore.collection('trainingSessions').doc(sessionId).update({
+          'status': 'completed',
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+
+        final sessionDoc =
+            await firestore.collection('trainingSessions').doc(sessionId).get();
+
+        expect(sessionDoc.data()?['status'], equals('completed'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Add comprehensive integration tests for training session flows using Firebase Emulator
- Add integration tests for notification settings persistence and toggling
- Extend FirebaseEmulatorHelper with training session support

## Changes

### Training Session Flow Tests (`integration_test/training_session_flow_test.dart`)
- **Training Session Creation**: Tests for creating sessions, storing location, participant limits, and timing
- **Participation**: Tests for joining/leaving sessions and participant tracking
- **Exercise Management**: Tests for adding, updating, and deleting exercises within sessions
- **Feedback Submission**: Tests for anonymous feedback with ratings and comments
- **Status Updates**: Tests for session cancellation and completion

### Notification Settings Tests (`integration_test/notification_settings_test.dart`)
- **Reading Preferences**: Tests for default values and reading existing preferences
- **Toggling**: Tests for toggling individual notification types
- **Persistence**: Tests for preferences persisting across sign out/sign in
- **Quiet Hours**: Tests for enabling/disabling and configuring quiet hours
- **Group-Specific**: Tests for per-group notification settings

### FirebaseEmulatorHelper Updates
- Added `trainingSessions` to collection clearing
- Added `exercises`, `feedback`, `participants` subcollection clearing
- Added `createTestTrainingSession()` helper
- Added `createTestExercise()` helper
- Added `createTestFeedback()` helper

## Test Plan
- [x] All unit tests pass (2105 passed, 7 skipped)
- [x] All widget tests pass (689 passed, 29 skipped)
- [ ] Integration tests run successfully with Firebase Emulator

## Related Issues
Closes #413