### PR TITLE
fix(games): enforce time and minimum players checks for result entry

### DIFF
--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -231,23 +231,23 @@ class GameModel with _$GameModel {
 
   /// Check if user can enter/record results for the game
   /// Allows participants (or creator) to enter results if the game is ready
-  /// (completed, in-progress, or past scheduled time)
+  /// (completed, in-progress, or past scheduled time) and has enough players
   bool canUserEnterResults(String userId) {
     final isParticipant = isPlayer(userId) || isCreator(userId);
     final hasExistingResult = result != null;
     final isCancelled = status == GameStatus.cancelled;
     final isVerification = status == GameStatus.verification;
-    
-    final isReady = status == GameStatus.completed || 
-                    status == GameStatus.inProgress || 
-                    isPast || 
-                    isCreator(userId);
 
-    return isParticipant && 
-           !isCancelled && 
-           !isVerification && 
-           !hasExistingResult && 
-           isReady;
+    final isReady = status == GameStatus.completed ||
+                    status == GameStatus.inProgress ||
+                    isPast;
+
+    return isParticipant &&
+           !isCancelled &&
+           !isVerification &&
+           !hasExistingResult &&
+           isReady &&
+           hasMinimumPlayers;
   }
 
   /// Validation methods

--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -711,6 +711,22 @@ class FirestoreGameRepository implements GameRepository {
               code: 'invalid-state');
         }
 
+        // Check if game has passed its scheduled time
+        if (!currentGame.isPast &&
+            currentGame.status != GameStatus.completed &&
+            currentGame.status != GameStatus.inProgress) {
+          throw GameException(
+              'Cannot save result before the scheduled game time',
+              code: 'failed-precondition');
+        }
+
+        // Check if game has minimum required players
+        if (!currentGame.hasMinimumPlayers) {
+          throw GameException(
+              'Cannot save result without the minimum number of players (${currentGame.minPlayers} required, ${currentGame.currentPlayerCount} joined)',
+              code: 'failed-precondition');
+        }
+
         // Validate teams
         if (teams.hasPlayerOnBothTeams()) {
           throw GameException('A player cannot be on both teams',


### PR DESCRIPTION
## Summary

- Fixes two validation gaps in `GameModel.canUserEnterResults()` that allowed game results to be entered prematurely or without enough players
- Removes the creator bypass that let game creators enter results before the scheduled time
- Adds `hasMinimumPlayers` check so games with insufficient players cannot have results entered
- Adds server-side validation in `FirestoreGameRepository.saveGameResult()` for defense-in-depth

## Root Cause

**Problem 1: Creator time bypass** — The `isReady` condition included `isCreator(userId)` as a separate OR branch, which meant creators could always enter results regardless of whether the game had started.

**Problem 2: Missing minimum players check** — `canUserEnterResults()` never validated `hasMinimumPlayers`, allowing results for games with fewer players than `minPlayers` (e.g., 1 player joined but 4 required).

## Changes

| File | Change |
|------|--------|
| `lib/core/data/models/game_model.dart` | Removed `isCreator` from `isReady`, added `hasMinimumPlayers` check |
| `lib/core/data/repositories/firestore_game_repository.dart` | Added time and minimum players validation in `saveGameResult()` |
| `test/unit/core/data/models/game_model_test.dart` | Updated 5 existing tests, added 5 new tests for new validation |
| `test/widget/.../game_details_result_entry_test.dart` | Updated 1 test, added 3 new widget tests |

## Test Plan

- [x] Participant can enter results when game is completed with enough players
- [x] Creator can enter results when game is past with enough players
- [x] Creator CANNOT enter results when game is future (time check enforced)
- [x] No one can enter results when game has insufficient players
- [x] No one can enter results when game has zero players
- [x] In-progress games with enough players still allow result entry
- [x] Non-participants cannot enter results even when game is ready
- [x] Cancelled, verification, and already-entered-result states still blocked
- [x] Widget tests confirm button visibility matches new validation logic
- [x] All 3061 existing tests pass (0 regressions), 3 pre-existing skips

Closes #298