### PR TITLE
feat(ui): split profile into profile/stats sections & update navigation (#451)

### DIFF
--- a/lib/core/theme/play_with_me_app_bar.dart
+++ b/lib/core/theme/play_with_me_app_bar.dart
@@ -1,25 +1,36 @@
 // Shared AppBar builder for consistent header styling across all pages.
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/invitations/presentation/pages/pending_invitations_page.dart';
+import 'package:play_with_me/features/profile/presentation/pages/profile_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
 class PlayWithMeAppBar {
   PlayWithMeAppBar._();
 
-  /// Builds the standard AppBar with volleyball icon, title, and optional actions.
+  /// Builds the standard AppBar with volleyball icon, title, and user actions.
   ///
-  /// [showUserActions] adds profile and logout icons (set false for auth pages).
-  /// [extraActions] are placed before the profile/logout icons.
+  /// When [showUserActions] is true (default), the AppBar includes:
+  /// - Invitation badge (requires [InvitationBloc] in context)
+  /// - Profile icon (navigates to ProfilePage)
+  /// - Logout icon (shows sign-out confirmation dialog)
+  ///
+  /// Set [showUserActions] to false for unauthenticated pages (login, register).
+  /// Set [showProfileAction] to false when already on the profile page.
+  ///
+  /// [extraActions] are placed after the user actions.
   static AppBar build({
     required BuildContext context,
     required String title,
     List<Widget>? extraActions,
     bool showUserActions = true,
+    bool showProfileAction = true,
   }) {
-    final l10n = AppLocalizations.of(context)!;
     return AppBar(
       backgroundColor: AppColors.appBarBackground,
       surfaceTintColor: Colors.transparent,
@@ -56,26 +67,127 @@ class PlayWithMeAppBar {
         ),
       ),
       actions: [
+        if (showUserActions) ..._buildUserActions(
+          context: context,
+          showProfileAction: showProfileAction,
+        ),
         if (extraActions != null) ...extraActions,
-        if (showUserActions) ...[
-          IconButton(
-            icon: const Icon(Icons.person_outline, size: 22),
-            tooltip: l10n.profile,
-            onPressed: () {
-              Navigator.pushNamed(context, '/profile');
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.logout, size: 22),
-            tooltip: l10n.signOut,
-            onPressed: () {
-              context.read<AuthenticationBloc>().add(
-                    const AuthenticationLogoutRequested(),
+      ],
+    );
+  }
+
+  static List<Widget> _buildUserActions({
+    required BuildContext context,
+    required bool showProfileAction,
+  }) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return [
+      // Invitation badge
+      BlocBuilder<InvitationBloc, InvitationState>(
+        builder: (context, state) {
+          int pendingCount = 0;
+          if (state is InvitationsLoaded) {
+            pendingCount = state.invitations.length;
+          }
+
+          return Stack(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.mail_outline, size: 22),
+                tooltip: l10n.invitations,
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PendingInvitationsPage(),
+                    ),
                   );
+                },
+              ),
+              if (pendingCount > 0)
+                Positioned(
+                  right: 8,
+                  top: 8,
+                  child: Container(
+                    padding: const EdgeInsets.all(3),
+                    decoration: BoxDecoration(
+                      color: Colors.red,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    constraints: const BoxConstraints(
+                      minWidth: 16,
+                      minHeight: 16,
+                    ),
+                    child: Text(
+                      pendingCount > 9 ? '9+' : '$pendingCount',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 9,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+      // Profile icon
+      if (showProfileAction)
+        IconButton(
+          icon: const Icon(Icons.person_outline, size: 22),
+          tooltip: l10n.profile,
+          onPressed: () => _navigateToProfile(context),
+        ),
+      // Logout icon
+      IconButton(
+        icon: const Icon(Icons.logout, size: 22),
+        tooltip: l10n.signOut,
+        onPressed: () => _showSignOutDialog(context),
+      ),
+    ];
+  }
+
+  static void _navigateToProfile(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (routeContext) => Scaffold(
+          appBar: PlayWithMeAppBar.build(
+            context: routeContext,
+            title: AppLocalizations.of(routeContext)!.profile,
+            showProfileAction: false,
+          ),
+          body: const ProfilePage(),
+        ),
+      ),
+    );
+  }
+
+  static void _showSignOutDialog(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.signOut),
+        content: Text(l10n.signOutConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () {
+              context
+                  .read<AuthenticationBloc>()
+                  .add(const AuthenticationLogoutRequested());
+              Navigator.of(dialogContext).pop();
             },
+            child: Text(l10n.signOut),
           ),
         ],
-      ],
+      ),
     );
   }
 }

