### PR TITLE
Story 17.3: Implement Cloud Functions for Invite System

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -96,3 +96,11 @@ export {
 // Export scheduled functions for game auto-abort
 export {autoAbortGames} from "./autoAbortGames";
 
+// Epic 17: Invite-Based Onboarding (Story 17.3)
+export {
+  createGroupInvite,
+  validateInviteToken,
+  joinGroupViaInvite,
+  revokeGroupInvite,
+} from "./invites";
+

--- a/functions/src/invites/createGroupInvite.ts
+++ b/functions/src/invites/createGroupInvite.ts
@@ -1,0 +1,207 @@
+// Cloud Function for creating group invite links
+// Epic 17 — Story 17.3
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import * as crypto from "crypto";
+import {
+  CreateGroupInviteRequest,
+  CreateGroupInviteResponse,
+  GroupData,
+} from "./types";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const BASE_URL = "https://playwithme.app/invite";
+
+// ============================================================================
+// Cloud Function Handler
+// ============================================================================
+
+/**
+ * Generate a new shareable invite link for a group.
+ *
+ * @param {CreateGroupInviteRequest} data - The request data.
+ * @param {functions.https.CallableContext} context - The callable context.
+ * @return {Promise<CreateGroupInviteResponse>} The invite response.
+ */
+export async function createGroupInviteHandler(
+  data: CreateGroupInviteRequest,
+  context: functions.https.CallableContext
+): Promise<CreateGroupInviteResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to create an invite link."
+    );
+  }
+
+  const uid = context.auth.uid;
+
+  // 2. Validate input parameters
+  if (!data || typeof data.groupId !== "string" || !data.groupId.trim()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'groupId' is required and must be a non-empty string."
+    );
+  }
+
+  if (
+    data.expiresInHours !== undefined &&
+    data.expiresInHours !== null &&
+    (typeof data.expiresInHours !== "number" || data.expiresInHours <= 0)
+  ) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'expiresInHours' must be a positive number."
+    );
+  }
+
+  if (
+    data.usageLimit !== undefined &&
+    data.usageLimit !== null &&
+    (typeof data.usageLimit !== "number" ||
+      data.usageLimit <= 0 ||
+      !Number.isInteger(data.usageLimit))
+  ) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'usageLimit' must be a positive integer."
+    );
+  }
+
+  const {groupId} = data;
+
+  functions.logger.info("[createGroupInvite] Creating invite", {
+    uid,
+    groupId,
+    expiresInHours: data.expiresInHours ?? "never",
+    usageLimit: data.usageLimit ?? "unlimited",
+  });
+
+  try {
+    const db = admin.firestore();
+
+    // 3. Fetch group document
+    const groupDoc = await db.collection("groups").doc(groupId).get();
+    if (!groupDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The group does not exist."
+      );
+    }
+
+    const groupData = groupDoc.data() as GroupData;
+
+    // 4. Validate user is a member
+    if (!groupData.memberIds.includes(uid)) {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You must be a member of the group to create an invite link."
+      );
+    }
+
+    // 5. Validate invite permission
+    const isAdmin =
+      (groupData.adminIds || []).includes(uid) ||
+      groupData.createdBy === uid;
+
+    if (!groupData.allowMembersToInviteOthers && !isAdmin) {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You do not have permission to create invite links for this group."
+      );
+    }
+
+    // 6. Validate group is not at capacity
+    if (groupData.memberIds.length >= groupData.maxMembers) {
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This group is at capacity and cannot accept new members."
+      );
+    }
+
+    // 7. Generate secure random token (32 chars, URL-safe base64)
+    const token = crypto.randomBytes(24).toString("base64url");
+
+    // 8. Calculate expiresAt
+    let expiresAt: Date | null = null;
+    if (data.expiresInHours) {
+      expiresAt = new Date(
+        Date.now() + data.expiresInHours * 60 * 60 * 1000
+      );
+    }
+
+    // 9. Atomic batch write: invite doc + token lookup
+    const inviteRef = db
+      .collection("groups")
+      .doc(groupId)
+      .collection("invites")
+      .doc();
+    const inviteId = inviteRef.id;
+    const tokenRef = db.collection("invite_tokens").doc(token);
+
+    const batch = db.batch();
+
+    batch.set(inviteRef, {
+      token,
+      createdBy: uid,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      expiresAt: expiresAt ?
+        admin.firestore.Timestamp.fromDate(expiresAt) :
+        null,
+      revoked: false,
+      usageLimit: data.usageLimit ?? null,
+      usageCount: 0,
+      groupId,
+      inviteType: "group_link",
+    });
+
+    batch.set(tokenRef, {
+      groupId,
+      inviteId,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      active: true,
+    });
+
+    await batch.commit();
+
+    // 10. Construct deep link URL
+    const deepLinkUrl = `${BASE_URL}/${token}`;
+
+    functions.logger.info("[createGroupInvite] Invite created", {
+      uid,
+      groupId,
+      inviteId,
+      tokenPrefix: token.substring(0, 8) + "...",
+    });
+
+    return {
+      success: true,
+      inviteId,
+      token,
+      deepLinkUrl,
+      expiresAt: expiresAt ? expiresAt.toISOString() : null,
+    };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[createGroupInvite] Error", {
+      uid,
+      groupId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to create invite link. Please try again later."
+    );
+  }
+}
+
+export const createGroupInvite = functions.https.onCall(
+  createGroupInviteHandler
+);

--- a/functions/src/invites/index.ts
+++ b/functions/src/invites/index.ts
@@ -1,0 +1,7 @@
+// Epic 17: Invite-Based Onboarding — Cloud Functions exports
+// Story 17.3
+
+export {createGroupInvite} from "./createGroupInvite";
+export {validateInviteToken} from "./validateInviteToken";
+export {joinGroupViaInvite} from "./joinGroupViaInvite";
+export {revokeGroupInvite} from "./revokeGroupInvite";

