### PR TITLE
Story 17.1: Design the Firestore Schema for Invites

### DIFF
--- a/docs/architecture/INVITE_SCHEMA.md
+++ b/docs/architecture/INVITE_SCHEMA.md
@@ -1,0 +1,161 @@
+# Invite Schema — Firestore Data Design
+
+**Epic:** 17 — Invite-Based Onboarding & Deep Link Group Join
+**Story:** 17.1 — Design the Firestore Schema for Invites
+
+---
+
+## Overview
+
+This document describes the Firestore data model for **group invite links**. The schema supports:
+
+- Shareable invite links with secure tokens
+- Optional expiration timestamps
+- Manual revocation
+- Optional usage limits
+- Efficient O(1) token lookup via a secondary collection
+
+---
+
+## Collections
+
+### 1. Primary: `groups/{groupId}/invites/{inviteId}`
+
+Stores invite metadata as a subcollection of the group it belongs to.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `inviteId` | `string` | Yes | auto-generated | Document ID |
+| `token` | `string` | Yes | — | Secure random string (URL-safe, 32+ chars) |
+| `createdBy` | `string` | Yes | — | User ID of the invite creator |
+| `createdAt` | `timestamp` | Yes | — | Server timestamp when invite was created |
+| `expiresAt` | `timestamp` | No | `null` | Expiration timestamp (`null` = never expires) |
+| `revoked` | `boolean` | Yes | `false` | Whether the invite has been manually revoked |
+| `usageLimit` | `int` | No | `null` | Maximum number of uses (`null` = unlimited) |
+| `usageCount` | `int` | Yes | `0` | Number of times the invite has been used |
+| `groupId` | `string` | Yes | — | Redundant group ID for cross-reference safety |
+| `inviteType` | `string` | Yes | `"group_link"` | Type discriminator for future invite types |
+
+### 2. Token Lookup: `invite_tokens/{token}`
+
+Enables O(1) token lookup without scanning all groups' invite subcollections.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `groupId` | `string` | The group this token belongs to |
+| `inviteId` | `string` | The invite document ID |
+| `createdAt` | `timestamp` | When the token was created |
+| `active` | `boolean` | Quick check if token is still valid |
+
+---
+
+## Design Decisions
+
+### Subcollection vs Root Collection
+
+Using `groups/{groupId}/invites/` keeps invites scoped to their group:
+
+- Efficient group-level queries (list all invites for a group)
+- Natural security rule inheritance (group membership check)
+- Avoids a single large root collection
+
+### Token Lookup Collection
+
+The `invite_tokens/` root collection is necessary because deep link resolution receives only the token — not the group ID. Without this secondary collection, resolving a token would require scanning every group's invites subcollection.
+
+### Atomic Writes
+
+Both `invite_tokens/{token}` and `groups/{groupId}/invites/{inviteId}` must be written atomically (batch write or transaction) during invite creation to prevent orphaned records.
+
+### Token Format
+
+Tokens use `crypto.randomBytes(24).toString('base64url')` producing 32 URL-safe characters with 192 bits of entropy. This prevents brute-force guessing while remaining compact for URLs.
+
+---
+
+## Firestore Security Rules
+
+```javascript
+// Invite documents: only group members can read, only Cloud Functions can write
+match /groups/{groupId}/invites/{inviteId} {
+  allow read: if request.auth != null &&
+    request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberIds;
+  allow write: if false; // Only via Cloud Functions (Admin SDK)
+}
+
+// Token lookup: authenticated users can read, only Cloud Functions can write
+match /invite_tokens/{token} {
+  allow read: if request.auth != null;
+  allow write: if false; // Only via Cloud Functions (Admin SDK)
+}
+```
+
+**Rationale:**
+
+- **Invites read** — restricted to group members so non-members cannot enumerate active invites.
+- **Invites write** — all mutations go through Cloud Functions for validation, idempotency, and atomic writes.
+- **Token read** — any authenticated user can resolve a token (needed for deep link join flow).
+- **Token write** — Cloud Functions only, ensures tokens are created atomically with their invite document.
+
+---
+
+## Required Indexes
+
+| Collection | Fields | Order | Purpose |
+|-----------|--------|-------|---------|
+| `groups/{groupId}/invites` | `createdBy`, `createdAt` | ASC, DESC | List a user's created invites |
+| `groups/{groupId}/invites` | `revoked`, `createdAt` | ASC, DESC | List active (non-revoked) invites |
+
+---
+
+## Flutter Data Model
+
+```dart
+@freezed
+class GroupInviteLinkModel with _$GroupInviteLinkModel {
+  const factory GroupInviteLinkModel({
+    required String id,
+    required String token,
+    required String createdBy,
+    @RequiredTimestampConverter() required DateTime createdAt,
+    @TimestampConverter() DateTime? expiresAt,
+    @Default(false) bool revoked,
+    int? usageLimit,
+    @Default(0) int usageCount,
+    required String groupId,
+    @Default('group_link') String inviteType,
+  }) = _GroupInviteLinkModel;
+}
+```
+
+### Business Logic Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `isExpired` | `bool` | `true` if `expiresAt` is non-null and in the past |
+| `isRevoked` | `bool` | `true` if `revoked == true` |
+| `isUsageLimitReached` | `bool` | `true` if `usageCount >= usageLimit` |
+| `isActive` | `bool` | `true` if not expired, not revoked, and limit not reached |
+| `remainingUses` | `int?` | `usageLimit - usageCount`, or `null` if unlimited |
+
+---
+
+## File Structure
+
+```
+lib/core/data/models/group_invite_link_model.dart           # Freezed model + Firestore conversion
+lib/core/data/models/group_invite_link_model.freezed.dart    # Generated
+lib/core/data/models/group_invite_link_model.g.dart          # Generated
+firestore.rules                                              # Security rules (updated)
+docs/architecture/INVITE_SCHEMA.md                           # This document
+```
+
+---
+
+## Architectural Compliance
+
+- Belongs to the **Groups layer** only
+- No dependency on Games or Social Graph (MyCommunity)
+- All write operations go through **Cloud Functions** (Admin SDK)
+- Security rules enforce read-only client access
+- Designed for millions of invites (scalable subcollection pattern)