--- a/lib/features/friends/presentation/pages/add_friend_page.dart
+++ b/lib/features/friends/presentation/pages/add_friend_page.dart
@@ -50,7 +50,7 @@ class _AddFriendPageState extends State<AddFriendPage> {
             appBar: PlayWithMeAppBar.build(
               context: context,
               title: 'Add Friend',
-              showUserActions: false,
+              showUserActions: true,
             ),
             body: const Center(
               child: Text('Please log in to add friends'),

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -276,7 +276,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
               appBar: PlayWithMeAppBar.build(
                 context: context,
                 title: 'Group Details',
-                showUserActions: false,
+                showUserActions: true,
               ),
               body: const Center(
                 child: Text('Please log in to view group details'),

--- a/lib/features/groups/presentation/pages/group_list_page.dart
+++ b/lib/features/groups/presentation/pages/group_list_page.dart
@@ -30,7 +30,7 @@ class GroupListPage extends StatelessWidget {
             appBar: PlayWithMeAppBar.build(
               context: context,
               title: AppLocalizations.of(context)!.myGroups,
-              showUserActions: false,
+              showUserActions: true,
             ),
             body: Center(
               child: Text(AppLocalizations.of(context)!.pleaseLogInToViewGroups),

--- a/lib/features/groups/presentation/pages/invite_member_page.dart
+++ b/lib/features/groups/presentation/pages/invite_member_page.dart
@@ -157,7 +157,7 @@ class _InviteMemberPageState extends State<InviteMemberPage> {
             appBar: PlayWithMeAppBar.build(
               context: context,
               title: 'Invite Members',
-              showUserActions: false,
+              showUserActions: true,
             ),
             body: const Center(
               child: Text('Please log in to invite members'),
@@ -171,7 +171,7 @@ class _InviteMemberPageState extends State<InviteMemberPage> {
             appBar: PlayWithMeAppBar.build(
               context: context,
               title: 'Invite Members',
-              showUserActions: false,
+              showUserActions: true,
             ),
             body: const Center(
               child: Text('Friend list not available'),

--- a/lib/features/invitations/presentation/pages/pending_invitations_page.dart
+++ b/lib/features/invitations/presentation/pages/pending_invitations_page.dart
@@ -23,7 +23,7 @@ class PendingInvitationsPage extends StatelessWidget {
             appBar: PlayWithMeAppBar.build(
               context: context,
               title: 'Invitations',
-              showUserActions: false,
+              showUserActions: true,
             ),
             body: const Center(
               child: Text('Please log in to view invitations'),

--- a/lib/features/profile/presentation/pages/stats_page.dart
+++ b/lib/features/profile/presentation/pages/stats_page.dart
@@ -1,0 +1,70 @@
+// Dedicated stats page displaying detailed player performance analytics.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_state.dart';
+import 'package:play_with_me/features/profile/presentation/widgets/expanded_stats_section.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+/// Stats tab content displaying all player performance and analytics.
+///
+/// This page answers: "How am I performing over time?"
+/// It shows:
+/// - Performance Overview (ELO, win rate, games played, best win)
+/// - Momentum & Consistency (streaks, trends)
+/// - Partners (best partner stats)
+/// - Rivals (nemesis stats)
+/// - Role-Based Performance (adaptability stats)
+class StatsPage extends StatelessWidget {
+  const StatsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PlayerStatsBloc, PlayerStatsState>(
+      builder: (context, statsState) {
+        if (statsState is PlayerStatsLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (statsState is PlayerStatsError) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  size: 48,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Error loading stats: ${statsState.message}',
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          );
+        }
+
+        if (statsState is PlayerStatsLoaded) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.only(top: 16, bottom: 20),
+            child: ExpandedStatsSection(
+              user: statsState.user,
+              ratingHistory: statsState.history,
+            ),
+          );
+        }
+
+        // Initial state
+        return Center(
+          child: Text(
+            AppLocalizations.of(context)!.noStatsYet,
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/training/presentation/pages/training_session_details_page.dart
+++ b/lib/features/training/presentation/pages/training_session_details_page.dart
@@ -85,7 +85,7 @@ class _TrainingSessionDetailsPageState
               appBar: PlayWithMeAppBar.build(
                 context: context,
                 title: l10n.training,
-                showUserActions: false,
+                showUserActions: true,
               ),
               body: const Center(child: CircularProgressIndicator()),
             );
@@ -96,7 +96,7 @@ class _TrainingSessionDetailsPageState
               appBar: PlayWithMeAppBar.build(
                 context: context,
                 title: l10n.training,
-                showUserActions: false,
+                showUserActions: true,
               ),
               body: Center(
                 child: Text(l10n.trainingNotFound),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -498,5 +498,7 @@
   "nextGame": "Nächstes Spiel",
   "noGamesScheduled": "Noch keine Spiele organisiert",
   "nextTrainingSession": "Nächste Trainingseinheit",
-  "noTrainingSessionsScheduled": "Keine Trainingseinheiten geplant"
+  "noTrainingSessionsScheduled": "Keine Trainingseinheiten geplant",
+  "stats": "Statistiken",
+  "myStats": "Meine Statistiken"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2350,5 +2350,15 @@
   "noTrainingSessionsScheduled": "No training sessions scheduled",
   "@noTrainingSessionsScheduled": {
     "description": "Message shown when user has no upcoming training sessions"
+  },
+
+  "stats": "Stats",
+  "@stats": {
+    "description": "Stats navigation tab label"
+  },
+
+  "myStats": "My Stats",
+  "@myStats": {
+    "description": "My Stats page title"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -498,5 +498,7 @@
   "nextGame": "Próximo partido",
   "noGamesScheduled": "Aún no hay partidos organizados",
   "nextTrainingSession": "Próxima sesión de entrenamiento",
-  "noTrainingSessionsScheduled": "No hay sesiones de entrenamiento programadas"
+  "noTrainingSessionsScheduled": "No hay sesiones de entrenamiento programadas",
+  "stats": "Estadísticas",
+  "myStats": "Mis Estadísticas"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -498,5 +498,7 @@
   "nextGame": "Prochain match",
   "noGamesScheduled": "Aucun match organisé pour le moment",
   "nextTrainingSession": "Prochaine séance d'entraînement",
-  "noTrainingSessionsScheduled": "Aucune séance d'entraînement prévue"
+  "noTrainingSessionsScheduled": "Aucune séance d'entraînement prévue",
+  "stats": "Stats",
+  "myStats": "Mes Stats"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -498,5 +498,7 @@
   "nextGame": "Prossima partita",
   "noGamesScheduled": "Nessuna partita organizzata ancora",
   "nextTrainingSession": "Prossimo allenamento",
-  "noTrainingSessionsScheduled": "Nessun allenamento programmato"
+  "noTrainingSessionsScheduled": "Nessun allenamento programmato",
+  "stats": "Statistiche",
+  "myStats": "Le Mie Statistiche"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3049,6 +3049,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No training sessions scheduled'**
   String get noTrainingSessionsScheduled;
+
+  /// Stats navigation tab label
+  ///
+  /// In en, this message translates to:
+  /// **'Stats'**
+  String get stats;
+
+  /// My Stats page title
+  ///
+  /// In en, this message translates to:
+  /// **'My Stats'**
+  String get myStats;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1651,4 +1651,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get noTrainingSessionsScheduled => 'Keine Trainingseinheiten geplant';
+
+  @override
+  String get stats => 'Statistiken';
+
+  @override
+  String get myStats => 'Meine Statistiken';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1628,4 +1628,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noTrainingSessionsScheduled => 'No training sessions scheduled';
+
+  @override
+  String get stats => 'Stats';
+
+  @override
+  String get myStats => 'My Stats';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1645,4 +1645,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get noTrainingSessionsScheduled =>
       'No hay sesiones de entrenamiento programadas';
+
+  @override
+  String get stats => 'Estadísticas';
+
+  @override
+  String get myStats => 'Mis Estadísticas';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1655,4 +1655,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get noTrainingSessionsScheduled =>
       'Aucune séance d\'entraînement prévue';
+
+  @override
+  String get stats => 'Stats';
+
+  @override
+  String get myStats => 'Mes Stats';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1643,4 +1643,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get noTrainingSessionsScheduled => 'Nessun allenamento programmato';
+
+  @override
+  String get stats => 'Statistiche';
+
+  @override
+  String get myStats => 'Le Mie Statistiche';
 }

--- a/test/unit/features/games/presentation/pages/game_result_view_page_test.dart
+++ b/test/unit/features/games/presentation/pages/game_result_view_page_test.dart
@@ -1,18 +1,41 @@
 // Tests player name resolution in GameResultViewPage widget.
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/games/presentation/pages/game_result_view_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockInvitationBloc extends Mock implements InvitationBloc {}
+class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
 
 void main() {
   group('GameResultViewPage', () {
     late GameModel gameWithResult;
     late Map<String, UserModel> players;
+    late MockInvitationBloc mockInvitationBloc;
+    late MockAuthenticationBloc mockAuthBloc;
 
     setUp(() {
+      mockInvitationBloc = MockInvitationBloc();
+      mockAuthBloc = MockAuthenticationBloc();
+      when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+      when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockAuthBloc.state).thenReturn(
+        AuthenticationAuthenticated(
+          UserEntity(uid: 'test-user', email: 'test@example.com', isEmailVerified: true, isAnonymous: false),
+        ),
+      );
+      when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
+
       // Create test users
       players = {
         'user1': const UserModel(
@@ -91,9 +114,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: players,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: players,
+            ),
           ),
         ),
       );
@@ -116,9 +145,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: null, // No player data
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: null, // No player data
+            ),
           ),
         ),
       );
@@ -147,9 +182,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: partialPlayers,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: partialPlayers,
+            ),
           ),
         ),
       );
@@ -172,9 +213,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: players,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: players,
+            ),
           ),
         ),
       );
@@ -197,9 +244,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithoutResult,
-            players: players,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithoutResult,
+              players: players,
+            ),
           ),
         ),
       );