--- a/functions/src/invites/joinGroupViaInvite.ts
+++ b/functions/src/invites/joinGroupViaInvite.ts
@@ -1,0 +1,206 @@
+// Cloud Function for joining a group via invite token
+// Epic 17 — Story 17.3
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import {
+  JoinGroupViaInviteRequest,
+  JoinGroupViaInviteResponse,
+  TokenLookupData,
+  InviteData,
+  GroupData,
+} from "./types";
+
+// ============================================================================
+// Cloud Function Handler
+// ============================================================================
+
+/**
+ * Join the authenticated user to the group associated with the invite token.
+ * Uses a Firestore transaction for atomicity and race condition prevention.
+ *
+ * @param {JoinGroupViaInviteRequest} data - The request data.
+ * @param {functions.https.CallableContext} context - The callable context.
+ * @return {Promise<JoinGroupViaInviteResponse>} The join response.
+ */
+export async function joinGroupViaInviteHandler(
+  data: JoinGroupViaInviteRequest,
+  context: functions.https.CallableContext
+): Promise<JoinGroupViaInviteResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to join a group."
+    );
+  }
+
+  const uid = context.auth.uid;
+
+  // 2. Validate token input
+  if (!data || typeof data.token !== "string" || !data.token.trim()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'token' is required and must be a non-empty string."
+    );
+  }
+
+  const {token} = data;
+
+  functions.logger.info("[joinGroupViaInvite] Join attempt", {
+    uid,
+    tokenPrefix: token.substring(0, 8) + "...",
+  });
+
+  try {
+    const db = admin.firestore();
+
+    // Look up token first (outside transaction for the ref)
+    const tokenRef = db.collection("invite_tokens").doc(token);
+    const tokenDoc = await tokenRef.get();
+
+    if (!tokenDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "This invite link does not exist."
+      );
+    }
+
+    const tokenData = tokenDoc.data() as TokenLookupData;
+
+    if (!tokenData.active) {
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This invite link is no longer active."
+      );
+    }
+
+    const inviteRef = db
+      .collection("groups")
+      .doc(tokenData.groupId)
+      .collection("invites")
+      .doc(tokenData.inviteId);
+    const groupRef = db.collection("groups").doc(tokenData.groupId);
+
+    let alreadyMember = false;
+    let groupName = "";
+
+    // 3. Run Firestore transaction
+    await db.runTransaction(async (transaction) => {
+      // Reads must come before writes in transactions
+      const inviteDoc = await transaction.get(inviteRef);
+      const groupDoc = await transaction.get(groupRef);
+
+      // Validate invite exists
+      if (!inviteDoc.exists) {
+        throw new functions.https.HttpsError(
+          "not-found",
+          "This invite link does not exist."
+        );
+      }
+
+      const inviteData = inviteDoc.data() as InviteData;
+
+      // Validate invite not revoked
+      if (inviteData.revoked) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "This invite link has been revoked."
+        );
+      }
+
+      // Validate invite not expired
+      if (inviteData.expiresAt) {
+        const expiresAtDate = inviteData.expiresAt.toDate();
+        if (expiresAtDate <= new Date()) {
+          throw new functions.https.HttpsError(
+            "failed-precondition",
+            "This invite link has expired."
+          );
+        }
+      }
+
+      // Validate usage limit not reached
+      if (
+        inviteData.usageLimit !== null &&
+        inviteData.usageCount >= inviteData.usageLimit
+      ) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "This invite link has reached its usage limit."
+        );
+      }
+
+      // Validate group exists
+      if (!groupDoc.exists) {
+        throw new functions.https.HttpsError(
+          "not-found",
+          "The group associated with this invite no longer exists."
+        );
+      }
+
+      const groupData = groupDoc.data() as GroupData;
+      groupName = groupData.name;
+
+      // Check if user is already a member (idempotent no-op)
+      if (groupData.memberIds.includes(uid)) {
+        alreadyMember = true;
+        return; // No writes needed
+      }
+
+      // Check group capacity
+      if (groupData.memberIds.length >= groupData.maxMembers) {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "This group is at capacity and cannot accept new members."
+        );
+      }
+
+      // Transaction writes
+      transaction.update(groupRef, {
+        memberIds: admin.firestore.FieldValue.arrayUnion(uid),
+        lastActivity: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      transaction.update(inviteRef, {
+        usageCount: admin.firestore.FieldValue.increment(1),
+      });
+    });
+
+    if (alreadyMember) {
+      functions.logger.info("[joinGroupViaInvite] User already member", {
+        uid,
+        groupId: tokenData.groupId,
+      });
+    } else {
+      functions.logger.info("[joinGroupViaInvite] User joined group", {
+        uid,
+        groupId: tokenData.groupId,
+        inviteId: tokenData.inviteId,
+      });
+    }
+
+    return {
+      success: true,
+      groupId: tokenData.groupId,
+      groupName,
+      alreadyMember,
+    };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[joinGroupViaInvite] Error", {
+      uid,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to join group. Please try again later."
+    );
+  }
+}
+
+export const joinGroupViaInvite = functions.https.onCall(
+  joinGroupViaInviteHandler
+);

