### PR TITLE
fix(friends): resilient parallel loading prevents Android ExecutionException

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- Fixes #454: "Error loading friends" with `ExecutionException` on Android when accessing group page
- **Root Cause 1 (primary):** Missing `com.google.gms.google-services` Gradle plugin — `google-services.json` files existed per flavor but were never processed, so native Firebase Installations Service couldn't obtain auth tokens
- **Root Cause 2 (resilience):** `Future.wait` in `FriendBloc._onLoadRequested()` discards all results when any single call fails — replaced with per-call error isolation

## Changes

| File | Change |
|------|--------|
| `android/settings.gradle.kts` | Added `com.google.gms.google-services` plugin declaration |
| `android/app/build.gradle.kts` | Applied `com.google.gms.google-services` plugin |
| `lib/features/friends/presentation/bloc/friend_bloc.dart` | Replaced `Future.wait` with `_safeCall` helper for resilient per-call error handling; removed `print` debug statements |
| `test/unit/features/friends/presentation/bloc/friend_bloc_test.dart` | Added 5 new partial failure tests, updated existing error test |

## Why two fixes?

The **Gradle plugin** is the primary fix — without it, Firebase Installations Service fails on Android, causing `ExecutionException` on all Cloud Function calls. However, the **resilient loading** is still necessary as a defense-in-depth measure: even with proper Firebase setup, individual Cloud Function calls can still fail due to cold starts, transient network issues, or rate limiting. The `_safeCall` approach ensures partial data is preserved rather than losing everything.

## Test plan
- [x] getFriends throws → loaded with empty friends, pending requests preserved
- [x] getPendingRequests(received) throws → friends and sent requests preserved
- [x] getPendingRequests(sent) throws → friends and received requests preserved
- [x] All three calls fail → loaded with empty lists (graceful degradation)
- [x] getFriends succeeds, both pending requests fail → friends preserved
- [x] All 3037 existing tests pass (0 failures)
- [x] `flutter analyze` passes with 0 new issues
- [x] Gradle configuration validates (`BUILD SUCCESSFUL`)