--- a/firestore.rules
+++ b/firestore.rules
@@ -165,6 +165,28 @@ service cloud.firestore {
       // Only admins can delete groups
       allow delete: if isAuthenticated() &&
                        request.auth.uid in resource.data.adminIds;
+
+      // ============================================
+      // Group Invite Links (Epic 17 — Story 17.1)
+      // ============================================
+
+      // Invite documents: only group members can read, only Cloud Functions can write
+      match /invites/{inviteId} {
+        allow read: if isAuthenticated() &&
+                       request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberIds;
+        allow write: if false; // Only via Cloud Functions (Admin SDK)
+      }
+    }
+
+    // ============================================
+    // Invite Token Lookup (Epic 17 — Story 17.1)
+    // ============================================
+
+    // Token lookup: authenticated users can read (for deep link resolution),
+    // only Cloud Functions can write
+    match /invite_tokens/{token} {
+      allow read: if isAuthenticated();
+      allow write: if false; // Only via Cloud Functions (Admin SDK)
     }
 
     // ============================================

--- a/lib/core/data/models/group_invite_link_model.dart
+++ b/lib/core/data/models/group_invite_link_model.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:play_with_me/core/data/models/friendship_model.dart';
+
+part 'group_invite_link_model.freezed.dart';
+part 'group_invite_link_model.g.dart';
+
+/// Data model for group invite links stored in Firestore.
+///
+/// Supports expiration, revocation, and optional usage limits.
+///
+/// Firestore collection: /groups/{groupId}/invites/{inviteId}
+/// Token lookup collection: /invite_tokens/{token}
+@freezed
+class GroupInviteLinkModel with _$GroupInviteLinkModel {
+  const factory GroupInviteLinkModel({
+    required String id,
+    required String token,
+    required String createdBy,
+    @RequiredTimestampConverter() required DateTime createdAt,
+    @TimestampConverter() DateTime? expiresAt,
+    @Default(false) bool revoked,
+    int? usageLimit,
+    @Default(0) int usageCount,
+    required String groupId,
+    @Default('group_link') String inviteType,
+  }) = _GroupInviteLinkModel;
+
+  const GroupInviteLinkModel._();
+
+  factory GroupInviteLinkModel.fromJson(Map<String, dynamic> json) =>
+      _$GroupInviteLinkModelFromJson(json);
+
+  /// Factory constructor for creating from Firestore DocumentSnapshot
+  factory GroupInviteLinkModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return GroupInviteLinkModel.fromJson({
+      ...data,
+      'id': doc.id,
+    });
+  }
+
+  /// Convert to Firestore-compatible map (excludes id since it's the document ID)
+  Map<String, dynamic> toFirestore() {
+    final json = toJson();
+    json.remove('id');
+    return json;
+  }
+
+  /// Whether the invite has expired based on expiresAt timestamp
+  bool get isExpired => expiresAt != null && expiresAt!.isBefore(DateTime.now());
+
+  /// Whether the invite has been manually revoked
+  bool get isRevoked => revoked;
+
+  /// Whether the usage limit has been reached
+  bool get isUsageLimitReached =>
+      usageLimit != null && usageCount >= usageLimit!;
+
+  /// Whether the invite is currently active (not expired, not revoked, not at limit)
+  bool get isActive => !isExpired && !isRevoked && !isUsageLimitReached;
+
+  /// Number of remaining uses, or null if unlimited
+  int? get remainingUses =>
+      usageLimit != null ? usageLimit! - usageCount : null;
+}