--- a/functions/src/invites/revokeGroupInvite.ts
+++ b/functions/src/invites/revokeGroupInvite.ts
@@ -1,0 +1,149 @@
+// Cloud Function for revoking group invite links
+// Epic 17 — Story 17.3
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import {
+  RevokeGroupInviteRequest,
+  RevokeGroupInviteResponse,
+  InviteData,
+  GroupData,
+} from "./types";
+
+// ============================================================================
+// Cloud Function Handler
+// ============================================================================
+
+/**
+ * Revoke an existing invite link so it can no longer be used.
+ *
+ * @param {RevokeGroupInviteRequest} data - The request data.
+ * @param {functions.https.CallableContext} context - The callable context.
+ * @return {Promise<RevokeGroupInviteResponse>} The revoke response.
+ */
+export async function revokeGroupInviteHandler(
+  data: RevokeGroupInviteRequest,
+  context: functions.https.CallableContext
+): Promise<RevokeGroupInviteResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to revoke an invite link."
+    );
+  }
+
+  const uid = context.auth.uid;
+
+  // 2. Validate input parameters
+  if (!data || typeof data.groupId !== "string" || !data.groupId.trim()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'groupId' is required and must be a non-empty string."
+    );
+  }
+
+  if (typeof data.inviteId !== "string" || !data.inviteId.trim()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'inviteId' is required and must be a non-empty string."
+    );
+  }
+
+  const {groupId, inviteId} = data;
+
+  functions.logger.info("[revokeGroupInvite] Revoking invite", {
+    uid,
+    groupId,
+    inviteId,
+  });
+
+  try {
+    const db = admin.firestore();
+
+    // 3. Fetch invite document
+    const inviteRef = db
+      .collection("groups")
+      .doc(groupId)
+      .collection("invites")
+      .doc(inviteId);
+    const inviteDoc = await inviteRef.get();
+
+    if (!inviteDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The invite does not exist."
+      );
+    }
+
+    const inviteData = inviteDoc.data() as InviteData;
+
+    // 4. Check if already revoked
+    if (inviteData.revoked) {
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "This invite is already revoked."
+      );
+    }
+
+    // 5. Fetch group document to check permissions
+    const groupDoc = await db.collection("groups").doc(groupId).get();
+    if (!groupDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The group does not exist."
+      );
+    }
+
+    const groupData = groupDoc.data() as GroupData;
+
+    // 6. Validate permission: admin, creator, or invite creator
+    const isGroupAdmin =
+      (groupData.adminIds || []).includes(uid) ||
+      groupData.createdBy === uid;
+    const isInviteCreator = inviteData.createdBy === uid;
+
+    if (!isGroupAdmin && !isInviteCreator) {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You do not have permission to revoke this invite."
+      );
+    }
+
+    // 7. Batch write: revoke invite + deactivate token
+    const tokenRef = db.collection("invite_tokens").doc(inviteData.token);
+    const batch = db.batch();
+
+    batch.update(inviteRef, {revoked: true});
+    batch.update(tokenRef, {active: false});
+
+    await batch.commit();
+
+    functions.logger.info("[revokeGroupInvite] Invite revoked", {
+      uid,
+      groupId,
+      inviteId,
+      tokenPrefix: inviteData.token.substring(0, 8) + "...",
+    });
+
+    return {success: true};
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[revokeGroupInvite] Error", {
+      uid,
+      groupId,
+      inviteId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to revoke invite link. Please try again later."
+    );
+  }
+}
+
+export const revokeGroupInvite = functions.https.onCall(
+  revokeGroupInviteHandler
+);

--- a/functions/src/invites/types.ts
+++ b/functions/src/invites/types.ts
@@ -1,0 +1,104 @@
+// Shared TypeScript interfaces for invite system Cloud Functions
+// Epic 17 — Story 17.3
+
+// ============================================================================
+// createGroupInvite
+// ============================================================================
+
+export interface CreateGroupInviteRequest {
+  groupId: string;
+  expiresInHours?: number;
+  usageLimit?: number;
+}
+
+export interface CreateGroupInviteResponse {
+  success: boolean;
+  inviteId: string;
+  token: string;
+  deepLinkUrl: string;
+  expiresAt: string | null;
+}
+
+// ============================================================================
+// validateInviteToken
+// ============================================================================
+
+export interface ValidateInviteTokenRequest {
+  token: string;
+}
+
+export interface ValidateInviteTokenResponse {
+  valid: boolean;
+  groupId: string;
+  groupName: string;
+  groupDescription?: string;
+  groupPhotoUrl?: string;
+  groupMemberCount: number;
+  inviterName: string;
+  inviterPhotoUrl?: string;
+  expiresAt: string | null;
+  remainingUses: number | null;
+}
+
+// ============================================================================
+// joinGroupViaInvite
+// ============================================================================
+
+export interface JoinGroupViaInviteRequest {
+  token: string;
+}
+
+export interface JoinGroupViaInviteResponse {
+  success: boolean;
+  groupId: string;
+  groupName: string;
+  alreadyMember: boolean;
+}
+
+// ============================================================================
+// revokeGroupInvite
+// ============================================================================
+
+export interface RevokeGroupInviteRequest {
+  groupId: string;
+  inviteId: string;
+}
+
+export interface RevokeGroupInviteResponse {
+  success: boolean;
+}
+
+// ============================================================================
+// Shared internal types
+// ============================================================================
+
+export interface TokenLookupData {
+  groupId: string;
+  inviteId: string;
+  createdAt: FirebaseFirestore.Timestamp;
+  active: boolean;
+}
+
+export interface InviteData {
+  token: string;
+  createdBy: string;
+  createdAt: FirebaseFirestore.Timestamp;
+  expiresAt: FirebaseFirestore.Timestamp | null;
+  revoked: boolean;
+  usageLimit: number | null;
+  usageCount: number;
+  groupId: string;
+  inviteType: string;
+}
+
+export interface GroupData {
+  name: string;
+  description?: string;
+  photoUrl?: string;
+  createdBy: string;
+  memberIds: string[];
+  adminIds: string[];
+  maxMembers: number;
+  allowMembersToInviteOthers: boolean;
+  lastActivity?: FirebaseFirestore.Timestamp;
+}