@@ -219,9 +272,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: players,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: players,
+            ),
           ),
         ),
       );
@@ -245,9 +304,15 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: const [Locale('en')],
-          home: GameResultViewPage(
-            game: gameWithResult,
-            players: players,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+              BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            ],
+            child: GameResultViewPage(
+              game: gameWithResult,
+              players: players,
+            ),
           ),
         ),
       );

--- a/test/unit/features/groups/presentation/pages/group_list_page_test.dart
+++ b/test/unit/features/groups/presentation/pages/group_list_page_test.dart
@@ -8,6 +8,8 @@ import 'package:play_with_me/core/data/models/group_model.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_event.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_state.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
@@ -21,6 +23,7 @@ import '../../../../helpers/test_helpers.dart';
 // Mock classes
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
 class MockGroupBloc extends Mock implements GroupBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 // Fakes for mocktail
 class FakeGroupEvent extends Fake implements GroupEvent {}
@@ -30,6 +33,7 @@ class FakeLocalePreferencesEntity extends Fake implements LocalePreferencesEntit
 void main() {
   late MockAuthenticationBloc mockAuthBloc;
   late MockGroupBloc mockGroupBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   setUpAll(() {
     registerFallbackValue(FakeGroupEvent());
@@ -43,6 +47,9 @@ void main() {
 
     mockAuthBloc = MockAuthenticationBloc();
     mockGroupBloc = MockGroupBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
 
     // Default auth bloc state
     when(() => mockAuthBloc.state).thenReturn(
@@ -79,6 +86,7 @@ void main() {
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
       ],
       child: MaterialApp(
         localizationsDelegates: const [

--- a/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
@@ -5,6 +5,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_event.dart';
@@ -15,6 +20,8 @@ import 'package:play_with_me/features/profile/presentation/pages/email_verificat
 class MockEmailVerificationBloc
     extends Mock
     implements EmailVerificationBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
+class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
 
 // Fake classes for mocktail
 class FakeEmailVerificationEvent extends Fake
@@ -25,6 +32,8 @@ class FakeEmailVerificationState extends Fake
 
 void main() {
   late MockEmailVerificationBloc mockBloc;
+  late MockInvitationBloc mockInvitationBloc;
+  late MockAuthenticationBloc mockAuthBloc;
 
   setUpAll(() {
     registerFallbackValue(FakeEmailVerificationEvent());
@@ -33,6 +42,16 @@ void main() {
 
   setUp(() {
     mockBloc = MockEmailVerificationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    mockAuthBloc = MockAuthenticationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(
+        UserEntity(uid: 'test-user', email: 'test@example.com', isEmailVerified: true, isAnonymous: false),
+      ),
+    );
+    when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
   });
 
   Widget createWidgetUnderTest() {
@@ -46,8 +65,12 @@ void main() {
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: const [Locale('en')],
-        home: BlocProvider<EmailVerificationBloc>.value(
-          value: mockBloc,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<EmailVerificationBloc>.value(value: mockBloc),
+            BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+            BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          ],
           child: const EmailVerificationPage(),
         ),
       ),

--- a/test/unit/features/profile/presentation/pages/profile_edit_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/profile_edit_page_test.dart
@@ -9,6 +9,8 @@ import 'package:play_with_me/core/domain/repositories/image_storage_repository.d
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/core/services/image_picker_service.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/domain/repositories/auth_repository.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
@@ -28,6 +30,7 @@ class MockImageStorageRepository extends Mock implements ImageStorageRepository 
 class MockImagePickerService extends Mock implements ImagePickerService {}
 class MockLocalePreferencesRepository extends Mock implements LocalePreferencesRepository {}
 class MockLocalePreferencesBloc extends Mock implements LocalePreferencesBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 // Fakes for fallback values
 class FakeLocalePreferencesEntity extends Fake implements LocalePreferencesEntity {}
@@ -38,6 +41,7 @@ void main() {
   late MockAuthRepository mockAuthRepository;
   late MockAuthenticationBloc mockAuthBloc;
   late MockLocalePreferencesBloc mockLocalePrefsBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   setUpAll(() {
     // Register fallback values for mocktail matchers
@@ -99,6 +103,9 @@ void main() {
     mockAuthRepository = MockAuthRepository();
     mockAuthBloc = MockAuthenticationBloc();
     mockLocalePrefsBloc = MockLocalePreferencesBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
 
     // Stub the locale preferences bloc with default behavior
     when(() => mockLocalePrefsBloc.state).thenReturn(
@@ -134,6 +141,7 @@ void main() {
         child: MultiBlocProvider(
           providers: [
             BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+            BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
             BlocProvider<LocalePreferencesBloc>.value(value: mockLocalePrefsBloc),
           ],
           child: ProfileEditPage(user: user),

--- a/test/unit/features/profile/presentation/pages/profile_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/profile_page_test.dart
@@ -1,4 +1,4 @@
-// Verifies that ProfilePage displays user profile information correctly using AuthenticationBloc
+// Verifies that ProfilePage displays user identity and account settings correctly
 
 import 'dart:async';
 
@@ -14,12 +14,11 @@ import 'package:play_with_me/features/profile/presentation/pages/profile_page.da
 import 'package:play_with_me/features/profile/presentation/widgets/profile_header.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/profile_info_card.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/profile_actions.dart';
+import 'package:play_with_me/features/profile/presentation/widgets/expanded_stats_section.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
 import 'package:get_it/get_it.dart';
-import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
-import '../../../../core/data/repositories/mock_user_repository.dart';
 import '../../../../core/data/repositories/mock_game_repository.dart';
 
 // Fake AuthenticationBloc for testing
@@ -48,13 +47,9 @@ class FakeAuthenticationBloc extends Fake implements AuthenticationBloc {
 
 void main() {
   setUp(() {
-    if (GetIt.I.isRegistered<UserRepository>()) {
-      GetIt.I.unregister<UserRepository>();
-    }
     if (GetIt.I.isRegistered<GameRepository>()) {
       GetIt.I.unregister<GameRepository>();
     }
-    GetIt.I.registerSingleton<UserRepository>(MockUserRepository());
     GetIt.I.registerSingleton<GameRepository>(MockGameRepository());
   });
 
@@ -75,7 +70,7 @@ void main() {
       supportedLocales: const [Locale('en')],
       home: BlocProvider<AuthenticationBloc>.value(
         value: fakeBloc,
-        child: const ProfilePage(),
+        child: const Scaffold(body: ProfilePage()),
       ),
     );
   }
@@ -97,19 +92,18 @@ void main() {
         createWidgetUnderTest(state: AuthenticationAuthenticated(testUser)),
       );
 
-      // Verify AppBar
-      expect(find.byType(AppBar), findsOneWidget);
-      expect(find.text('Profile'), findsOneWidget);
-
-      // Verify components are present
+      // Verify components are present (ProfilePage is now a tab, no own AppBar)
       expect(find.byType(ProfileHeader), findsOneWidget);
       expect(find.byType(ProfileInfoCard), findsOneWidget);
       expect(find.byType(ProfileActions), findsOneWidget);
 
       // Verify user information is displayed
       expect(find.text('Test User'), findsOneWidget);
-      // Email appears twice: once in ProfileHeader and once in ProfileInfoCard (with verification status)
+      // Email appears twice: once in ProfileHeader and once in ProfileInfoCard
       expect(find.text('test@example.com'), findsNWidgets(2));
+
+      // Verify stats are NOT shown on profile page (moved to Stats tab)
+      expect(find.byType(ExpandedStatsSection), findsNothing);
     });
 
     testWidgets('displays loading indicator when authentication is unknown', (tester) async {

--- a/test/widget/features/friends/presentation/pages/add_friend_page_test.dart
+++ b/test/widget/features/friends/presentation/pages/add_friend_page_test.dart
@@ -6,6 +6,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
@@ -23,6 +26,10 @@ class MockAuthenticationBloc
     extends MockBloc<AuthenticationEvent, AuthenticationState>
     implements AuthenticationBloc {}
 
+class MockInvitationBloc
+    extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
 class FakeFriendEvent extends Fake implements FriendEvent {}
 
 class FakeFriendState extends Fake implements FriendState {}
@@ -34,6 +41,7 @@ class FakeAuthenticationState extends Fake implements AuthenticationState {}
 void main() {
   late MockFriendBloc mockFriendBloc;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   final testUser = UserEntity(
     uid: 'test-user-123',
@@ -61,6 +69,8 @@ void main() {
   setUp(() {
     mockFriendBloc = MockFriendBloc();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
 
     when(() => mockFriendBloc.state).thenReturn(const FriendState.initial());
     when(() => mockAuthBloc.state)
@@ -85,6 +95,7 @@ void main() {
         providers: [
           BlocProvider<FriendBloc>.value(value: mockFriendBloc),
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: const AddFriendPage(),
       ),

--- a/test/widget/features/games/presentation/pages/game_creation_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_creation_page_test.dart
@@ -7,6 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -21,6 +24,10 @@ class MockGameCreationBloc
 
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
 
+class MockInvitationBloc
+    extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
 class FakeGameCreationEvent extends Fake implements GameCreationEvent {}
 
 class FakeGameCreationState extends Fake implements GameCreationState {}
@@ -28,6 +35,7 @@ class FakeGameCreationState extends Fake implements GameCreationState {}
 void main() {
   late MockGameCreationBloc mockGameCreationBloc;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   const testUserId = 'test-user-123';
   const testGroupId = 'test-group-123';
@@ -41,6 +49,8 @@ void main() {
   setUp(() {
     mockGameCreationBloc = MockGameCreationBloc();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
 
     when(() => mockGameCreationBloc.state)
         .thenReturn(const GameCreationInitial());
@@ -77,6 +87,7 @@ void main() {
         providers: [
           BlocProvider<GameCreationBloc>.value(value: mockGameCreationBloc),
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: const GameCreationPage(
           groupId: testGroupId,

--- a/test/widget/features/games/presentation/pages/game_details_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_page_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -20,11 +22,13 @@ import '../../../../../unit/core/data/repositories/mock_user_repository.dart';
 
 // Mock classes
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 void main() {
   late MockGameRepository mockGameRepository;
   late MockUserRepository mockUserRepository;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
   late GameDetailsBloc gameDetailsBloc;
 
   const testUserId = 'test-uid-123';
@@ -34,6 +38,9 @@ void main() {
     mockGameRepository = MockGameRepository();
     mockUserRepository = MockUserRepository();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
 
     // Add test users to mock repository
     mockUserRepository.addUser(TestUserData.testUser);
@@ -88,6 +95,7 @@ void main() {
       home: MultiBlocProvider(
         providers: [
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: GameDetailsPage(
           gameId: gameId,

--- a/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
@@ -9,6 +9,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
@@ -22,10 +25,14 @@ import '../../../../../unit/core/data/repositories/mock_user_repository.dart';
 class MockAuthenticationBloc extends MockBloc<AuthenticationEvent, AuthenticationState>
     implements AuthenticationBloc {}
 
+class MockInvitationBloc extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
 void main() {
   late MockGameRepository mockGameRepository;
   late MockUserRepository mockUserRepository;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
   final sl = GetIt.instance;
 
   const creatorId = 'user-creator';
@@ -44,6 +51,8 @@ void main() {
     mockGameRepository = MockGameRepository();
     mockUserRepository = MockUserRepository();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
 
     if (sl.isRegistered<GameRepository>()) {
       sl.unregister<GameRepository>();
@@ -61,16 +70,20 @@ void main() {
   });
 
   Widget createWidgetUnderTest(String gameId) {
-    return MaterialApp(
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
       ],
-      supportedLocales: const [Locale('en')],      home: BlocProvider<AuthenticationBloc>.value(
-        value: mockAuthBloc,
-        child: GameDetailsPage(
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en')],
+        home: GameDetailsPage(
           gameId: gameId,
           gameRepository: mockGameRepository,
           userRepository: mockUserRepository,

--- a/test/widget/features/games/presentation/pages/game_details_verification_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_verification_test.dart
@@ -8,6 +8,9 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
@@ -20,10 +23,14 @@ import '../../../../../unit/core/data/repositories/mock_user_repository.dart';
 class MockAuthenticationBloc extends MockBloc<AuthenticationEvent, AuthenticationState>
     implements AuthenticationBloc {}
 
+class MockInvitationBloc extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
 void main() {
   late MockGameRepository mockGameRepository;
   late MockUserRepository mockUserRepository;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
   final sl = GetIt.instance;
 
   const submitterId = 'user-1';
@@ -44,7 +51,9 @@ void main() {
     mockGameRepository = MockGameRepository();
     mockUserRepository = MockUserRepository();
     mockAuthBloc = MockAuthenticationBloc();
-    
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+
     if (sl.isRegistered<GameRepository>()) {
       sl.unregister<GameRepository>();
     }
@@ -63,8 +72,12 @@ void main() {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: const [Locale('en')],      home: BlocProvider<AuthenticationBloc>.value(
-        value: mockAuthBloc,
+      supportedLocales: const [Locale('en')],
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+        ],
         child: GameDetailsPage(
           gameId: verificationGame.id,
           gameRepository: mockGameRepository,

--- a/test/widget/features/games/presentation/pages/record_results_page_test.dart
+++ b/test/widget/features/games/presentation/pages/record_results_page_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -27,6 +29,7 @@ class MockGameRepository extends Mock implements GameRepository {}
 class MockUserRepository extends Mock implements UserRepository {}
 
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
@@ -42,6 +45,7 @@ void main() {
   late MockGameRepository mockGameRepository;
   late MockUserRepository mockUserRepository;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   const testUserId = 'test-uid-123';
   const testGameId = 'test-game-123';
@@ -76,6 +80,9 @@ void main() {
     mockGameRepository = MockGameRepository();
     mockUserRepository = MockUserRepository();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
     sl.registerSingleton<AuthenticationBloc>(mockAuthBloc);
     sl.registerSingleton<GameRepository>(mockGameRepository);
     sl.registerSingleton<UserRepository>(mockUserRepository);
@@ -93,8 +100,11 @@ void main() {
   });
 
   Widget createApp({required String gameId}) {
-    return BlocProvider<AuthenticationBloc>.value(
-      value: mockAuthBloc,
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+      ],
       child: MaterialApp(
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -146,8 +156,11 @@ void main() {
     testWidgets('can save teams when all players are assigned and navigates', (tester) async {
       final mockObserver = MockNavigatorObserver();
 
-      await tester.pumpWidget(BlocProvider<AuthenticationBloc>.value(
-        value: mockAuthBloc,
+      await tester.pumpWidget(MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+        ],
         child: MaterialApp(
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/test/widget/features/groups/presentation/pages/group_creation_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/group_creation_page_test.dart
@@ -10,6 +10,9 @@ import 'package:play_with_me/core/data/models/group_model.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_event.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_state.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
@@ -23,6 +26,10 @@ class MockAuthenticationBloc
     extends MockBloc<AuthenticationEvent, AuthenticationState>
     implements AuthenticationBloc {}
 
+class MockInvitationBloc
+    extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
 class FakeGroupEvent extends Fake implements GroupEvent {}
 
 class FakeGroupState extends Fake implements GroupState {}
@@ -30,6 +37,7 @@ class FakeGroupState extends Fake implements GroupState {}
 void main() {
   late MockGroupBloc mockGroupBloc;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   const testUserId = 'test-user-123';
 
@@ -41,6 +49,8 @@ void main() {
   setUp(() {
     mockGroupBloc = MockGroupBloc();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
 
     when(() => mockGroupBloc.state).thenReturn(const GroupInitial());
 
@@ -75,6 +85,7 @@ void main() {
         providers: [
           BlocProvider<GroupBloc>.value(value: mockGroupBloc),
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: const GroupCreationPage(),
       ),
@@ -456,6 +467,8 @@ void main() {
                             BlocProvider<GroupBloc>.value(value: mockGroupBloc),
                             BlocProvider<AuthenticationBloc>.value(
                                 value: mockAuthBloc),
+                            BlocProvider<InvitationBloc>.value(
+                                value: mockInvitationBloc),
                           ],
                           child: const GroupCreationPage(),
                         ),

--- a/test/widget/features/groups/presentation/pages/group_details_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/group_details_page_test.dart
@@ -16,6 +16,9 @@ import 'package:play_with_me/core/presentation/bloc/group_member/group_member_bl
 import 'package:play_with_me/core/presentation/bloc/group_member/group_member_event.dart';
 import 'package:play_with_me/core/presentation/bloc/group_member/group_member_state.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
@@ -29,6 +32,10 @@ class MockGroupMemberBloc
 class MockAuthenticationBloc
     extends MockBloc<AuthenticationEvent, AuthenticationState>
     implements AuthenticationBloc {}
+
+class MockInvitationBloc
+    extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
 
 class MockGroupRepository extends Mock implements GroupRepository {}
 
@@ -45,6 +52,7 @@ class FakeGroupMemberState extends Fake implements GroupMemberState {}
 void main() {
   late MockGroupMemberBloc mockGroupMemberBloc;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
   late MockGroupRepository mockGroupRepository;
   late MockUserRepository mockUserRepository;
   late MockGameRepository mockGameRepository;
@@ -99,6 +107,8 @@ void main() {
   setUp(() {
     mockGroupMemberBloc = MockGroupMemberBloc();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
     mockGroupRepository = MockGroupRepository();
     mockUserRepository = MockUserRepository();
     mockGameRepository = MockGameRepository();
@@ -167,6 +177,7 @@ void main() {
       supportedLocales: const [Locale('en')],      home: MultiBlocProvider(
         providers: [
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: GroupDetailsPage(
           groupId: testGroupId,

--- a/test/widget/features/groups/presentation/pages/invite_member_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/invite_member_page_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
 import 'package:play_with_me/core/domain/repositories/group_repository.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -18,18 +20,23 @@ class MockFriendRepository extends Mock implements FriendRepository {}
 class MockGroupRepository extends Mock implements GroupRepository {}
 class MockInvitationRepository extends Mock implements InvitationRepository {}
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 void main() {
   late MockFriendRepository mockFriendRepository;
   late MockGroupRepository mockGroupRepository;
   late MockInvitationRepository mockInvitationRepository;
   late MockAuthenticationBloc mockAuthenticationBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   setUp(() {
     mockFriendRepository = MockFriendRepository();
     mockGroupRepository = MockGroupRepository();
     mockInvitationRepository = MockInvitationRepository();
     mockAuthenticationBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
 
     // Default group data setup
     when(() => mockGroupRepository.getGroupById(any())).thenAnswer(
@@ -68,8 +75,11 @@ void main() {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [Locale('en')],
-      home: BlocProvider<AuthenticationBloc>.value(
-        value: mockAuthenticationBloc,
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthenticationBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+        ],
         child: InviteMemberPage(
           groupId: 'test-group',
           groupName: 'Test Group',

--- a/test/widget/features/invitations/presentation/pages/pending_invitations_page_test.dart
+++ b/test/widget/features/invitations/presentation/pages/pending_invitations_page_test.dart
@@ -132,7 +132,8 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pump();
 
-        expect(find.byIcon(Icons.mail_outline), findsOneWidget);
+        // mail_outline icon appears in both the AppBar (22px) and empty state (64px)
+        expect(find.byIcon(Icons.mail_outline), findsNWidgets(2));
         expect(find.text('No Pending Invitations'), findsOneWidget);
         expect(
           find.text(
@@ -441,7 +442,8 @@ void main() {
         await tester.pumpWidget(createTestWidget());
         await tester.pump();
 
-        expect(find.byIcon(Icons.mail_outline), findsOneWidget);
+        // mail_outline icon appears in both the AppBar (22px) and empty state (64px)
+        expect(find.byIcon(Icons.mail_outline), findsNWidgets(2));
       });
 
       testWidgets('displays empty state title', (tester) async {

--- a/test/widget/features/profile/presentation/pages/profile_page_stats_test.dart
+++ b/test/widget/features/profile/presentation/pages/profile_page_stats_test.dart
@@ -1,3 +1,5 @@
+// Verifies that StatsPage displays player statistics correctly using PlayerStatsBloc
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,39 +8,23 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/rating_history_entry.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/data/models/user_ranking.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
-import 'package:play_with_me/core/domain/repositories/game_repository.dart';
-import '../../../../../unit/core/data/repositories/mock_game_repository.dart';
-import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
-import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
-import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
-import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
-import 'package:play_with_me/features/profile/presentation/pages/profile_page.dart';
+import 'package:play_with_me/features/profile/presentation/pages/stats_page.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_event.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_state.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-class MockAuthenticationBloc extends MockBloc<AuthenticationEvent, AuthenticationState>
-    implements AuthenticationBloc {}
-
 class MockUserRepository extends Mock implements UserRepository {}
 
-class FakeAuthenticationState extends Fake implements AuthenticationState {}
-
 void main() {
-  late MockAuthenticationBloc mockAuthBloc;
   late MockUserRepository mockUserRepository;
   final sl = GetIt.instance;
 
   const userId = 'test-uid';
-  // UserEntity for Auth Bloc
-  const testUserEntity = UserEntity(
-    uid: userId,
-    email: 'test@example.com',
-    isEmailVerified: true,
-    isAnonymous: false,
-  );
 
-  // UserModel for Stats Bloc (via Repository)
   final testUserModel = UserModel(
     uid: userId,
     email: 'test@example.com',
@@ -64,29 +50,25 @@ void main() {
     )
   ];
 
-  setUpAll(() {
-    registerFallbackValue(FakeAuthenticationState());
-  });
-
   setUp(() {
-    mockAuthBloc = MockAuthenticationBloc();
     mockUserRepository = MockUserRepository();
 
     if (sl.isRegistered<UserRepository>()) {
       sl.unregister<UserRepository>();
     }
-    if (sl.isRegistered<GameRepository>()) {
-      sl.unregister<GameRepository>();
-    }
     sl.registerSingleton<UserRepository>(mockUserRepository);
-    sl.registerSingleton<GameRepository>(MockGameRepository());
 
-    when(() => mockAuthBloc.state).thenReturn(const AuthenticationAuthenticated(testUserEntity));
-    // Use broadcast stream to allow multiple subscriptions
     when(() => mockUserRepository.getUserStream(userId))
         .thenAnswer((_) => Stream.value(testUserModel).asBroadcastStream());
     when(() => mockUserRepository.getRatingHistory(userId))
         .thenAnswer((_) => Stream.value(testHistory).asBroadcastStream());
+    when(() => mockUserRepository.getUserRanking(userId))
+        .thenAnswer((_) async => UserRanking(
+              globalRank: 5,
+              totalUsers: 100,
+              percentile: 95.0,
+              calculatedAt: DateTime(2024, 1, 1),
+            ));
   });
 
   tearDown(() {
@@ -102,19 +84,20 @@ void main() {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [Locale('en')],
-      home: BlocProvider<AuthenticationBloc>.value(
-        value: mockAuthBloc,
-        child: const ProfilePage(),
+      home: BlocProvider<PlayerStatsBloc>(
+        create: (_) => PlayerStatsBloc(
+          userRepository: mockUserRepository,
+        )..add(LoadPlayerStats(userId)),
+        child: const Scaffold(body: StatsPage()),
       ),
     );
   }
 
-  testWidgets('ProfilePage displays PlayerStatsSection and correct stats', (tester) async {
+  testWidgets('StatsPage displays ExpandedStatsSection and correct stats', (tester) async {
     await tester.pumpWidget(createWidgetUnderTest());
-    await tester.pumpAndSettle(); // Wait for async blocs to load
+    await tester.pumpAndSettle();
 
-    // Check if section title is present
-    // New stats layout uses ExpandedStatsSection with different structure
+    // Check if Performance Overview section is present (from ExpandedStatsSection)
     expect(find.text('Performance Overview'), findsOneWidget);
 
     // Check if Current ELO is present
@@ -123,7 +106,7 @@ void main() {
 
     // Check if Win Rate is present
     expect(find.text('Win Rate'), findsOneWidget);
-    expect(find.text('60.0%'), findsOneWidget); // 6/10
+    expect(find.text('60.0%'), findsOneWidget);
 
     // Check if Games Played is present
     expect(find.text('Games Played'), findsOneWidget);

--- a/test/widget/features/profile/presentation/pages/stats_page_test.dart
+++ b/test/widget/features/profile/presentation/pages/stats_page_test.dart
@@ -1,0 +1,171 @@
+// Verifies that StatsPage renders correctly in different PlayerStatsBloc states
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/rating_history_entry.dart';
+import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/data/models/user_ranking.dart';
+import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/features/profile/presentation/pages/stats_page.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_event.dart';
+import 'package:play_with_me/features/profile/presentation/bloc/player_stats/player_stats_state.dart';
+import 'package:play_with_me/features/profile/presentation/widgets/expanded_stats_section.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockPlayerStatsBloc
+    extends MockBloc<PlayerStatsEvent, PlayerStatsState>
+    implements PlayerStatsBloc {}
+
+class MockUserRepository extends Mock implements UserRepository {}
+
+void main() {
+  late MockPlayerStatsBloc mockBloc;
+  late MockUserRepository mockUserRepository;
+  final sl = GetIt.instance;
+
+  const userId = 'test-uid';
+
+  final testUserModel = UserModel(
+    uid: userId,
+    email: 'test@example.com',
+    isEmailVerified: true,
+    isAnonymous: false,
+    eloRating: 1500,
+    gamesPlayed: 5,
+    gamesWon: 3,
+    gamesLost: 2,
+    currentStreak: 1,
+  );
+
+  final testHistory = [
+    RatingHistoryEntry(
+      entryId: 'e1',
+      gameId: 'g1',
+      oldRating: 1480,
+      newRating: 1500,
+      ratingChange: 20,
+      opponentTeam: 'Opponents',
+      won: true,
+      timestamp: DateTime.now(),
+    ),
+  ];
+
+  setUp(() {
+    mockBloc = MockPlayerStatsBloc();
+    mockUserRepository = MockUserRepository();
+
+    if (sl.isRegistered<UserRepository>()) {
+      sl.unregister<UserRepository>();
+    }
+    sl.registerSingleton<UserRepository>(mockUserRepository);
+
+    // Stub methods used by internal blocs in MomentumConsistencyCard
+    when(() => mockUserRepository.getUserStream(any()))
+        .thenAnswer((_) => Stream.value(testUserModel));
+    when(() => mockUserRepository.getRatingHistory(any(), limit: any(named: 'limit')))
+        .thenAnswer((_) => Stream.value(testHistory));
+    when(() => mockUserRepository.getRatingHistory(any()))
+        .thenAnswer((_) => Stream.value(testHistory));
+    when(() => mockUserRepository.getUserRanking(any()))
+        .thenAnswer((_) async => UserRanking(
+              globalRank: 1,
+              totalUsers: 10,
+              percentile: 90.0,
+              friendsRank: 1,
+              totalFriends: 5,
+              calculatedAt: DateTime.now(),
+            ));
+  });
+
+  tearDown(() async {
+    await mockBloc.close();
+    sl.reset();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: BlocProvider<PlayerStatsBloc>.value(
+        value: mockBloc,
+        child: const Scaffold(body: StatsPage()),
+      ),
+    );
+  }
+
+  group('StatsPage', () {
+    testWidgets('displays loading indicator when stats are loading', (tester) async {
+      whenListen(mockBloc, const Stream<PlayerStatsState>.empty(),
+          initialState: PlayerStatsLoading());
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('displays ExpandedStatsSection when stats are loaded', (tester) async {
+      final loadedState = PlayerStatsLoaded(
+        user: testUserModel,
+        history: testHistory,
+        ranking: null,
+        rankingLoadFailed: false,
+      );
+      whenListen(mockBloc, const Stream<PlayerStatsState>.empty(),
+          initialState: loadedState);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // ExpandedStatsSection should be displayed
+      expect(find.byType(ExpandedStatsSection), findsOneWidget);
+
+      // Verify Performance Overview section is present
+      expect(find.text('Performance Overview'), findsOneWidget);
+
+      // Verify Momentum & Consistency section is present
+      expect(find.text('Momentum & Consistency'), findsOneWidget);
+    });
+
+    testWidgets('displays error message when stats fail to load', (tester) async {
+      const errorState = PlayerStatsError('Network error');
+      whenListen(mockBloc, const Stream<PlayerStatsState>.empty(),
+          initialState: errorState);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.textContaining('Error loading stats'), findsOneWidget);
+    });
+
+    testWidgets('is scrollable when loaded', (tester) async {
+      final loadedState = PlayerStatsLoaded(
+        user: testUserModel,
+        history: testHistory,
+        ranking: null,
+        rankingLoadFailed: false,
+      );
+      whenListen(mockBloc, const Stream<PlayerStatsState>.empty(),
+          initialState: loadedState);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
@@ -6,6 +6,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
@@ -20,6 +23,7 @@ class MockTrainingSessionCreationBloc
     implements TrainingSessionCreationBloc {}
 
 class MockAuthenticationBloc extends Mock implements AuthenticationBloc {}
+class MockInvitationBloc extends Mock implements InvitationBloc {}
 
 class FakeTrainingSessionCreationEvent extends Fake
     implements TrainingSessionCreationEvent {}
@@ -30,6 +34,7 @@ class FakeTrainingSessionCreationState extends Fake
 void main() {
   late MockTrainingSessionCreationBloc mockCreationBloc;
   late MockAuthenticationBloc mockAuthBloc;
+  late MockInvitationBloc mockInvitationBloc;
 
   const testUserId = 'test-user-123';
   const testGroupId = 'test-group-123';
@@ -43,6 +48,9 @@ void main() {
   setUp(() {
     mockCreationBloc = MockTrainingSessionCreationBloc();
     mockAuthBloc = MockAuthenticationBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockInvitationBloc.stream).thenAnswer((_) => const Stream.empty());
 
     when(() => mockCreationBloc.state)
         .thenReturn(const TrainingSessionCreationInitial());
@@ -81,6 +89,7 @@ void main() {
           BlocProvider<TrainingSessionCreationBloc>.value(
               value: mockCreationBloc),
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
         ],
         child: const TrainingSessionCreationPage(
           groupId: testGroupId,

--- a/test/widget/features/training/presentation/pages/training_session_feedback_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_feedback_page_test.dart
@@ -6,6 +6,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
+import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_bloc.dart';
 import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_event.dart';
 import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_state.dart';
@@ -16,12 +23,22 @@ class MockTrainingFeedbackBloc
     extends MockBloc<TrainingFeedbackEvent, TrainingFeedbackState>
     implements TrainingFeedbackBloc {}
 
+class MockInvitationBloc
+    extends MockBloc<InvitationEvent, InvitationState>
+    implements InvitationBloc {}
+
+class MockAuthenticationBloc
+    extends MockBloc<AuthenticationEvent, AuthenticationState>
+    implements AuthenticationBloc {}
+
 class FakeTrainingFeedbackEvent extends Fake implements TrainingFeedbackEvent {}
 
 class FakeTrainingFeedbackState extends Fake implements TrainingFeedbackState {}
 
 void main() {
   late MockTrainingFeedbackBloc mockFeedbackBloc;
+  late MockInvitationBloc mockInvitationBloc;
+  late MockAuthenticationBloc mockAuthBloc;
 
   const testSessionId = 'test-session-123';
   const testSessionTitle = 'Morning Beach Drills';
@@ -33,6 +50,14 @@ void main() {
 
   setUp(() {
     mockFeedbackBloc = MockTrainingFeedbackBloc();
+    mockInvitationBloc = MockInvitationBloc();
+    mockAuthBloc = MockAuthenticationBloc();
+    when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockAuthBloc.state).thenReturn(
+      AuthenticationAuthenticated(
+        UserEntity(uid: 'test-user', email: 'test@example.com', isEmailVerified: true, isAnonymous: false),
+      ),
+    );
 
     when(() => mockFeedbackBloc.state).thenReturn(const FeedbackInitial());
   });
@@ -50,8 +75,12 @@ void main() {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: const [Locale('en')],
-      home: BlocProvider<TrainingFeedbackBloc>.value(
-        value: mockFeedbackBloc,
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<TrainingFeedbackBloc>.value(value: mockFeedbackBloc),
+          BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+          BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+        ],
         child: const TrainingSessionFeedbackPage(
           trainingSessionId: testSessionId,
           sessionTitle: testSessionTitle,


### PR DESCRIPTION
## Summary
- **Profile moved to AppBar**: Profile icon, Invitations badge, and Logout icon now appear in the AppBar on all authenticated pages
- **Stats tab added**: Extracted player stats into a dedicated `StatsPage` on the bottom navigation bar (4 tabs: Home, Stats, Groups, Community)
- **Self-contained AppBar**: Refactored `PlayWithMeAppBar` to internally manage InvitationBloc and AuthenticationBloc — no callbacks needed from pages
- **Groups icon updated**: Changed from `Icons.group` to `Icons.group_work` for visual distinction from Community's `Icons.people`
- **24 test files updated**: Added `MockInvitationBloc` and `MockAuthenticationBloc` to all widget/unit tests that render pages with the AppBar

## Test plan
- [x] All 3030+ unit/widget tests pass (0 failures)
- [x] `flutter analyze` reports 0 errors
- [x] AppBar icons (Invitations, Profile, Logout) appear on all authenticated pages
- [x] Auth pages (login, register, password_reset) correctly hide user action icons
- [x] Bottom nav has 4 tabs: Home, Stats, Groups, Community
- [x] Localization strings added for all 5 languages (EN, FR, DE, ES, IT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)