--- a/lib/core/data/models/group_invite_link_model.freezed.dart
+++ b/lib/core/data/models/group_invite_link_model.freezed.dart
@@ -1,0 +1,394 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'group_invite_link_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+GroupInviteLinkModel _$GroupInviteLinkModelFromJson(Map<String, dynamic> json) {
+  return _GroupInviteLinkModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GroupInviteLinkModel {
+  String get id => throw _privateConstructorUsedError;
+  String get token => throw _privateConstructorUsedError;
+  String get createdBy => throw _privateConstructorUsedError;
+  @RequiredTimestampConverter()
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get expiresAt => throw _privateConstructorUsedError;
+  bool get revoked => throw _privateConstructorUsedError;
+  int? get usageLimit => throw _privateConstructorUsedError;
+  int get usageCount => throw _privateConstructorUsedError;
+  String get groupId => throw _privateConstructorUsedError;
+  String get inviteType => throw _privateConstructorUsedError;
+
+  /// Serializes this GroupInviteLinkModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of GroupInviteLinkModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $GroupInviteLinkModelCopyWith<GroupInviteLinkModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GroupInviteLinkModelCopyWith<$Res> {
+  factory $GroupInviteLinkModelCopyWith(
+    GroupInviteLinkModel value,
+    $Res Function(GroupInviteLinkModel) then,
+  ) = _$GroupInviteLinkModelCopyWithImpl<$Res, GroupInviteLinkModel>;
+  @useResult
+  $Res call({
+    String id,
+    String token,
+    String createdBy,
+    @RequiredTimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? expiresAt,
+    bool revoked,
+    int? usageLimit,
+    int usageCount,
+    String groupId,
+    String inviteType,
+  });
+}
+
+/// @nodoc
+class _$GroupInviteLinkModelCopyWithImpl<
+  $Res,
+  $Val extends GroupInviteLinkModel
+>
+    implements $GroupInviteLinkModelCopyWith<$Res> {
+  _$GroupInviteLinkModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GroupInviteLinkModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? token = null,
+    Object? createdBy = null,
+    Object? createdAt = null,
+    Object? expiresAt = freezed,
+    Object? revoked = null,
+    Object? usageLimit = freezed,
+    Object? usageCount = null,
+    Object? groupId = null,
+    Object? inviteType = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            token: null == token
+                ? _value.token
+                : token // ignore: cast_nullable_to_non_nullable
+                      as String,
+            createdBy: null == createdBy
+                ? _value.createdBy
+                : createdBy // ignore: cast_nullable_to_non_nullable
+                      as String,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            expiresAt: freezed == expiresAt
+                ? _value.expiresAt
+                : expiresAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            revoked: null == revoked
+                ? _value.revoked
+                : revoked // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            usageLimit: freezed == usageLimit
+                ? _value.usageLimit
+                : usageLimit // ignore: cast_nullable_to_non_nullable
+                      as int?,
+            usageCount: null == usageCount
+                ? _value.usageCount
+                : usageCount // ignore: cast_nullable_to_non_nullable
+                      as int,
+            groupId: null == groupId
+                ? _value.groupId
+                : groupId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            inviteType: null == inviteType
+                ? _value.inviteType
+                : inviteType // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$GroupInviteLinkModelImplCopyWith<$Res>
+    implements $GroupInviteLinkModelCopyWith<$Res> {
+  factory _$$GroupInviteLinkModelImplCopyWith(
+    _$GroupInviteLinkModelImpl value,
+    $Res Function(_$GroupInviteLinkModelImpl) then,
+  ) = __$$GroupInviteLinkModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String token,
+    String createdBy,
+    @RequiredTimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? expiresAt,
+    bool revoked,
+    int? usageLimit,
+    int usageCount,
+    String groupId,
+    String inviteType,
+  });
+}
+
+/// @nodoc
+class __$$GroupInviteLinkModelImplCopyWithImpl<$Res>
+    extends _$GroupInviteLinkModelCopyWithImpl<$Res, _$GroupInviteLinkModelImpl>
+    implements _$$GroupInviteLinkModelImplCopyWith<$Res> {
+  __$$GroupInviteLinkModelImplCopyWithImpl(
+    _$GroupInviteLinkModelImpl _value,
+    $Res Function(_$GroupInviteLinkModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GroupInviteLinkModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? token = null,
+    Object? createdBy = null,
+    Object? createdAt = null,
+    Object? expiresAt = freezed,
+    Object? revoked = null,
+    Object? usageLimit = freezed,
+    Object? usageCount = null,
+    Object? groupId = null,
+    Object? inviteType = null,
+  }) {
+    return _then(
+      _$GroupInviteLinkModelImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        token: null == token
+            ? _value.token
+            : token // ignore: cast_nullable_to_non_nullable
+                  as String,
+        createdBy: null == createdBy
+            ? _value.createdBy
+            : createdBy // ignore: cast_nullable_to_non_nullable
+                  as String,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        expiresAt: freezed == expiresAt
+            ? _value.expiresAt
+            : expiresAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        revoked: null == revoked
+            ? _value.revoked
+            : revoked // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        usageLimit: freezed == usageLimit
+            ? _value.usageLimit
+            : usageLimit // ignore: cast_nullable_to_non_nullable
+                  as int?,
+        usageCount: null == usageCount
+            ? _value.usageCount
+            : usageCount // ignore: cast_nullable_to_non_nullable
+                  as int,
+        groupId: null == groupId
+            ? _value.groupId
+            : groupId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        inviteType: null == inviteType
+            ? _value.inviteType
+            : inviteType // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GroupInviteLinkModelImpl extends _GroupInviteLinkModel {
+  const _$GroupInviteLinkModelImpl({
+    required this.id,
+    required this.token,
+    required this.createdBy,
+    @RequiredTimestampConverter() required this.createdAt,
+    @TimestampConverter() this.expiresAt,
+    this.revoked = false,
+    this.usageLimit,
+    this.usageCount = 0,
+    required this.groupId,
+    this.inviteType = 'group_link',
+  }) : super._();
+
+  factory _$GroupInviteLinkModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GroupInviteLinkModelImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String token;
+  @override
+  final String createdBy;
+  @override
+  @RequiredTimestampConverter()
+  final DateTime createdAt;
+  @override
+  @TimestampConverter()
+  final DateTime? expiresAt;
+  @override
+  @JsonKey()
+  final bool revoked;
+  @override
+  final int? usageLimit;
+  @override
+  @JsonKey()
+  final int usageCount;
+  @override
+  final String groupId;
+  @override
+  @JsonKey()
+  final String inviteType;
+
+  @override
+  String toString() {
+    return 'GroupInviteLinkModel(id: $id, token: $token, createdBy: $createdBy, createdAt: $createdAt, expiresAt: $expiresAt, revoked: $revoked, usageLimit: $usageLimit, usageCount: $usageCount, groupId: $groupId, inviteType: $inviteType)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GroupInviteLinkModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.createdBy, createdBy) ||
+                other.createdBy == createdBy) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.expiresAt, expiresAt) ||
+                other.expiresAt == expiresAt) &&
+            (identical(other.revoked, revoked) || other.revoked == revoked) &&
+            (identical(other.usageLimit, usageLimit) ||
+                other.usageLimit == usageLimit) &&
+            (identical(other.usageCount, usageCount) ||
+                other.usageCount == usageCount) &&
+            (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.inviteType, inviteType) ||
+                other.inviteType == inviteType));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    token,
+    createdBy,
+    createdAt,
+    expiresAt,
+    revoked,
+    usageLimit,
+    usageCount,
+    groupId,
+    inviteType,
+  );
+
+  /// Create a copy of GroupInviteLinkModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GroupInviteLinkModelImplCopyWith<_$GroupInviteLinkModelImpl>
+  get copyWith =>
+      __$$GroupInviteLinkModelImplCopyWithImpl<_$GroupInviteLinkModelImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GroupInviteLinkModelImplToJson(this);
+  }
+}
+
+abstract class _GroupInviteLinkModel extends GroupInviteLinkModel {
+  const factory _GroupInviteLinkModel({
+    required final String id,
+    required final String token,
+    required final String createdBy,
+    @RequiredTimestampConverter() required final DateTime createdAt,
+    @TimestampConverter() final DateTime? expiresAt,
+    final bool revoked,
+    final int? usageLimit,
+    final int usageCount,
+    required final String groupId,
+    final String inviteType,
+  }) = _$GroupInviteLinkModelImpl;
+  const _GroupInviteLinkModel._() : super._();
+
+  factory _GroupInviteLinkModel.fromJson(Map<String, dynamic> json) =
+      _$GroupInviteLinkModelImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get token;
+  @override
+  String get createdBy;
+  @override
+  @RequiredTimestampConverter()
+  DateTime get createdAt;
+  @override
+  @TimestampConverter()
+  DateTime? get expiresAt;
+  @override
+  bool get revoked;
+  @override
+  int? get usageLimit;
+  @override
+  int get usageCount;
+  @override
+  String get groupId;
+  @override
+  String get inviteType;
+
+  /// Create a copy of GroupInviteLinkModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GroupInviteLinkModelImplCopyWith<_$GroupInviteLinkModelImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/core/data/models/group_invite_link_model.g.dart
+++ b/lib/core/data/models/group_invite_link_model.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'group_invite_link_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GroupInviteLinkModelImpl _$$GroupInviteLinkModelImplFromJson(
+  Map<String, dynamic> json,
+) => _$GroupInviteLinkModelImpl(
+  id: json['id'] as String,
+  token: json['token'] as String,
+  createdBy: json['createdBy'] as String,
+  createdAt: const RequiredTimestampConverter().fromJson(json['createdAt']),
+  expiresAt: const TimestampConverter().fromJson(json['expiresAt']),
+  revoked: json['revoked'] as bool? ?? false,
+  usageLimit: (json['usageLimit'] as num?)?.toInt(),
+  usageCount: (json['usageCount'] as num?)?.toInt() ?? 0,
+  groupId: json['groupId'] as String,
+  inviteType: json['inviteType'] as String? ?? 'group_link',
+);
+
+Map<String, dynamic> _$$GroupInviteLinkModelImplToJson(
+  _$GroupInviteLinkModelImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'token': instance.token,
+  'createdBy': instance.createdBy,
+  'createdAt': const RequiredTimestampConverter().toJson(instance.createdAt),
+  'expiresAt': const TimestampConverter().toJson(instance.expiresAt),
+  'revoked': instance.revoked,
+  'usageLimit': instance.usageLimit,
+  'usageCount': instance.usageCount,
+  'groupId': instance.groupId,
+  'inviteType': instance.inviteType,
+};