--- a/functions/src/invites/validateInviteToken.ts
+++ b/functions/src/invites/validateInviteToken.ts
@@ -1,0 +1,222 @@
+// Cloud Function for validating invite tokens
+// Epic 17 — Story 17.3
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import {
+  ValidateInviteTokenRequest,
+  ValidateInviteTokenResponse,
+  TokenLookupData,
+  InviteData,
+  GroupData,
+} from "./types";
+
+// ============================================================================
+// Cloud Function Handler
+// ============================================================================
+
+/**
+ * Validate an invite token and return group information for the pre-join screen.
+ *
+ * @param {ValidateInviteTokenRequest} data - The request data.
+ * @param {functions.https.CallableContext} context - The callable context.
+ * @return {Promise<ValidateInviteTokenResponse>} The validation response.
+ */
+export async function validateInviteTokenHandler(
+  data: ValidateInviteTokenRequest,
+  context: functions.https.CallableContext
+): Promise<ValidateInviteTokenResponse> {
+  // 1. Authentication check
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to validate an invite link."
+    );
+  }
+
+  const uid = context.auth.uid;
+
+  // 2. Validate token input
+  if (!data || typeof data.token !== "string" || !data.token.trim()) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'token' is required and must be a non-empty string."
+    );
+  }
+
+  const {token} = data;
+
+  functions.logger.info("[validateInviteToken] Validating token", {
+    uid,
+    tokenPrefix: token.substring(0, 8) + "...",
+  });
+
+  try {
+    const db = admin.firestore();
+
+    // 3. Fetch token lookup document
+    const tokenDoc = await db.collection("invite_tokens").doc(token).get();
+    if (!tokenDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "This invite link does not exist."
+      );
+    }
+
+    const tokenData = tokenDoc.data() as TokenLookupData;
+
+    // 4. Check token is active
+    if (!tokenData.active) {
+      functions.logger.warn("[validateInviteToken] Token inactive", {
+        uid,
+        reason: "inactive",
+      });
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This invite link is no longer active."
+      );
+    }
+
+    // 5. Fetch invite document
+    const inviteDoc = await db
+      .collection("groups")
+      .doc(tokenData.groupId)
+      .collection("invites")
+      .doc(tokenData.inviteId)
+      .get();
+
+    if (!inviteDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "This invite link does not exist."
+      );
+    }
+
+    const inviteData = inviteDoc.data() as InviteData;
+
+    // 6. Validate invite is not revoked
+    if (inviteData.revoked) {
+      functions.logger.warn("[validateInviteToken] Token invalid", {
+        uid,
+        reason: "revoked",
+      });
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This invite link has been revoked."
+      );
+    }
+
+    // 7. Validate invite is not expired
+    if (inviteData.expiresAt) {
+      const expiresAtDate = inviteData.expiresAt.toDate();
+      if (expiresAtDate <= new Date()) {
+        functions.logger.warn("[validateInviteToken] Token invalid", {
+          uid,
+          reason: "expired",
+        });
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "This invite link has expired."
+        );
+      }
+    }
+
+    // 8. Validate usage limit not reached
+    if (
+      inviteData.usageLimit !== null &&
+      inviteData.usageCount >= inviteData.usageLimit
+    ) {
+      functions.logger.warn("[validateInviteToken] Token invalid", {
+        uid,
+        reason: "usage_limit_reached",
+      });
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "This invite link has reached its usage limit."
+      );
+    }
+
+    // 9. Fetch group document
+    const groupDoc = await db
+      .collection("groups")
+      .doc(tokenData.groupId)
+      .get();
+
+    if (!groupDoc.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        "The group associated with this invite no longer exists."
+      );
+    }
+
+    const groupData = groupDoc.data() as GroupData;
+
+    // 10. Fetch inviter profile
+    const inviterDoc = await db
+      .collection("users")
+      .doc(inviteData.createdBy)
+      .get();
+
+    let inviterName = "Unknown";
+    let inviterPhotoUrl: string | undefined;
+
+    if (inviterDoc.exists) {
+      const inviterData = inviterDoc.data()!;
+      inviterName =
+        inviterData.displayName || inviterData.email || "Unknown";
+      inviterPhotoUrl = inviterData.photoUrl || undefined;
+    }
+
+    // 11. Calculate remaining uses
+    const remainingUses =
+      inviteData.usageLimit !== null ?
+        inviteData.usageLimit - inviteData.usageCount :
+        null;
+
+    functions.logger.info("[validateInviteToken] Token valid", {
+      uid,
+      groupId: tokenData.groupId,
+      inviteId: tokenData.inviteId,
+    });
+
+    const response: ValidateInviteTokenResponse = {
+      valid: true,
+      groupId: tokenData.groupId,
+      groupName: groupData.name,
+      groupMemberCount: groupData.memberIds.length,
+      inviterName,
+      expiresAt: inviteData.expiresAt ?
+        inviteData.expiresAt.toDate().toISOString() :
+        null,
+      remainingUses,
+    };
+
+    if (groupData.description) {
+      response.groupDescription = groupData.description;
+    }
+    if (groupData.photoUrl) {
+      response.groupPhotoUrl = groupData.photoUrl;
+    }
+    if (inviterPhotoUrl) {
+      response.inviterPhotoUrl = inviterPhotoUrl;
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[validateInviteToken] Error", {
+      uid,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to validate invite link. Please try again later."
+    );
+  }
+}
+
+export const validateInviteToken = functions.https.onCall(
+  validateInviteTokenHandler
+);

--- a/functions/test/unit/invites/createGroupInvite.test.ts
+++ b/functions/test/unit/invites/createGroupInvite.test.ts
@@ -1,0 +1,358 @@
+// Unit tests for createGroupInvite Cloud Function
+// Epic 17 — Story 17.3
+
+import * as admin from "firebase-admin";
+import {createGroupInviteHandler} from "../../../src/invites/createGroupInvite";
+
+// Mock crypto
+jest.mock("crypto", () => ({
+  randomBytes: jest.fn(() => ({
+    toString: jest.fn(() => "mocktoken12345678901234567890ab"),
+  })),
+}));
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({})),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+        Timestamp: {
+          fromDate: jest.fn((date: Date) => ({toDate: () => date})),
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "HttpsError";
+      }
+    },
+    onCall: jest.fn((handler) => handler),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("createGroupInvite Cloud Function", () => {
+  let mockDb: any;
+  let mockBatch: any;
+  let mockGroupDoc: any;
+  let mockInviteRef: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockBatch = {
+      set: jest.fn(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockInviteRef = {
+      id: "invite-abc123",
+    };
+
+    mockGroupDoc = {
+      exists: true,
+      data: () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "user789"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: true,
+      }),
+    };
+
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+              collection: jest.fn(() => ({
+                doc: jest.fn(() => mockInviteRef),
+              })),
+            })),
+          };
+        }
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => ({})),
+          };
+        }
+        return {};
+      }),
+      batch: jest.fn(() => mockBatch),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  describe("Authentication", () => {
+    it("should throw unauthenticated error if user is not logged in", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: null} as any
+        )
+      ).rejects.toThrow("You must be logged in to create an invite link.");
+    });
+  });
+
+  describe("Input Validation", () => {
+    it("should throw invalid-argument if groupId is missing", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {} as any,
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'groupId' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if groupId is empty string", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "  "},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'groupId' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if expiresInHours is not positive", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123", expiresInHours: -5},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'expiresInHours' must be a positive number."
+      );
+    });
+
+    it("should throw invalid-argument if expiresInHours is zero", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123", expiresInHours: 0},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'expiresInHours' must be a positive number."
+      );
+    });
+
+    it("should throw invalid-argument if usageLimit is not a positive integer", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123", usageLimit: 2.5},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'usageLimit' must be a positive integer."
+      );
+    });
+
+    it("should throw invalid-argument if usageLimit is zero", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123", usageLimit: 0},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'usageLimit' must be a positive integer."
+      );
+    });
+  });
+
+  describe("Group Validation", () => {
+    it("should throw not-found if group does not exist", async () => {
+      mockGroupDoc.exists = false;
+
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow("The group does not exist.");
+    });
+
+    it("should throw permission-denied if user is not a member", async () => {
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: {uid: "outsider999"}} as any
+        )
+      ).rejects.toThrow(
+        "You must be a member of the group to create an invite link."
+      );
+    });
+
+    it("should throw permission-denied if member cannot invite and is not admin", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "user789"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: false,
+      });
+
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: {uid: "user789"}} as any
+        )
+      ).rejects.toThrow(
+        "You do not have permission to create invite links for this group."
+      );
+    });
+
+    it("should allow admin to invite even if allowMembersToInviteOthers is false", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "user789"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: false,
+      });
+
+      const result = await createGroupInviteHandler(
+        {groupId: "group123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should throw failed-precondition if group is at capacity", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "user789"],
+        adminIds: ["creator123"],
+        maxMembers: 2,
+        allowMembersToInviteOthers: true,
+      });
+
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "This group is at capacity and cannot accept new members."
+      );
+    });
+  });
+
+  describe("Successful Invite Creation", () => {
+    it("should create invite and return correct response", async () => {
+      const result = await createGroupInviteHandler(
+        {groupId: "group123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.inviteId).toBe("invite-abc123");
+      expect(result.token).toBe("mocktoken12345678901234567890ab");
+      expect(result.deepLinkUrl).toBe(
+        "https://playwithme.app/invite/mocktoken12345678901234567890ab"
+      );
+      expect(result.expiresAt).toBeNull();
+    });
+
+    it("should write both invite and token lookup in a batch", async () => {
+      await createGroupInviteHandler(
+        {groupId: "group123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.set).toHaveBeenCalledTimes(2);
+      expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it("should set expiresAt when expiresInHours is provided", async () => {
+      const result = await createGroupInviteHandler(
+        {groupId: "group123", expiresInHours: 48},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.expiresAt).not.toBeNull();
+    });
+
+    it("should set expiresAt to null when not provided", async () => {
+      const result = await createGroupInviteHandler(
+        {groupId: "group123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.expiresAt).toBeNull();
+    });
+
+    it("should pass usageLimit to invite document", async () => {
+      await createGroupInviteHandler(
+        {groupId: "group123", usageLimit: 10},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.set).toHaveBeenCalledWith(
+        mockInviteRef,
+        expect.objectContaining({
+          usageLimit: 10,
+          usageCount: 0,
+        })
+      );
+    });
+
+    it("should pass null usageLimit when not provided", async () => {
+      await createGroupInviteHandler(
+        {groupId: "group123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.set).toHaveBeenCalledWith(
+        mockInviteRef,
+        expect.objectContaining({
+          usageLimit: null,
+        })
+      );
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should throw internal error on unexpected failure", async () => {
+      mockBatch.commit.mockRejectedValue(new Error("Firestore error"));
+
+      await expect(
+        createGroupInviteHandler(
+          {groupId: "group123"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Failed to create invite link. Please try again later."
+      );
+    });
+  });
+});

--- a/functions/test/unit/invites/joinGroupViaInvite.test.ts
+++ b/functions/test/unit/invites/joinGroupViaInvite.test.ts
@@ -1,0 +1,394 @@
+// Unit tests for joinGroupViaInvite Cloud Function
+// Epic 17 — Story 17.3
+
+import * as admin from "firebase-admin";
+import {joinGroupViaInviteHandler} from "../../../src/invites/joinGroupViaInvite";
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({})),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+          arrayUnion: jest.fn((...args: any[]) => ({
+            _methodName: "arrayUnion",
+            _elements: args,
+          })),
+          increment: jest.fn((n: number) => ({
+            _methodName: "increment",
+            _operand: n,
+          })),
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "HttpsError";
+      }
+    },
+    onCall: jest.fn((handler) => handler),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("joinGroupViaInvite Cloud Function", () => {
+  let mockDb: any;
+  let mockTokenDoc: any;
+  let mockInviteDoc: any;
+  let mockGroupDoc: any;
+  let mockTransaction: any;
+
+  const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTokenDoc = {
+      exists: true,
+      data: () => ({
+        groupId: "group-456",
+        inviteId: "invite-789",
+        active: true,
+      }),
+    };
+
+    mockInviteDoc = {
+      exists: true,
+      data: () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: false,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+        inviteType: "group_link",
+      }),
+    };
+
+    mockGroupDoc = {
+      exists: true,
+      data: () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "member2"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: true,
+      }),
+    };
+
+    mockTransaction = {
+      get: jest.fn((ref: any) => {
+        if (ref._type === "invite") return Promise.resolve(mockInviteDoc);
+        if (ref._type === "group") return Promise.resolve(mockGroupDoc);
+        return Promise.resolve(mockTokenDoc);
+      }),
+      update: jest.fn(),
+    };
+
+    const mockTokenRef = {_type: "token"};
+    const mockInviteRef = {_type: "invite"};
+    const mockGroupRef = {_type: "group"};
+
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => ({
+              ...mockTokenRef,
+              get: jest.fn().mockResolvedValue(mockTokenDoc),
+            })),
+          };
+        }
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              ...mockGroupRef,
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+              collection: jest.fn(() => ({
+                doc: jest.fn(() => mockInviteRef),
+              })),
+            })),
+          };
+        }
+        return {};
+      }),
+      runTransaction: jest.fn(async (callback: any) => {
+        // Override transaction.get to return correct docs
+        const txn = {
+          get: jest.fn((ref: any) => {
+            if (ref._type === "invite") {
+              return Promise.resolve(mockInviteDoc);
+            }
+            if (ref._type === "group") {
+              return Promise.resolve(mockGroupDoc);
+            }
+            return Promise.resolve(mockTokenDoc);
+          }),
+          update: jest.fn(),
+        };
+        mockTransaction = txn;
+        await callback(txn);
+      }),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  describe("Authentication", () => {
+    it("should throw unauthenticated error if not logged in", async () => {
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: null} as any
+        )
+      ).rejects.toThrow("You must be logged in to join a group.");
+    });
+  });
+
+  describe("Input Validation", () => {
+    it("should throw invalid-argument if token is missing", async () => {
+      await expect(
+        joinGroupViaInviteHandler(
+          {} as any,
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'token' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if token is empty", async () => {
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "   "},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'token' is required and must be a non-empty string."
+      );
+    });
+  });
+
+  describe("Token Validation", () => {
+    it("should throw not-found if token does not exist", async () => {
+      mockTokenDoc.exists = false;
+
+      // Override the initial get to return non-existent token
+      mockDb.collection = jest.fn((collectionName: string) => {
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue({exists: false}),
+            })),
+          };
+        }
+        return {};
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "nonexistent"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link does not exist.");
+    });
+
+    it("should throw failed-precondition if token is inactive", async () => {
+      mockTokenDoc.data = () => ({
+        groupId: "group-456",
+        inviteId: "invite-789",
+        active: false,
+      });
+
+      // Override initial token get to return inactive
+      mockDb.collection = jest.fn((collectionName: string) => {
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockTokenDoc),
+            })),
+          };
+        }
+        return {};
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link is no longer active.");
+    });
+  });
+
+  describe("Transaction Logic", () => {
+    it("should throw failed-precondition if invite is revoked", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        expiresAt: null,
+        revoked: true,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+      });
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "newuser"}} as any
+        )
+      ).rejects.toThrow("This invite link has been revoked.");
+    });
+
+    it("should throw failed-precondition if invite is expired", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        expiresAt: {toDate: () => pastDate},
+        revoked: false,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+      });
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "newuser"}} as any
+        )
+      ).rejects.toThrow("This invite link has expired.");
+    });
+
+    it("should throw failed-precondition if usage limit reached", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        expiresAt: null,
+        revoked: false,
+        usageLimit: 5,
+        usageCount: 5,
+        groupId: "group-456",
+      });
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "newuser"}} as any
+        )
+      ).rejects.toThrow(
+        "This invite link has reached its usage limit."
+      );
+    });
+
+    it("should throw failed-precondition if group is at capacity", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "member2"],
+        adminIds: ["creator123"],
+        maxMembers: 2,
+        allowMembersToInviteOthers: true,
+      });
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "newuser"}} as any
+        )
+      ).rejects.toThrow(
+        "This group is at capacity and cannot accept new members."
+      );
+    });
+  });
+
+  describe("Idempotency", () => {
+    it("should return alreadyMember true if user is already in group", async () => {
+      // User is already a member
+      const result = await joinGroupViaInviteHandler(
+        {token: "abc123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.alreadyMember).toBe(true);
+      expect(result.groupId).toBe("group-456");
+      expect(result.groupName).toBe("Beach Volleyball");
+    });
+
+    it("should not perform writes when user is already a member", async () => {
+      await joinGroupViaInviteHandler(
+        {token: "abc123"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      // Transaction update should not have been called
+      expect(mockTransaction.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Successful Join", () => {
+    it("should join user to group and return success", async () => {
+      const result = await joinGroupViaInviteHandler(
+        {token: "abc123"},
+        {auth: {uid: "newuser"}} as any
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.alreadyMember).toBe(false);
+      expect(result.groupId).toBe("group-456");
+      expect(result.groupName).toBe("Beach Volleyball");
+    });
+
+    it("should update group memberIds and invite usageCount", async () => {
+      await joinGroupViaInviteHandler(
+        {token: "abc123"},
+        {auth: {uid: "newuser"}} as any
+      );
+
+      // Should have 2 update calls: group and invite
+      expect(mockTransaction.update).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should throw internal on unexpected transaction error", async () => {
+      mockDb.runTransaction = jest.fn().mockRejectedValue(
+        new Error("Transaction failed")
+      );
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+
+      await expect(
+        joinGroupViaInviteHandler(
+          {token: "abc123"},
+          {auth: {uid: "newuser"}} as any
+        )
+      ).rejects.toThrow(
+        "Failed to join group. Please try again later."
+      );
+    });
+  });
+});

--- a/functions/test/unit/invites/revokeGroupInvite.test.ts
+++ b/functions/test/unit/invites/revokeGroupInvite.test.ts
@@ -1,0 +1,303 @@
+// Unit tests for revokeGroupInvite Cloud Function
+// Epic 17 — Story 17.3
+
+import * as admin from "firebase-admin";
+import {revokeGroupInviteHandler} from "../../../src/invites/revokeGroupInvite";
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({})),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "HttpsError";
+      }
+    },
+    onCall: jest.fn((handler) => handler),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("revokeGroupInvite Cloud Function", () => {
+  let mockDb: any;
+  let mockBatch: any;
+  let mockInviteDoc: any;
+  let mockGroupDoc: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockBatch = {
+      update: jest.fn(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockInviteDoc = {
+      exists: true,
+      data: () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: false,
+        usageLimit: null,
+        usageCount: 3,
+        groupId: "group-456",
+        inviteType: "group_link",
+      }),
+    };
+
+    mockGroupDoc = {
+      exists: true,
+      data: () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123", "inviter-user", "member3"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: true,
+      }),
+    };
+
+    const mockInviteRef = {_type: "invite"};
+    const mockTokenRef = {_type: "token"};
+
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+              collection: jest.fn(() => ({
+                doc: jest.fn(() => ({
+                  ...mockInviteRef,
+                  get: jest.fn().mockResolvedValue(mockInviteDoc),
+                })),
+              })),
+            })),
+          };
+        }
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => mockTokenRef),
+          };
+        }
+        return {};
+      }),
+      batch: jest.fn(() => mockBatch),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  describe("Authentication", () => {
+    it("should throw unauthenticated error if not logged in", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "invite-789"},
+          {auth: null} as any
+        )
+      ).rejects.toThrow("You must be logged in to revoke an invite link.");
+    });
+  });
+
+  describe("Input Validation", () => {
+    it("should throw invalid-argument if groupId is missing", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {inviteId: "invite-789"} as any,
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'groupId' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if groupId is empty", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "  ", inviteId: "invite-789"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'groupId' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if inviteId is missing", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456"} as any,
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'inviteId' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if inviteId is empty", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "  "},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'inviteId' is required and must be a non-empty string."
+      );
+    });
+  });
+
+  describe("Invite Validation", () => {
+    it("should throw not-found if invite does not exist", async () => {
+      mockInviteDoc.exists = false;
+
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "invite-789"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow("The invite does not exist.");
+    });
+
+    it("should throw already-exists if invite is already revoked", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        revoked: true,
+        usageLimit: null,
+        usageCount: 3,
+        groupId: "group-456",
+      });
+
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "invite-789"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow("This invite is already revoked.");
+    });
+  });
+
+  describe("Permission Validation", () => {
+    it("should throw permission-denied if user is not admin and not invite creator", async () => {
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "invite-789"},
+          {auth: {uid: "member3"}} as any
+        )
+      ).rejects.toThrow(
+        "You do not have permission to revoke this invite."
+      );
+    });
+
+    it("should allow group admin to revoke", async () => {
+      const result = await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should allow group creator to revoke", async () => {
+      const result = await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should allow invite creator to revoke their own invite", async () => {
+      const result = await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "inviter-user"}} as any
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("Successful Revocation", () => {
+    it("should revoke invite and return success", async () => {
+      const result = await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should write both invite revocation and token deactivation", async () => {
+      await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.update).toHaveBeenCalledTimes(2);
+      expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it("should set revoked to true on invite", async () => {
+      await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.update).toHaveBeenCalledWith(
+        expect.anything(),
+        {revoked: true}
+      );
+    });
+
+    it("should set active to false on token lookup", async () => {
+      await revokeGroupInviteHandler(
+        {groupId: "group-456", inviteId: "invite-789"},
+        {auth: {uid: "creator123"}} as any
+      );
+
+      expect(mockBatch.update).toHaveBeenCalledWith(
+        expect.anything(),
+        {active: false}
+      );
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should throw internal on unexpected failure", async () => {
+      mockBatch.commit.mockRejectedValue(new Error("Firestore error"));
+
+      await expect(
+        revokeGroupInviteHandler(
+          {groupId: "group-456", inviteId: "invite-789"},
+          {auth: {uid: "creator123"}} as any
+        )
+      ).rejects.toThrow(
+        "Failed to revoke invite link. Please try again later."
+      );
+    });
+  });
+});