--- a/test/unit/core/data/models/group_invite_link_model_test.dart
+++ b/test/unit/core/data/models/group_invite_link_model_test.dart
@@ -1,0 +1,601 @@
+// Tests GroupInviteLinkModel serialization, business logic, and Firestore conversion.
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/group_invite_link_model.dart';
+
+void main() {
+  group('GroupInviteLinkModel', () {
+    final testCreatedAt = DateTime(2025, 6, 15, 10, 30);
+    final testExpiresAt = DateTime(2025, 7, 15, 10, 30);
+
+    GroupInviteLinkModel createTestInvite({
+      String id = 'invite-123',
+      String token = 'abc123def456ghi789jkl012mno345pq',
+      String createdBy = 'user-789',
+      DateTime? createdAt,
+      DateTime? expiresAt,
+      bool revoked = false,
+      int? usageLimit,
+      int usageCount = 0,
+      String groupId = 'group-456',
+      String inviteType = 'group_link',
+    }) {
+      return GroupInviteLinkModel(
+        id: id,
+        token: token,
+        createdBy: createdBy,
+        createdAt: createdAt ?? testCreatedAt,
+        expiresAt: expiresAt,
+        revoked: revoked,
+        usageLimit: usageLimit,
+        usageCount: usageCount,
+        groupId: groupId,
+        inviteType: inviteType,
+      );
+    }
+
+    group('constructor', () {
+      test('creates instance with required fields only', () {
+        final invite = GroupInviteLinkModel(
+          id: 'invite-123',
+          token: 'abc123def456ghi789jkl012mno345pq',
+          createdBy: 'user-789',
+          createdAt: testCreatedAt,
+          groupId: 'group-456',
+        );
+
+        expect(invite.id, 'invite-123');
+        expect(invite.token, 'abc123def456ghi789jkl012mno345pq');
+        expect(invite.createdBy, 'user-789');
+        expect(invite.createdAt, testCreatedAt);
+        expect(invite.groupId, 'group-456');
+      });
+
+      test('defaults revoked to false', () {
+        final invite = createTestInvite();
+        expect(invite.revoked, isFalse);
+      });
+
+      test('defaults usageCount to 0', () {
+        final invite = createTestInvite();
+        expect(invite.usageCount, 0);
+      });
+
+      test('defaults inviteType to group_link', () {
+        final invite = createTestInvite();
+        expect(invite.inviteType, 'group_link');
+      });
+
+      test('defaults expiresAt to null', () {
+        final invite = createTestInvite();
+        expect(invite.expiresAt, isNull);
+      });
+
+      test('defaults usageLimit to null', () {
+        final invite = createTestInvite();
+        expect(invite.usageLimit, isNull);
+      });
+
+      test('creates instance with all fields including optional', () {
+        final invite = createTestInvite(
+          expiresAt: testExpiresAt,
+          revoked: true,
+          usageLimit: 10,
+          usageCount: 5,
+        );
+
+        expect(invite.expiresAt, testExpiresAt);
+        expect(invite.revoked, isTrue);
+        expect(invite.usageLimit, 10);
+        expect(invite.usageCount, 5);
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes JSON with Timestamp for createdAt', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'revoked': false,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.id, 'invite-123');
+        expect(invite.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with int timestamp for createdAt', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': testCreatedAt.millisecondsSinceEpoch,
+          'revoked': false,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with ISO string for createdAt', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': testCreatedAt.toIso8601String(),
+          'revoked': false,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.createdAt, testCreatedAt);
+      });
+
+      test('deserializes JSON with expiresAt Timestamp when present', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'expiresAt': Timestamp.fromDate(testExpiresAt),
+          'revoked': false,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.expiresAt, testExpiresAt);
+      });
+
+      test('deserializes JSON with null expiresAt', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'expiresAt': null,
+          'revoked': false,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.expiresAt, isNull);
+      });
+
+      test('deserializes JSON with usageLimit when present', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'revoked': false,
+          'usageLimit': 50,
+          'usageCount': 10,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.usageLimit, 50);
+        expect(invite.usageCount, 10);
+      });
+
+      test('deserializes JSON with null usageLimit', () {
+        final json = {
+          'id': 'invite-123',
+          'token': 'abc123def456ghi789jkl012mno345pq',
+          'createdBy': 'user-789',
+          'createdAt': Timestamp.fromDate(testCreatedAt),
+          'revoked': false,
+          'usageLimit': null,
+          'usageCount': 0,
+          'groupId': 'group-456',
+          'inviteType': 'group_link',
+        };
+
+        final invite = GroupInviteLinkModel.fromJson(json);
+
+        expect(invite.usageLimit, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all fields to JSON', () {
+        final invite = createTestInvite(
+          expiresAt: testExpiresAt,
+          usageLimit: 10,
+          usageCount: 3,
+        );
+
+        final json = invite.toJson();
+
+        expect(json['id'], 'invite-123');
+        expect(json['token'], 'abc123def456ghi789jkl012mno345pq');
+        expect(json['createdBy'], 'user-789');
+        expect(json['revoked'], false);
+        expect(json['usageLimit'], 10);
+        expect(json['usageCount'], 3);
+        expect(json['groupId'], 'group-456');
+        expect(json['inviteType'], 'group_link');
+      });
+
+      test('converts createdAt to Timestamp', () {
+        final invite = createTestInvite();
+
+        final json = invite.toJson();
+
+        expect(json['createdAt'], isA<Timestamp>());
+        expect((json['createdAt'] as Timestamp).toDate(), testCreatedAt);
+      });
+
+      test('converts expiresAt to Timestamp when present', () {
+        final invite = createTestInvite(expiresAt: testExpiresAt);
+
+        final json = invite.toJson();
+
+        expect(json['expiresAt'], isA<Timestamp>());
+        expect((json['expiresAt'] as Timestamp).toDate(), testExpiresAt);
+      });
+
+      test('expiresAt is null when not set', () {
+        final invite = createTestInvite();
+
+        final json = invite.toJson();
+
+        expect(json['expiresAt'], isNull);
+      });
+
+      test('usageLimit is null when not set', () {
+        final invite = createTestInvite();
+
+        final json = invite.toJson();
+
+        expect(json['usageLimit'], isNull);
+      });
+    });
+
+    group('toFirestore', () {
+      test('excludes id from Firestore data', () {
+        final invite = createTestInvite();
+
+        final firestoreData = invite.toFirestore();
+
+        expect(firestoreData.containsKey('id'), isFalse);
+      });
+
+      test('includes all other fields', () {
+        final invite = createTestInvite(
+          expiresAt: testExpiresAt,
+          usageLimit: 10,
+          usageCount: 3,
+        );
+
+        final firestoreData = invite.toFirestore();
+
+        expect(firestoreData['token'], 'abc123def456ghi789jkl012mno345pq');
+        expect(firestoreData['createdBy'], 'user-789');
+        expect(firestoreData['revoked'], false);
+        expect(firestoreData['usageLimit'], 10);
+        expect(firestoreData['usageCount'], 3);
+        expect(firestoreData['groupId'], 'group-456');
+        expect(firestoreData['inviteType'], 'group_link');
+        expect(firestoreData['createdAt'], isA<Timestamp>());
+        expect(firestoreData['expiresAt'], isA<Timestamp>());
+      });
+
+      test('converts DateTime fields to Timestamp', () {
+        final invite = createTestInvite(expiresAt: testExpiresAt);
+
+        final firestoreData = invite.toFirestore();
+
+        expect(firestoreData['createdAt'], isA<Timestamp>());
+        expect(firestoreData['expiresAt'], isA<Timestamp>());
+        expect(
+          (firestoreData['createdAt'] as Timestamp).toDate(),
+          testCreatedAt,
+        );
+        expect(
+          (firestoreData['expiresAt'] as Timestamp).toDate(),
+          testExpiresAt,
+        );
+      });
+    });
+
+    group('isExpired', () {
+      test('returns false when expiresAt is null', () {
+        final invite = createTestInvite(expiresAt: null);
+
+        expect(invite.isExpired, isFalse);
+      });
+
+      test('returns false when expiresAt is in the future', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().add(const Duration(days: 7)),
+        );
+
+        expect(invite.isExpired, isFalse);
+      });
+
+      test('returns true when expiresAt is in the past', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().subtract(const Duration(days: 1)),
+        );
+
+        expect(invite.isExpired, isTrue);
+      });
+    });
+
+    group('isRevoked', () {
+      test('returns false when revoked is false', () {
+        final invite = createTestInvite(revoked: false);
+
+        expect(invite.isRevoked, isFalse);
+      });
+
+      test('returns true when revoked is true', () {
+        final invite = createTestInvite(revoked: true);
+
+        expect(invite.isRevoked, isTrue);
+      });
+    });
+
+    group('isUsageLimitReached', () {
+      test('returns false when usageLimit is null (unlimited)', () {
+        final invite = createTestInvite(usageLimit: null, usageCount: 100);
+
+        expect(invite.isUsageLimitReached, isFalse);
+      });
+
+      test('returns false when usageCount is below usageLimit', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 5);
+
+        expect(invite.isUsageLimitReached, isFalse);
+      });
+
+      test('returns true when usageCount equals usageLimit', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 10);
+
+        expect(invite.isUsageLimitReached, isTrue);
+      });
+
+      test('returns true when usageCount exceeds usageLimit', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 15);
+
+        expect(invite.isUsageLimitReached, isTrue);
+      });
+    });
+
+    group('isActive', () {
+      test('returns true when not expired, not revoked, and limit not reached',
+          () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().add(const Duration(days: 7)),
+          revoked: false,
+          usageLimit: 10,
+          usageCount: 3,
+        );
+
+        expect(invite.isActive, isTrue);
+      });
+
+      test('returns true when no expiration and no usage limit', () {
+        final invite = createTestInvite(
+          expiresAt: null,
+          revoked: false,
+          usageLimit: null,
+          usageCount: 100,
+        );
+
+        expect(invite.isActive, isTrue);
+      });
+
+      test('returns false when expired', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().subtract(const Duration(days: 1)),
+          revoked: false,
+          usageLimit: null,
+        );
+
+        expect(invite.isActive, isFalse);
+      });
+
+      test('returns false when revoked', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().add(const Duration(days: 7)),
+          revoked: true,
+          usageLimit: null,
+        );
+
+        expect(invite.isActive, isFalse);
+      });
+
+      test('returns false when usage limit reached', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().add(const Duration(days: 7)),
+          revoked: false,
+          usageLimit: 5,
+          usageCount: 5,
+        );
+
+        expect(invite.isActive, isFalse);
+      });
+
+      test('returns false when expired and revoked and limit reached', () {
+        final invite = createTestInvite(
+          expiresAt: DateTime.now().subtract(const Duration(days: 1)),
+          revoked: true,
+          usageLimit: 5,
+          usageCount: 5,
+        );
+
+        expect(invite.isActive, isFalse);
+      });
+    });
+
+    group('remainingUses', () {
+      test('returns null when usageLimit is null (unlimited)', () {
+        final invite = createTestInvite(usageLimit: null, usageCount: 100);
+
+        expect(invite.remainingUses, isNull);
+      });
+
+      test('returns correct remaining count', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 3);
+
+        expect(invite.remainingUses, 7);
+      });
+
+      test('returns 0 when limit reached', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 10);
+
+        expect(invite.remainingUses, 0);
+      });
+
+      test('returns negative when count exceeds limit', () {
+        final invite = createTestInvite(usageLimit: 10, usageCount: 12);
+
+        expect(invite.remainingUses, -2);
+      });
+
+      test('returns full limit when usageCount is 0', () {
+        final invite = createTestInvite(usageLimit: 25, usageCount: 0);
+
+        expect(invite.remainingUses, 25);
+      });
+    });
+
+    group('copyWith', () {
+      test('creates copy with updated token', () {
+        final invite = createTestInvite();
+
+        final copy = invite.copyWith(token: 'new-token-value');
+
+        expect(copy.token, 'new-token-value');
+        expect(copy.id, invite.id);
+        expect(copy.groupId, invite.groupId);
+      });
+
+      test('creates copy with updated revoked status', () {
+        final invite = createTestInvite(revoked: false);
+
+        final copy = invite.copyWith(revoked: true);
+
+        expect(copy.revoked, isTrue);
+        expect(copy.id, invite.id);
+      });
+
+      test('creates copy with updated usageCount', () {
+        final invite = createTestInvite(usageCount: 5);
+
+        final copy = invite.copyWith(usageCount: 6);
+
+        expect(copy.usageCount, 6);
+        expect(copy.usageLimit, invite.usageLimit);
+      });
+
+      test('creates copy with multiple fields updated', () {
+        final invite = createTestInvite();
+
+        final copy = invite.copyWith(
+          revoked: true,
+          usageCount: 10,
+          expiresAt: testExpiresAt,
+        );
+
+        expect(copy.revoked, isTrue);
+        expect(copy.usageCount, 10);
+        expect(copy.expiresAt, testExpiresAt);
+        expect(copy.id, invite.id);
+        expect(copy.token, invite.token);
+        expect(copy.groupId, invite.groupId);
+      });
+    });
+
+    group('equality', () {
+      test('two invites with same data are equal', () {
+        final invite1 = createTestInvite();
+        final invite2 = createTestInvite();
+
+        expect(invite1, invite2);
+        expect(invite1.hashCode, invite2.hashCode);
+      });
+
+      test('two invites with different id are not equal', () {
+        final invite1 = createTestInvite(id: 'invite-1');
+        final invite2 = createTestInvite(id: 'invite-2');
+
+        expect(invite1, isNot(invite2));
+      });
+
+      test('two invites with different token are not equal', () {
+        final invite1 = createTestInvite(token: 'token-aaa');
+        final invite2 = createTestInvite(token: 'token-bbb');
+
+        expect(invite1, isNot(invite2));
+      });
+
+      test('two invites with different revoked status are not equal', () {
+        final invite1 = createTestInvite(revoked: false);
+        final invite2 = createTestInvite(revoked: true);
+
+        expect(invite1, isNot(invite2));
+      });
+
+      test('two invites with different usageCount are not equal', () {
+        final invite1 = createTestInvite(usageCount: 0);
+        final invite2 = createTestInvite(usageCount: 5);
+
+        expect(invite1, isNot(invite2));
+      });
+    });
+
+    group('JSON round trip', () {
+      test('toJson then fromJson preserves all fields', () {
+        final original = createTestInvite(
+          expiresAt: testExpiresAt,
+          revoked: true,
+          usageLimit: 50,
+          usageCount: 25,
+        );
+
+        final json = original.toJson();
+        final restored = GroupInviteLinkModel.fromJson(json);
+
+        expect(restored, original);
+      });
+
+      test('toJson then fromJson preserves null optional fields', () {
+        final original = createTestInvite(
+          expiresAt: null,
+          usageLimit: null,
+        );
+
+        final json = original.toJson();
+        final restored = GroupInviteLinkModel.fromJson(json);
+
+        expect(restored.expiresAt, isNull);
+        expect(restored.usageLimit, isNull);
+        expect(restored, original);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `GroupInviteLinkModel` (Freezed) with support for token-based invite links, expiration, revocation, and usage limits
- Add Firestore security rules for `groups/{groupId}/invites/{inviteId}` subcollection and `invite_tokens/{token}` root collection
- Add schema documentation in `docs/architecture/INVITE_SCHEMA.md` covering collections, indexes, security rules, and design decisions
- Add 53 unit tests covering serialization, Firestore conversion, business logic methods, equality, and JSON round-trips

## Details

### Firestore Collections

| Collection | Purpose |
|-----------|---------|
| `groups/{groupId}/invites/{inviteId}` | Invite metadata scoped to group (read: group members, write: Cloud Functions only) |
| `invite_tokens/{token}` | O(1) token lookup for deep link resolution (read: authenticated users, write: Cloud Functions only) |

### Data Model Fields

`token`, `createdBy`, `createdAt`, `expiresAt` (nullable), `revoked`, `usageLimit` (nullable), `usageCount`, `groupId`, `inviteType`

### Business Logic

`isExpired`, `isRevoked`, `isUsageLimitReached`, `isActive`, `remainingUses`

### Architectural Compliance

- Groups layer only (no Games or Social Graph dependency)
- All write operations via Cloud Functions (Admin SDK)
- Security rules enforce read-only client access

Closes #463

## Test plan

- [x] 53 unit tests for `GroupInviteLinkModel` covering:
  - Constructor with required and optional fields
  - JSON deserialization (Timestamp, int, ISO string formats)
  - JSON serialization with Timestamp conversion
  - `toFirestore()` excludes `id` field
  - Business logic: `isExpired`, `isRevoked`, `isUsageLimitReached`, `isActive`, `remainingUses`
  - `copyWith` immutability
  - Equality and hashCode
  - JSON round-trip preservation
- [x] `flutter analyze` passes with 0 new warnings
- [x] Full unit test suite (2390 tests) passes with no regressions