--- a/functions/test/unit/invites/validateInviteToken.test.ts
+++ b/functions/test/unit/invites/validateInviteToken.test.ts
@@ -1,0 +1,391 @@
+// Unit tests for validateInviteToken Cloud Function
+// Epic 17 — Story 17.3
+
+import * as admin from "firebase-admin";
+import {validateInviteTokenHandler} from "../../../src/invites/validateInviteToken";
+
+// Mock Firebase Admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({})),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      code: string;
+      constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "HttpsError";
+      }
+    },
+    onCall: jest.fn((handler) => handler),
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("validateInviteToken Cloud Function", () => {
+  let mockDb: any;
+  let mockTokenDoc: any;
+  let mockInviteDoc: any;
+  let mockGroupDoc: any;
+  let mockInviterDoc: any;
+
+  const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTokenDoc = {
+      exists: true,
+      data: () => ({
+        groupId: "group-456",
+        inviteId: "invite-789",
+        createdAt: {toDate: () => new Date()},
+        active: true,
+      }),
+    };
+
+    mockInviteDoc = {
+      exists: true,
+      data: () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: false,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+        inviteType: "group_link",
+      }),
+    };
+
+    mockGroupDoc = {
+      exists: true,
+      data: () => ({
+        name: "Beach Volleyball",
+        description: "Fun times",
+        photoUrl: "https://example.com/photo.jpg",
+        createdBy: "creator123",
+        memberIds: ["creator123", "member2"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: true,
+      }),
+    };
+
+    mockInviterDoc = {
+      exists: true,
+      data: () => ({
+        displayName: "John Doe",
+        email: "john@example.com",
+        photoUrl: "https://example.com/john.jpg",
+      }),
+    };
+
+    mockDb = {
+      collection: jest.fn((collectionName: string) => {
+        if (collectionName === "invite_tokens") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockTokenDoc),
+            })),
+          };
+        }
+        if (collectionName === "groups") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockGroupDoc),
+              collection: jest.fn(() => ({
+                doc: jest.fn(() => ({
+                  get: jest.fn().mockResolvedValue(mockInviteDoc),
+                })),
+              })),
+            })),
+          };
+        }
+        if (collectionName === "users") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn().mockResolvedValue(mockInviterDoc),
+            })),
+          };
+        }
+        return {};
+      }),
+    };
+
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  describe("Authentication", () => {
+    it("should throw unauthenticated error if not logged in", async () => {
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: null} as any
+        )
+      ).rejects.toThrow("You must be logged in to validate an invite link.");
+    });
+  });
+
+  describe("Input Validation", () => {
+    it("should throw invalid-argument if token is missing", async () => {
+      await expect(
+        validateInviteTokenHandler(
+          {} as any,
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'token' is required and must be a non-empty string."
+      );
+    });
+
+    it("should throw invalid-argument if token is empty", async () => {
+      await expect(
+        validateInviteTokenHandler(
+          {token: "  "},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Parameter 'token' is required and must be a non-empty string."
+      );
+    });
+  });
+
+  describe("Token Validation", () => {
+    it("should throw not-found if token does not exist", async () => {
+      mockTokenDoc.exists = false;
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "nonexistent"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link does not exist.");
+    });
+
+    it("should throw failed-precondition if token is inactive", async () => {
+      mockTokenDoc.data = () => ({
+        groupId: "group-456",
+        inviteId: "invite-789",
+        active: false,
+      });
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link is no longer active.");
+    });
+  });
+
+  describe("Invite Validation", () => {
+    it("should throw failed-precondition if invite is revoked", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: true,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+        inviteType: "group_link",
+      });
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link has been revoked.");
+    });
+
+    it("should throw failed-precondition if invite is expired", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: {toDate: () => pastDate},
+        revoked: false,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+        inviteType: "group_link",
+      });
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow("This invite link has expired.");
+    });
+
+    it("should throw failed-precondition if usage limit reached", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: false,
+        usageLimit: 5,
+        usageCount: 5,
+        groupId: "group-456",
+        inviteType: "group_link",
+      });
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "This invite link has reached its usage limit."
+      );
+    });
+
+    it("should pass when expiresAt is in the future", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: {toDate: () => futureDate},
+        revoked: false,
+        usageLimit: null,
+        usageCount: 0,
+        groupId: "group-456",
+        inviteType: "group_link",
+      });
+
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.expiresAt).toBe(futureDate.toISOString());
+    });
+  });
+
+  describe("Successful Validation", () => {
+    it("should return correct group info", async () => {
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.groupId).toBe("group-456");
+      expect(result.groupName).toBe("Beach Volleyball");
+      expect(result.groupDescription).toBe("Fun times");
+      expect(result.groupPhotoUrl).toBe("https://example.com/photo.jpg");
+      expect(result.groupMemberCount).toBe(2);
+    });
+
+    it("should return inviter info", async () => {
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.inviterName).toBe("John Doe");
+      expect(result.inviterPhotoUrl).toBe("https://example.com/john.jpg");
+    });
+
+    it("should return null remainingUses for unlimited invites", async () => {
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.remainingUses).toBeNull();
+    });
+
+    it("should return correct remainingUses for limited invites", async () => {
+      mockInviteDoc.data = () => ({
+        token: "testtoken123",
+        createdBy: "inviter-user",
+        createdAt: {toDate: () => new Date()},
+        expiresAt: null,
+        revoked: false,
+        usageLimit: 10,
+        usageCount: 3,
+        groupId: "group-456",
+        inviteType: "group_link",
+      });
+
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.remainingUses).toBe(7);
+    });
+
+    it("should omit optional fields when not present", async () => {
+      mockGroupDoc.data = () => ({
+        name: "Beach Volleyball",
+        createdBy: "creator123",
+        memberIds: ["creator123"],
+        adminIds: ["creator123"],
+        maxMembers: 20,
+        allowMembersToInviteOthers: true,
+      });
+
+      mockInviterDoc.data = () => ({
+        displayName: "John",
+        email: "john@example.com",
+      });
+
+      const result = await validateInviteTokenHandler(
+        {token: "abc123"},
+        {auth: {uid: "user123"}} as any
+      );
+
+      expect(result.groupDescription).toBeUndefined();
+      expect(result.groupPhotoUrl).toBeUndefined();
+      expect(result.inviterPhotoUrl).toBeUndefined();
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should throw internal on unexpected error", async () => {
+      (admin.firestore as unknown as jest.Mock).mockReturnValue({
+        collection: jest.fn(() => {
+          throw new Error("Unexpected");
+        }),
+      });
+
+      await expect(
+        validateInviteTokenHandler(
+          {token: "abc123"},
+          {auth: {uid: "user123"}} as any
+        )
+      ).rejects.toThrow(
+        "Failed to validate invite link. Please try again later."
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement 4 callable Cloud Functions for the group invite system per the API contract defined in Story 17.2:
  - **`createGroupInvite`**: Generate secure token (192-bit entropy), validate permissions (`allowMembersToInviteOthers` or admin), atomic batch write for invite + token lookup
  - **`validateInviteToken`**: Token lookup, state validation (active, not revoked, not expired, usage limit), return group info and inviter profile for pre-join screen
  - **`joinGroupViaInvite`**: Transaction-based join with idempotency (`alreadyMember` no-op), capacity check, usage count increment
  - **`revokeGroupInvite`**: Permission checks (admin/creator/invite owner), batch write to revoke invite and deactivate token
- Shared TypeScript interfaces in `functions/src/invites/types.ts`
- Functions registered in `functions/src/index.ts`
- All functions follow CLAUDE.md Section 11: idempotent, atomic, fail-fast, structured logging, standard `HttpsError` codes
- No cross-layer violations (Groups layer only, no Social Graph mutation)
- Deployed to all 3 environments: `playwithme-dev`, `playwithme-stg`, `playwithme-prod`

Closes #465

## Test plan

- [x] 64 unit tests across 4 test files covering:
  - Authentication validation (unauthenticated errors)
  - Input validation (missing/empty/invalid parameters)
  - Permission checks (non-member, non-admin, invite permissions)
  - Group state validation (not found, at capacity)
  - Token state validation (not found, inactive, revoked, expired, usage limit)
  - Happy paths with correct response shapes
  - Idempotency (`joinGroupViaInvite` with already-member)
  - Atomic writes (batch and transaction verification)
  - Error handling (internal errors on unexpected failures)
- [x] TypeScript compiles with `tsc --noEmit` (0 errors)
- [x] Source lint passes with `eslint src/invites/` (0 errors)
- [x] All 341 existing unit tests pass (no regressions)
- [x] Functions deployed and verified on all 3 environments