### PR TITLE
Story 17.4: Generate Shareable Group Invite Link (UI)

### DIFF
--- a/lib/core/data/repositories/firestore_group_invite_link_repository.dart
+++ b/lib/core/data/repositories/firestore_group_invite_link_repository.dart
@@ -1,0 +1,107 @@
+// Firestore implementation of GroupInviteLinkRepository.
+// Calls Cloud Functions for invite link creation and revocation.
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+
+class FirestoreGroupInviteLinkRepository implements GroupInviteLinkRepository {
+  final FirebaseFunctions _functions;
+
+  FirestoreGroupInviteLinkRepository({
+    required FirebaseFunctions functions,
+  }) : _functions = functions;
+
+  @override
+  Future<({String inviteId, String token, String deepLinkUrl})>
+      createGroupInvite({
+    required String groupId,
+    int? expiresInHours,
+    int? usageLimit,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('createGroupInvite');
+      final params = <String, dynamic>{
+        'groupId': groupId,
+      };
+      if (expiresInHours != null) {
+        params['expiresInHours'] = expiresInHours;
+      }
+      if (usageLimit != null) {
+        params['usageLimit'] = usageLimit;
+      }
+
+      final result = await callable.call(params);
+      final data = Map<String, dynamic>.from(result.data as Map);
+
+      return (
+        inviteId: data['inviteId'] as String,
+        token: data['token'] as String,
+        deepLinkUrl: data['deepLinkUrl'] as String,
+      );
+    } on FirebaseFunctionsException catch (e) {
+      throw _handleError(e);
+    } catch (e) {
+      throw GroupInviteLinkException(
+          'Failed to create invite link: $e');
+    }
+  }
+
+  @override
+  Future<void> revokeGroupInvite({
+    required String groupId,
+    required String inviteId,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('revokeGroupInvite');
+      await callable.call({
+        'groupId': groupId,
+        'inviteId': inviteId,
+      });
+    } on FirebaseFunctionsException catch (e) {
+      throw _handleError(e);
+    } catch (e) {
+      throw GroupInviteLinkException(
+          'Failed to revoke invite link: $e');
+    }
+  }
+
+  GroupInviteLinkException _handleError(FirebaseFunctionsException e) {
+    switch (e.code) {
+      case 'not-found':
+        return GroupInviteLinkException(
+          e.message ?? 'Resource not found',
+          code: e.code,
+        );
+      case 'permission-denied':
+        return GroupInviteLinkException(
+          e.message ?? 'You do not have permission to perform this action',
+          code: e.code,
+        );
+      case 'unauthenticated':
+        return GroupInviteLinkException(
+          'You must be logged in to perform this action',
+          code: e.code,
+        );
+      case 'invalid-argument':
+        return GroupInviteLinkException(
+          e.message ?? 'Invalid input provided',
+          code: e.code,
+        );
+      case 'already-exists':
+        return GroupInviteLinkException(
+          e.message ?? 'This invite is already revoked',
+          code: e.code,
+        );
+      case 'failed-precondition':
+        return GroupInviteLinkException(
+          e.message ?? 'Cannot complete this action right now',
+          code: e.code,
+        );
+      default:
+        return GroupInviteLinkException(
+          e.message ?? 'An error occurred. Please try again.',
+          code: e.code,
+        );
+    }
+  }
+}

--- a/lib/core/domain/exceptions/repository_exceptions.dart
+++ b/lib/core/domain/exceptions/repository_exceptions.dart
@@ -77,3 +77,14 @@ class ImageStorageException implements Exception {
   @override
   String toString() => message;
 }
+
+/// Exception thrown by GroupInviteLinkRepository operations.
+class GroupInviteLinkException implements Exception {
+  final String message;
+  final String? code;
+
+  GroupInviteLinkException(this.message, {this.code});
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/domain/repositories/group_invite_link_repository.dart
+++ b/lib/core/domain/repositories/group_invite_link_repository.dart
@@ -1,0 +1,24 @@
+/// Repository interface for group invite link operations.
+///
+/// All methods call Cloud Functions (createGroupInvite, revokeGroupInvite)
+/// to generate shareable invite links and manage their lifecycle.
+abstract class GroupInviteLinkRepository {
+  /// Creates a new group invite link by calling the createGroupInvite Cloud Function.
+  ///
+  /// Returns a record with the invite ID, token, and deep link URL.
+  /// Throws [GroupInviteLinkException] on failure.
+  Future<({String inviteId, String token, String deepLinkUrl})>
+      createGroupInvite({
+    required String groupId,
+    int? expiresInHours,
+    int? usageLimit,
+  });
+
+  /// Revokes an existing group invite link by calling the revokeGroupInvite Cloud Function.
+  ///
+  /// Throws [GroupInviteLinkException] on failure.
+  Future<void> revokeGroupInvite({
+    required String groupId,
+    required String inviteId,
+  });
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -20,6 +20,7 @@ import 'package:play_with_me/core/domain/repositories/training_feedback_reposito
 import 'package:play_with_me/core/domain/repositories/image_storage_repository.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
 import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_user_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_group_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_game_repository.dart';
@@ -29,6 +30,7 @@ import 'package:play_with_me/core/data/repositories/firestore_training_feedback_
 import 'package:play_with_me/core/data/repositories/firebase_image_storage_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_invitation_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_friend_repository.dart';
+import 'package:play_with_me/core/data/repositories/firestore_group_invite_link_repository.dart';
 import 'package:play_with_me/core/services/image_picker_service.dart';
 import 'package:play_with_me/core/presentation/bloc/user/user_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_bloc.dart';
@@ -49,6 +51,7 @@ import 'package:play_with_me/features/training/presentation/bloc/training_sessio
 import 'package:play_with_me/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart';
 import 'package:play_with_me/features/training/presentation/bloc/exercise/exercise_bloc.dart';
 import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -183,6 +186,14 @@ Future<void> initializeDependencies() async {
         functions: sl(),
         firestore: sl(),
         auth: sl(),
+      ),
+    );
+  }
+
+  if (!sl.isRegistered<GroupInviteLinkRepository>()) {
+    sl.registerLazySingleton<GroupInviteLinkRepository>(
+      () => FirestoreGroupInviteLinkRepository(
+        functions: sl(),
       ),
     );
   }
@@ -336,6 +347,12 @@ Future<void> initializeDependencies() async {
       () => TrainingSessionParticipationBloc(
         trainingSessionRepository: sl(),
       ),
+    );
+  }
+
+  if (!sl.isRegistered<GroupInviteLinkBloc>()) {
+    sl.registerFactory<GroupInviteLinkBloc>(
+      () => GroupInviteLinkBloc(repository: sl()),
     );
   }
 }

--- a/lib/core/utils/error_messages.dart
+++ b/lib/core/utils/error_messages.dart
@@ -16,7 +16,8 @@ class ErrorMessages {
         e is InvitationException ||
         e is UserException ||
         e is ExerciseException ||
-        e is ImageStorageException) {
+        e is ImageStorageException ||
+        e is GroupInviteLinkException) {
       return (e.toString(), _isRetryableByCode(_getExceptionCode(e)));
     }
     // Check FirebaseFunctionsException first as it may extend FirebaseException
@@ -38,6 +39,7 @@ class ErrorMessages {
     if (e is UserException) return e.code;
     if (e is ExerciseException) return e.code;
     if (e is ImageStorageException) return e.code;
+    if (e is GroupInviteLinkException) return e.code;
     return null;
   }
 
@@ -277,6 +279,19 @@ class InvitationErrorMessages {
         'You cannot invite yourself to a group',
         false,
       );
+    }
+
+    // Fall back to generic error message handling
+    return ErrorMessages.getErrorMessage(e);
+  }
+}
+
+/// Group invite link-specific error messages.
+class GroupInviteLinkErrorMessages {
+  /// Get error message for group invite link operations.
+  static (String message, bool isRetryable) getErrorMessage(Exception e) {
+    if (e is GroupInviteLinkException) {
+      return (e.message, ErrorMessages._isRetryableByCode(e.code));
     }
 
     // Fall back to generic error message handling

--- a/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart
+++ b/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart
@@ -1,0 +1,89 @@
+// BLoC for managing group invite link generation and revocation.
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/core/utils/error_messages.dart';
+import 'group_invite_link_event.dart';
+import 'group_invite_link_state.dart';
+
+class GroupInviteLinkBloc
+    extends Bloc<GroupInviteLinkEvent, GroupInviteLinkState> {
+  final GroupInviteLinkRepository _repository;
+
+  GroupInviteLinkBloc({required GroupInviteLinkRepository repository})
+      : _repository = repository,
+        super(const GroupInviteLinkInitial()) {
+    on<GenerateInvite>(_onGenerateInvite);
+    on<RevokeInvite>(_onRevokeInvite);
+  }
+
+  Future<void> _onGenerateInvite(
+    GenerateInvite event,
+    Emitter<GroupInviteLinkState> emit,
+  ) async {
+    try {
+      emit(const GroupInviteLinkLoading());
+
+      final result = await _repository.createGroupInvite(
+        groupId: event.groupId,
+        expiresInHours: event.expiresInHours,
+        usageLimit: event.usageLimit,
+      );
+
+      emit(GroupInviteLinkGenerated(
+        deepLinkUrl: result.deepLinkUrl,
+        inviteId: result.inviteId,
+      ));
+    } on GroupInviteLinkException catch (e) {
+      final (message, isRetryable) =
+          GroupInviteLinkErrorMessages.getErrorMessage(e);
+      emit(GroupInviteLinkError(
+        message: message,
+        errorCode: e.code ?? 'GENERATE_INVITE_ERROR',
+        isRetryable: isRetryable,
+      ));
+    } catch (e) {
+      final (message, isRetryable) = e is Exception
+          ? ErrorMessages.getErrorMessage(e)
+          : ('Failed to generate invite link', true);
+      emit(GroupInviteLinkError(
+        message: message,
+        errorCode: 'GENERATE_INVITE_ERROR',
+        isRetryable: isRetryable,
+      ));
+    }
+  }
+
+  Future<void> _onRevokeInvite(
+    RevokeInvite event,
+    Emitter<GroupInviteLinkState> emit,
+  ) async {
+    try {
+      emit(const GroupInviteLinkLoading());
+
+      await _repository.revokeGroupInvite(
+        groupId: event.groupId,
+        inviteId: event.inviteId,
+      );
+
+      emit(const GroupInviteLinkRevoked());
+    } on GroupInviteLinkException catch (e) {
+      final (message, isRetryable) =
+          GroupInviteLinkErrorMessages.getErrorMessage(e);
+      emit(GroupInviteLinkError(
+        message: message,
+        errorCode: e.code ?? 'REVOKE_INVITE_ERROR',
+        isRetryable: isRetryable,
+      ));
+    } catch (e) {
+      final (message, isRetryable) = e is Exception
+          ? ErrorMessages.getErrorMessage(e)
+          : ('Failed to revoke invite link', true);
+      emit(GroupInviteLinkError(
+        message: message,
+        errorCode: 'REVOKE_INVITE_ERROR',
+        isRetryable: isRetryable,
+      ));
+    }
+  }
+}

--- a/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart
+++ b/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart
@@ -1,0 +1,35 @@
+import 'package:play_with_me/core/presentation/bloc/base_bloc_event.dart';
+
+abstract class GroupInviteLinkEvent extends BaseBlocEvent {
+  const GroupInviteLinkEvent();
+}
+
+/// Event to generate a new invite link for a group.
+class GenerateInvite extends GroupInviteLinkEvent {
+  final String groupId;
+  final int? expiresInHours;
+  final int? usageLimit;
+
+  const GenerateInvite({
+    required this.groupId,
+    this.expiresInHours,
+    this.usageLimit,
+  });
+
+  @override
+  List<Object?> get props => [groupId, expiresInHours, usageLimit];
+}
+
+/// Event to revoke an existing invite link.
+class RevokeInvite extends GroupInviteLinkEvent {
+  final String groupId;
+  final String inviteId;
+
+  const RevokeInvite({
+    required this.groupId,
+    required this.inviteId,
+  });
+
+  @override
+  List<Object?> get props => [groupId, inviteId];
+}

--- a/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart
+++ b/lib/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart
@@ -1,0 +1,52 @@
+import 'package:play_with_me/core/presentation/bloc/base_bloc_state.dart';
+
+abstract class GroupInviteLinkState extends BaseBlocState {
+  const GroupInviteLinkState();
+}
+
+class GroupInviteLinkInitial extends GroupInviteLinkState
+    implements InitialState {
+  const GroupInviteLinkInitial();
+}
+
+class GroupInviteLinkLoading extends GroupInviteLinkState
+    implements LoadingState {
+  const GroupInviteLinkLoading();
+}
+
+class GroupInviteLinkGenerated extends GroupInviteLinkState
+    implements SuccessState {
+  final String deepLinkUrl;
+  final String inviteId;
+
+  const GroupInviteLinkGenerated({
+    required this.deepLinkUrl,
+    required this.inviteId,
+  });
+
+  @override
+  List<Object?> get props => [deepLinkUrl, inviteId];
+}
+
+class GroupInviteLinkRevoked extends GroupInviteLinkState
+    implements SuccessState {
+  const GroupInviteLinkRevoked();
+}
+
+class GroupInviteLinkError extends GroupInviteLinkState implements ErrorState {
+  @override
+  final String message;
+  @override
+  final String? errorCode;
+  @override
+  final bool isRetryable;
+
+  const GroupInviteLinkError({
+    required this.message,
+    this.errorCode,
+    this.isRetryable = true,
+  });
+
+  @override
+  List<Object?> get props => [message, errorCode, isRetryable];
+}

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -25,6 +25,8 @@ import 'package:play_with_me/features/games/presentation/pages/game_creation_pag
 import 'package:play_with_me/features/games/presentation/pages/games_list_page.dart';
 import 'package:play_with_me/features/training/presentation/bloc/training_session_creation/training_session_creation_bloc.dart';
 import 'package:play_with_me/features/training/presentation/pages/training_session_creation_page.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/widgets/invite_link_section.dart';
 
 class GroupDetailsPage extends StatelessWidget {
   final String groupId;
@@ -42,8 +44,11 @@ class GroupDetailsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => sl<GroupMemberBloc>(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (context) => sl<GroupMemberBloc>()),
+        BlocProvider(create: (context) => sl<GroupInviteLinkBloc>()),
+      ],
       child: _GroupDetailsPageContent(
         groupId: groupId,
         groupRepositoryOverride: groupRepositoryOverride,
@@ -401,6 +406,12 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
             // Group header
             _buildGroupHeader(context),
             const Divider(),
+
+            // Invite link section (visible only for eligible members)
+            if (_group!.canUserInviteOthers(currentUserId))
+              InviteLinkSection(groupId: widget.groupId),
+            if (_group!.canUserInviteOthers(currentUserId))
+              const Divider(),
 
             // Members section
             Padding(

--- a/lib/features/groups/presentation/widgets/invite_link_section.dart
+++ b/lib/features/groups/presentation/widgets/invite_link_section.dart
@@ -1,0 +1,212 @@
+// Widget section for generating and sharing group invite links.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart';
+
+class InviteLinkSection extends StatelessWidget {
+  final String groupId;
+
+  const InviteLinkSection({
+    super.key,
+    required this.groupId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return BlocConsumer<GroupInviteLinkBloc, GroupInviteLinkState>(
+      listener: (context, state) {
+        if (state is GroupInviteLinkRevoked) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(l10n.inviteRevoked),
+              backgroundColor: Colors.green,
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        } else if (state is GroupInviteLinkError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.red,
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        return Container(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.inviteLinkSectionTitle,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.secondary,
+                    ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.inviteLinkDescription,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textMuted,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              _buildContent(context, state, l10n),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    GroupInviteLinkState state,
+    AppLocalizations l10n,
+  ) {
+    if (state is GroupInviteLinkLoading) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (state is GroupInviteLinkGenerated) {
+      return _buildGeneratedLinkSection(context, state, l10n);
+    }
+
+    // Initial, error, or revoked states show the generate button
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton.icon(
+        onPressed: () {
+          context.read<GroupInviteLinkBloc>().add(
+                GenerateInvite(groupId: groupId),
+              );
+        },
+        icon: const Icon(Icons.link),
+        label: Text(l10n.generateInviteLink),
+        style: FilledButton.styleFrom(
+          backgroundColor: AppColors.secondary,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 12),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGeneratedLinkSection(
+    BuildContext context,
+    GroupInviteLinkGenerated state,
+    AppLocalizations l10n,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Link display
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: AppColors.scaffoldBackground,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.divider),
+          ),
+          child: Text(
+            state.deepLinkUrl,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: AppColors.secondary,
+                  fontFamily: 'monospace',
+                ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        // Action buttons
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: () => _copyToClipboard(context, state.deepLinkUrl, l10n),
+                icon: const Icon(Icons.copy, size: 18),
+                label: Text(l10n.copyLink),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.secondary,
+                  side: const BorderSide(color: AppColors.secondary),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: () => _shareLink(context, state.deepLinkUrl, l10n),
+                icon: const Icon(Icons.share, size: 18),
+                label: Text(l10n.shareLink),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.secondary,
+                  side: const BorderSide(color: AppColors.secondary),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        // Revoke button
+        SizedBox(
+          width: double.infinity,
+          child: TextButton.icon(
+            onPressed: () {
+              context.read<GroupInviteLinkBloc>().add(
+                    RevokeInvite(
+                      groupId: groupId,
+                      inviteId: state.inviteId,
+                    ),
+                  );
+            },
+            icon: const Icon(Icons.link_off, size: 18),
+            label: Text(l10n.revokeInvite),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.danger,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _copyToClipboard(
+    BuildContext context,
+    String url,
+    AppLocalizations l10n,
+  ) {
+    Clipboard.setData(ClipboardData(text: url));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(l10n.linkCopied),
+        backgroundColor: Colors.green,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  void _shareLink(
+    BuildContext context,
+    String url,
+    AppLocalizations l10n,
+  ) {
+    Share.share(l10n.inviteLinkShareMessage(url));
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -500,5 +500,16 @@
   "nextTrainingSession": "Nächste Trainingseinheit",
   "noTrainingSessionsScheduled": "Keine Trainingseinheiten geplant",
   "stats": "Statistiken",
-  "myStats": "Meine Statistiken"
+  "myStats": "Meine Statistiken",
+  "generateInviteLink": "Einladungslink erstellen",
+  "copyLink": "Link kopieren",
+  "shareLink": "Teilen",
+  "linkCopied": "Link in die Zwischenablage kopiert",
+  "inviteLinkSectionTitle": "Mitglieder einladen",
+  "inviteLinkDescription": "Teile diesen Link, um Personen einzuladen, der Gruppe beizutreten.",
+  "revokeInvite": "Einladung widerrufen",
+  "inviteRevoked": "Einladungslink widerrufen",
+  "generateInviteError": "Einladungslink konnte nicht erstellt werden",
+  "revokeInviteError": "Einladungslink konnte nicht widerrufen werden",
+  "inviteLinkShareMessage": "Tritt meiner Gruppe auf PlayWithMe bei! {url}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2360,5 +2360,63 @@
   "myStats": "My Stats",
   "@myStats": {
     "description": "My Stats page title"
+  },
+
+  "generateInviteLink": "Generate Invite Link",
+  "@generateInviteLink": {
+    "description": "Button label to generate a shareable group invite link"
+  },
+
+  "copyLink": "Copy Link",
+  "@copyLink": {
+    "description": "Button label to copy the invite link to clipboard"
+  },
+
+  "shareLink": "Share",
+  "@shareLink": {
+    "description": "Button label to open native share sheet for the invite link"
+  },
+
+  "linkCopied": "Link copied to clipboard",
+  "@linkCopied": {
+    "description": "Snackbar message after invite link is copied"
+  },
+
+  "inviteLinkSectionTitle": "Invite Members",
+  "@inviteLinkSectionTitle": {
+    "description": "Section title for invite link generation area"
+  },
+
+  "inviteLinkDescription": "Share this link to invite people to join the group.",
+  "@inviteLinkDescription": {
+    "description": "Description text in the invite link section"
+  },
+
+  "revokeInvite": "Revoke Invite",
+  "@revokeInvite": {
+    "description": "Button label to revoke an invite link"
+  },
+
+  "inviteRevoked": "Invite link revoked",
+  "@inviteRevoked": {
+    "description": "Snackbar message after invite link is revoked"
+  },
+
+  "generateInviteError": "Failed to generate invite link",
+  "@generateInviteError": {
+    "description": "Error message when invite link generation fails"
+  },
+
+  "revokeInviteError": "Failed to revoke invite link",
+  "@revokeInviteError": {
+    "description": "Error message when invite link revocation fails"
+  },
+
+  "inviteLinkShareMessage": "Join my group on PlayWithMe! {url}",
+  "@inviteLinkShareMessage": {
+    "description": "Message shared via native share sheet with the invite link",
+    "placeholders": {
+      "url": {"type": "String"}
+    }
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -500,5 +500,16 @@
   "nextTrainingSession": "Próxima sesión de entrenamiento",
   "noTrainingSessionsScheduled": "No hay sesiones de entrenamiento programadas",
   "stats": "Estadísticas",
-  "myStats": "Mis Estadísticas"
+  "myStats": "Mis Estadísticas",
+  "generateInviteLink": "Generar enlace de invitación",
+  "copyLink": "Copiar enlace",
+  "shareLink": "Compartir",
+  "linkCopied": "Enlace copiado al portapapeles",
+  "inviteLinkSectionTitle": "Invitar miembros",
+  "inviteLinkDescription": "Comparte este enlace para invitar a personas a unirse al grupo.",
+  "revokeInvite": "Revocar invitación",
+  "inviteRevoked": "Enlace de invitación revocado",
+  "generateInviteError": "No se pudo generar el enlace de invitación",
+  "revokeInviteError": "No se pudo revocar el enlace de invitación",
+  "inviteLinkShareMessage": "¡Únete a mi grupo en PlayWithMe! {url}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -500,5 +500,16 @@
   "nextTrainingSession": "Prochaine séance d'entraînement",
   "noTrainingSessionsScheduled": "Aucune séance d'entraînement prévue",
   "stats": "Stats",
-  "myStats": "Mes Stats"
+  "myStats": "Mes Stats",
+  "generateInviteLink": "Générer un lien d'invitation",
+  "copyLink": "Copier le lien",
+  "shareLink": "Partager",
+  "linkCopied": "Lien copié dans le presse-papiers",
+  "inviteLinkSectionTitle": "Inviter des membres",
+  "inviteLinkDescription": "Partagez ce lien pour inviter des personnes à rejoindre le groupe.",
+  "revokeInvite": "Révoquer l'invitation",
+  "inviteRevoked": "Lien d'invitation révoqué",
+  "generateInviteError": "Impossible de générer le lien d'invitation",
+  "revokeInviteError": "Impossible de révoquer le lien d'invitation",
+  "inviteLinkShareMessage": "Rejoins mon groupe sur PlayWithMe ! {url}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -500,5 +500,16 @@
   "nextTrainingSession": "Prossimo allenamento",
   "noTrainingSessionsScheduled": "Nessun allenamento programmato",
   "stats": "Statistiche",
-  "myStats": "Le Mie Statistiche"
+  "myStats": "Le Mie Statistiche",
+  "generateInviteLink": "Genera link di invito",
+  "copyLink": "Copia link",
+  "shareLink": "Condividi",
+  "linkCopied": "Link copiato negli appunti",
+  "inviteLinkSectionTitle": "Invita membri",
+  "inviteLinkDescription": "Condividi questo link per invitare persone a unirsi al gruppo.",
+  "revokeInvite": "Revoca invito",
+  "inviteRevoked": "Link di invito revocato",
+  "generateInviteError": "Impossibile generare il link di invito",
+  "revokeInviteError": "Impossibile revocare il link di invito",
+  "inviteLinkShareMessage": "Unisciti al mio gruppo su PlayWithMe! {url}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3061,6 +3061,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'My Stats'**
   String get myStats;
+
+  /// Button label to generate a shareable group invite link
+  ///
+  /// In en, this message translates to:
+  /// **'Generate Invite Link'**
+  String get generateInviteLink;
+
+  /// Button label to copy the invite link to clipboard
+  ///
+  /// In en, this message translates to:
+  /// **'Copy Link'**
+  String get copyLink;
+
+  /// Button label to open native share sheet for the invite link
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get shareLink;
+
+  /// Snackbar message after invite link is copied
+  ///
+  /// In en, this message translates to:
+  /// **'Link copied to clipboard'**
+  String get linkCopied;
+
+  /// Section title for invite link generation area
+  ///
+  /// In en, this message translates to:
+  /// **'Invite Members'**
+  String get inviteLinkSectionTitle;
+
+  /// Description text in the invite link section
+  ///
+  /// In en, this message translates to:
+  /// **'Share this link to invite people to join the group.'**
+  String get inviteLinkDescription;
+
+  /// Button label to revoke an invite link
+  ///
+  /// In en, this message translates to:
+  /// **'Revoke Invite'**
+  String get revokeInvite;
+
+  /// Snackbar message after invite link is revoked
+  ///
+  /// In en, this message translates to:
+  /// **'Invite link revoked'**
+  String get inviteRevoked;
+
+  /// Error message when invite link generation fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to generate invite link'**
+  String get generateInviteError;
+
+  /// Error message when invite link revocation fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to revoke invite link'**
+  String get revokeInviteError;
+
+  /// Message shared via native share sheet with the invite link
+  ///
+  /// In en, this message translates to:
+  /// **'Join my group on PlayWithMe! {url}'**
+  String inviteLinkShareMessage(String url);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1657,4 +1657,42 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get myStats => 'Meine Statistiken';
+
+  @override
+  String get generateInviteLink => 'Einladungslink erstellen';
+
+  @override
+  String get copyLink => 'Link kopieren';
+
+  @override
+  String get shareLink => 'Teilen';
+
+  @override
+  String get linkCopied => 'Link in die Zwischenablage kopiert';
+
+  @override
+  String get inviteLinkSectionTitle => 'Mitglieder einladen';
+
+  @override
+  String get inviteLinkDescription =>
+      'Teile diesen Link, um Personen einzuladen, der Gruppe beizutreten.';
+
+  @override
+  String get revokeInvite => 'Einladung widerrufen';
+
+  @override
+  String get inviteRevoked => 'Einladungslink widerrufen';
+
+  @override
+  String get generateInviteError =>
+      'Einladungslink konnte nicht erstellt werden';
+
+  @override
+  String get revokeInviteError =>
+      'Einladungslink konnte nicht widerrufen werden';
+
+  @override
+  String inviteLinkShareMessage(String url) {
+    return 'Tritt meiner Gruppe auf PlayWithMe bei! $url';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1634,4 +1634,40 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get myStats => 'My Stats';
+
+  @override
+  String get generateInviteLink => 'Generate Invite Link';
+
+  @override
+  String get copyLink => 'Copy Link';
+
+  @override
+  String get shareLink => 'Share';
+
+  @override
+  String get linkCopied => 'Link copied to clipboard';
+
+  @override
+  String get inviteLinkSectionTitle => 'Invite Members';
+
+  @override
+  String get inviteLinkDescription =>
+      'Share this link to invite people to join the group.';
+
+  @override
+  String get revokeInvite => 'Revoke Invite';
+
+  @override
+  String get inviteRevoked => 'Invite link revoked';
+
+  @override
+  String get generateInviteError => 'Failed to generate invite link';
+
+  @override
+  String get revokeInviteError => 'Failed to revoke invite link';
+
+  @override
+  String inviteLinkShareMessage(String url) {
+    return 'Join my group on PlayWithMe! $url';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1651,4 +1651,41 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get myStats => 'Mis Estadísticas';
+
+  @override
+  String get generateInviteLink => 'Generar enlace de invitación';
+
+  @override
+  String get copyLink => 'Copiar enlace';
+
+  @override
+  String get shareLink => 'Compartir';
+
+  @override
+  String get linkCopied => 'Enlace copiado al portapapeles';
+
+  @override
+  String get inviteLinkSectionTitle => 'Invitar miembros';
+
+  @override
+  String get inviteLinkDescription =>
+      'Comparte este enlace para invitar a personas a unirse al grupo.';
+
+  @override
+  String get revokeInvite => 'Revocar invitación';
+
+  @override
+  String get inviteRevoked => 'Enlace de invitación revocado';
+
+  @override
+  String get generateInviteError =>
+      'No se pudo generar el enlace de invitación';
+
+  @override
+  String get revokeInviteError => 'No se pudo revocar el enlace de invitación';
+
+  @override
+  String inviteLinkShareMessage(String url) {
+    return '¡Únete a mi grupo en PlayWithMe! $url';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1661,4 +1661,42 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get myStats => 'Mes Stats';
+
+  @override
+  String get generateInviteLink => 'Générer un lien d\'invitation';
+
+  @override
+  String get copyLink => 'Copier le lien';
+
+  @override
+  String get shareLink => 'Partager';
+
+  @override
+  String get linkCopied => 'Lien copié dans le presse-papiers';
+
+  @override
+  String get inviteLinkSectionTitle => 'Inviter des membres';
+
+  @override
+  String get inviteLinkDescription =>
+      'Partagez ce lien pour inviter des personnes à rejoindre le groupe.';
+
+  @override
+  String get revokeInvite => 'Révoquer l\'invitation';
+
+  @override
+  String get inviteRevoked => 'Lien d\'invitation révoqué';
+
+  @override
+  String get generateInviteError =>
+      'Impossible de générer le lien d\'invitation';
+
+  @override
+  String get revokeInviteError =>
+      'Impossible de révoquer le lien d\'invitation';
+
+  @override
+  String inviteLinkShareMessage(String url) {
+    return 'Rejoins mon groupe sur PlayWithMe ! $url';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1649,4 +1649,40 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get myStats => 'Le Mie Statistiche';
+
+  @override
+  String get generateInviteLink => 'Genera link di invito';
+
+  @override
+  String get copyLink => 'Copia link';
+
+  @override
+  String get shareLink => 'Condividi';
+
+  @override
+  String get linkCopied => 'Link copiato negli appunti';
+
+  @override
+  String get inviteLinkSectionTitle => 'Invita membri';
+
+  @override
+  String get inviteLinkDescription =>
+      'Condividi questo link per invitare persone a unirsi al gruppo.';
+
+  @override
+  String get revokeInvite => 'Revoca invito';
+
+  @override
+  String get inviteRevoked => 'Link di invito revocato';
+
+  @override
+  String get generateInviteError => 'Impossibile generare il link di invito';
+
+  @override
+  String get revokeInviteError => 'Impossibile revocare il link di invito';
+
+  @override
+  String inviteLinkShareMessage(String url) {
+    return 'Unisciti al mio gruppo su PlayWithMe! $url';
+  }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,8 @@ import firebase_core
 import firebase_messaging
 import firebase_storage
 import flutter_local_notifications
+import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -26,5 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -940,6 +940,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.19"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1052,6 +1076,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1297,6 +1337,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   vector_math:
     dependency: transitive
     description:
@@ -1361,6 +1441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,9 @@ dependencies:
   flutter_local_notifications: ^18.0.1
   fl_chart: ^0.69.0
 
+  # Sharing
+  share_plus: ^10.1.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart
+++ b/test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart
@@ -1,0 +1,387 @@
+// Tests GroupInviteLinkBloc state transitions for invite generation and revocation.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart';
+
+class MockGroupInviteLinkRepository extends Mock
+    implements GroupInviteLinkRepository {}
+
+void main() {
+  group('GroupInviteLinkBloc', () {
+    late GroupInviteLinkBloc bloc;
+    late MockGroupInviteLinkRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockGroupInviteLinkRepository();
+      bloc = GroupInviteLinkBloc(repository: mockRepository);
+    });
+
+    tearDown(() {
+      bloc.close();
+    });
+
+    test('initial state is GroupInviteLinkInitial', () {
+      expect(bloc.state, equals(const GroupInviteLinkInitial()));
+    });
+
+    group('GenerateInvite', () {
+      const groupId = 'group-123';
+      const inviteId = 'invite-456';
+      const token = 'abc123token';
+      const deepLinkUrl = 'https://playwithme.app/invite/abc123token';
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, generated] when invite is created successfully',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenAnswer((_) async => (
+                inviteId: inviteId,
+                token: token,
+                deepLinkUrl: deepLinkUrl,
+              ));
+          return bloc;
+        },
+        act: (bloc) =>
+            bloc.add(const GenerateInvite(groupId: groupId)),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          const GroupInviteLinkGenerated(
+            deepLinkUrl: deepLinkUrl,
+            inviteId: inviteId,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.createGroupInvite(
+                groupId: groupId,
+                expiresInHours: null,
+                usageLimit: null,
+              )).called(1);
+        },
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'passes expiresInHours and usageLimit to repository',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenAnswer((_) async => (
+                inviteId: inviteId,
+                token: token,
+                deepLinkUrl: deepLinkUrl,
+              ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const GenerateInvite(
+          groupId: groupId,
+          expiresInHours: 48,
+          usageLimit: 10,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          const GroupInviteLinkGenerated(
+            deepLinkUrl: deepLinkUrl,
+            inviteId: inviteId,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.createGroupInvite(
+                groupId: groupId,
+                expiresInHours: 48,
+                usageLimit: 10,
+              )).called(1);
+        },
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when repository throws GroupInviteLinkException',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenThrow(GroupInviteLinkException(
+            'You do not have permission to create invite links for this group.',
+            code: 'permission-denied',
+          ));
+          return bloc;
+        },
+        act: (bloc) =>
+            bloc.add(const GenerateInvite(groupId: groupId)),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having((e) => e.message, 'message',
+                  'You do not have permission to create invite links for this group.')
+              .having((e) => e.errorCode, 'errorCode', 'permission-denied')
+              .having((e) => e.isRetryable, 'isRetryable', false),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] with retryable flag for internal errors',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenThrow(GroupInviteLinkException(
+            'Failed to create invite link. Please try again later.',
+            code: 'internal',
+          ));
+          return bloc;
+        },
+        act: (bloc) =>
+            bloc.add(const GenerateInvite(groupId: groupId)),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having((e) => e.message, 'message',
+                  'Failed to create invite link. Please try again later.')
+              .having((e) => e.isRetryable, 'isRetryable', true),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when capacity is reached',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenThrow(GroupInviteLinkException(
+            'This group is at capacity and cannot accept new members.',
+            code: 'failed-precondition',
+          ));
+          return bloc;
+        },
+        act: (bloc) =>
+            bloc.add(const GenerateInvite(groupId: groupId)),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having((e) => e.message, 'message',
+                  'This group is at capacity and cannot accept new members.')
+              .having((e) => e.isRetryable, 'isRetryable', true),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when unexpected exception occurs',
+        build: () {
+          when(() => mockRepository.createGroupInvite(
+                groupId: any(named: 'groupId'),
+                expiresInHours: any(named: 'expiresInHours'),
+                usageLimit: any(named: 'usageLimit'),
+              )).thenThrow(Exception('Network timeout'));
+          return bloc;
+        },
+        act: (bloc) =>
+            bloc.add(const GenerateInvite(groupId: groupId)),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having(
+                  (e) => e.errorCode, 'errorCode', 'GENERATE_INVITE_ERROR'),
+        ],
+      );
+    });
+
+    group('RevokeInvite', () {
+      const groupId = 'group-123';
+      const inviteId = 'invite-456';
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, revoked] when invite is revoked successfully',
+        build: () {
+          when(() => mockRepository.revokeGroupInvite(
+                groupId: any(named: 'groupId'),
+                inviteId: any(named: 'inviteId'),
+              )).thenAnswer((_) async {});
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const RevokeInvite(
+          groupId: groupId,
+          inviteId: inviteId,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          const GroupInviteLinkRevoked(),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.revokeGroupInvite(
+                groupId: groupId,
+                inviteId: inviteId,
+              )).called(1);
+        },
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when revocation fails with permission denied',
+        build: () {
+          when(() => mockRepository.revokeGroupInvite(
+                groupId: any(named: 'groupId'),
+                inviteId: any(named: 'inviteId'),
+              )).thenThrow(GroupInviteLinkException(
+            'You do not have permission to revoke this invite.',
+            code: 'permission-denied',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const RevokeInvite(
+          groupId: groupId,
+          inviteId: inviteId,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having((e) => e.message, 'message',
+                  'You do not have permission to revoke this invite.')
+              .having((e) => e.errorCode, 'errorCode', 'permission-denied')
+              .having((e) => e.isRetryable, 'isRetryable', false),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when invite not found',
+        build: () {
+          when(() => mockRepository.revokeGroupInvite(
+                groupId: any(named: 'groupId'),
+                inviteId: any(named: 'inviteId'),
+              )).thenThrow(GroupInviteLinkException(
+            'The invite does not exist.',
+            code: 'not-found',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const RevokeInvite(
+          groupId: groupId,
+          inviteId: inviteId,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having(
+                  (e) => e.message, 'message', 'The invite does not exist.')
+              .having((e) => e.errorCode, 'errorCode', 'not-found')
+              .having((e) => e.isRetryable, 'isRetryable', false),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when invite already revoked',
+        build: () {
+          when(() => mockRepository.revokeGroupInvite(
+                groupId: any(named: 'groupId'),
+                inviteId: any(named: 'inviteId'),
+              )).thenThrow(GroupInviteLinkException(
+            'This invite is already revoked.',
+            code: 'already-exists',
+          ));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const RevokeInvite(
+          groupId: groupId,
+          inviteId: inviteId,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having((e) => e.message, 'message',
+                  'This invite is already revoked.')
+              .having((e) => e.errorCode, 'errorCode', 'already-exists')
+              .having((e) => e.isRetryable, 'isRetryable', false),
+        ],
+      );
+
+      blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
+        'emits [loading, error] when unexpected exception occurs',
+        build: () {
+          when(() => mockRepository.revokeGroupInvite(
+                groupId: any(named: 'groupId'),
+                inviteId: any(named: 'inviteId'),
+              )).thenThrow(Exception('Connection failed'));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const RevokeInvite(
+          groupId: groupId,
+          inviteId: inviteId,
+        )),
+        expect: () => [
+          const GroupInviteLinkLoading(),
+          isA<GroupInviteLinkError>()
+              .having(
+                  (e) => e.errorCode, 'errorCode', 'REVOKE_INVITE_ERROR'),
+        ],
+      );
+    });
+
+    group('Event equality', () {
+      test('GenerateInvite events with same props are equal', () {
+        const event1 = GenerateInvite(groupId: 'group-1');
+        const event2 = GenerateInvite(groupId: 'group-1');
+        expect(event1, equals(event2));
+      });
+
+      test('GenerateInvite events with different props are not equal', () {
+        const event1 = GenerateInvite(groupId: 'group-1');
+        const event2 = GenerateInvite(groupId: 'group-2');
+        expect(event1, isNot(equals(event2)));
+      });
+
+      test('RevokeInvite events with same props are equal', () {
+        const event1 =
+            RevokeInvite(groupId: 'group-1', inviteId: 'invite-1');
+        const event2 =
+            RevokeInvite(groupId: 'group-1', inviteId: 'invite-1');
+        expect(event1, equals(event2));
+      });
+
+      test('RevokeInvite events with different props are not equal', () {
+        const event1 =
+            RevokeInvite(groupId: 'group-1', inviteId: 'invite-1');
+        const event2 =
+            RevokeInvite(groupId: 'group-1', inviteId: 'invite-2');
+        expect(event1, isNot(equals(event2)));
+      });
+    });
+
+    group('State equality', () {
+      test('GroupInviteLinkGenerated states with same props are equal', () {
+        const state1 = GroupInviteLinkGenerated(
+          deepLinkUrl: 'https://example.com/invite/abc',
+          inviteId: 'invite-1',
+        );
+        const state2 = GroupInviteLinkGenerated(
+          deepLinkUrl: 'https://example.com/invite/abc',
+          inviteId: 'invite-1',
+        );
+        expect(state1, equals(state2));
+      });
+
+      test('GroupInviteLinkError states with same props are equal', () {
+        const state1 = GroupInviteLinkError(
+          message: 'Error',
+          errorCode: 'ERR',
+          isRetryable: false,
+        );
+        const state2 = GroupInviteLinkError(
+          message: 'Error',
+          errorCode: 'ERR',
+          isRetryable: false,
+        );
+        expect(state1, equals(state2));
+      });
+    });
+  });
+}

--- a/test/widget/features/groups/presentation/pages/group_details_page_test.dart
+++ b/test/widget/features/groups/presentation/pages/group_details_page_test.dart
@@ -24,6 +24,10 @@ import 'package:play_with_me/features/auth/presentation/bloc/authentication/auth
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/groups/presentation/pages/group_details_page.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
 
 class MockGroupMemberBloc
     extends MockBloc<GroupMemberEvent, GroupMemberState>
@@ -45,6 +49,13 @@ class MockGameRepository extends Mock implements GameRepository {}
 
 class MockFriendRepository extends Mock implements FriendRepository {}
 
+class MockGroupInviteLinkBloc
+    extends MockBloc<GroupInviteLinkEvent, GroupInviteLinkState>
+    implements GroupInviteLinkBloc {}
+
+class MockGroupInviteLinkRepository extends Mock
+    implements GroupInviteLinkRepository {}
+
 class FakeGroupMemberEvent extends Fake implements GroupMemberEvent {}
 
 class FakeGroupMemberState extends Fake implements GroupMemberState {}
@@ -57,6 +68,7 @@ void main() {
   late MockUserRepository mockUserRepository;
   late MockGameRepository mockGameRepository;
   late MockFriendRepository mockFriendRepository;
+  late MockGroupInviteLinkBloc mockGroupInviteLinkBloc;
 
   const testUserId = 'test-user-123';
   const testGroupId = 'test-group-123';
@@ -113,6 +125,9 @@ void main() {
     mockUserRepository = MockUserRepository();
     mockGameRepository = MockGameRepository();
     mockFriendRepository = MockFriendRepository();
+    mockGroupInviteLinkBloc = MockGroupInviteLinkBloc();
+    when(() => mockGroupInviteLinkBloc.state)
+        .thenReturn(const GroupInviteLinkInitial());
 
     when(() => mockGroupMemberBloc.state)
         .thenReturn(const GroupMemberInitial());
@@ -148,6 +163,11 @@ void main() {
     }
     sl.registerFactory<GroupMemberBloc>(() => mockGroupMemberBloc);
 
+    if (sl.isRegistered<GroupInviteLinkBloc>()) {
+      sl.unregister<GroupInviteLinkBloc>();
+    }
+    sl.registerFactory<GroupInviteLinkBloc>(() => mockGroupInviteLinkBloc);
+
     if (sl.isRegistered<FriendRepository>()) {
       sl.unregister<FriendRepository>();
     }
@@ -160,6 +180,9 @@ void main() {
 
     if (sl.isRegistered<GroupMemberBloc>()) {
       sl.unregister<GroupMemberBloc>();
+    }
+    if (sl.isRegistered<GroupInviteLinkBloc>()) {
+      sl.unregister<GroupInviteLinkBloc>();
     }
     if (sl.isRegistered<FriendRepository>()) {
       sl.unregister<FriendRepository>();

--- a/test/widget/features/groups/presentation/widgets/invite_link_section_test.dart
+++ b/test/widget/features/groups/presentation/widgets/invite_link_section_test.dart
@@ -1,0 +1,243 @@
+// Widget tests for InviteLinkSection covering all UI states and user interactions.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_event.dart';
+import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_state.dart';
+import 'package:play_with_me/features/groups/presentation/widgets/invite_link_section.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockGroupInviteLinkBloc
+    extends MockBloc<GroupInviteLinkEvent, GroupInviteLinkState>
+    implements GroupInviteLinkBloc {}
+
+void main() {
+  late MockGroupInviteLinkBloc mockBloc;
+
+  setUp(() {
+    mockBloc = MockGroupInviteLinkBloc();
+  });
+
+  Widget buildTestWidget({String groupId = 'group-123'}) {
+    return MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: Scaffold(
+        body: BlocProvider<GroupInviteLinkBloc>.value(
+          value: mockBloc,
+          child: InviteLinkSection(groupId: groupId),
+        ),
+      ),
+    );
+  }
+
+  group('InviteLinkSection', () {
+    testWidgets('shows section title and description', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkInitial());
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invite Members'), findsOneWidget);
+      expect(
+        find.text(
+            'Share this link to invite people to join the group.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows generate button in initial state', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkInitial());
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Generate Invite Link'), findsOneWidget);
+      expect(find.byIcon(Icons.link), findsOneWidget);
+    });
+
+    testWidgets('tapping generate button dispatches GenerateInvite event',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkInitial());
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Generate Invite Link'));
+
+      verify(
+        () => mockBloc.add(const GenerateInvite(groupId: 'group-123')),
+      ).called(1);
+    });
+
+    testWidgets('shows loading indicator in loading state', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkLoading());
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Generate Invite Link'), findsNothing);
+    });
+
+    testWidgets('shows generated link with copy and share buttons',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
+        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        inviteId: 'invite-456',
+      ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('https://playwithme.app/invite/abc123'),
+        findsOneWidget,
+      );
+      expect(find.text('Copy Link'), findsOneWidget);
+      expect(find.text('Share'), findsOneWidget);
+      expect(find.text('Revoke Invite'), findsOneWidget);
+    });
+
+    testWidgets('copy button copies link to clipboard', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
+        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        inviteId: 'invite-456',
+      ));
+
+      // Set up clipboard mock
+      final List<MethodCall> clipboardCalls = [];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall methodCall) async {
+          clipboardCalls.add(methodCall);
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy Link'));
+      await tester.pump();
+
+      // Verify clipboard was called with the right data
+      expect(
+        clipboardCalls.any((call) => call.method == 'Clipboard.setData'),
+        isTrue,
+      );
+
+      // Verify snackbar appears
+      expect(find.text('Link copied to clipboard'), findsOneWidget);
+
+      // Clean up
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    testWidgets('revoke button dispatches RevokeInvite event',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
+        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        inviteId: 'invite-456',
+      ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Revoke Invite'));
+
+      verify(
+        () => mockBloc.add(const RevokeInvite(
+          groupId: 'group-123',
+          inviteId: 'invite-456',
+        )),
+      ).called(1);
+    });
+
+    testWidgets('shows generate button after revocation', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkRevoked());
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Generate Invite Link'), findsOneWidget);
+    });
+
+    testWidgets('shows generate button after error', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkError(
+        message: 'Some error',
+      ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Generate Invite Link'), findsOneWidget);
+    });
+
+    testWidgets('shows error snackbar when error state emitted',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkInitial());
+      whenListen(
+        mockBloc,
+        Stream<GroupInviteLinkState>.fromIterable([
+          const GroupInviteLinkError(
+              message: 'Failed to generate invite link'),
+        ]),
+        initialState: const GroupInviteLinkInitial(),
+      );
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      expect(
+        find.text('Failed to generate invite link'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows revoked snackbar when revoked state emitted',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkInitial());
+      whenListen(
+        mockBloc,
+        Stream<GroupInviteLinkState>.fromIterable([
+          const GroupInviteLinkRevoked(),
+        ]),
+        initialState: const GroupInviteLinkInitial(),
+      );
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      expect(find.text('Invite link revoked'), findsOneWidget);
+    });
+
+    testWidgets('shows copy and share icons', (tester) async {
+      when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
+        deepLinkUrl: 'https://playwithme.app/invite/test',
+        inviteId: 'inv-1',
+      ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.copy), findsOneWidget);
+      expect(find.byIcon(Icons.share), findsOneWidget);
+      expect(find.byIcon(Icons.link_off), findsOneWidget);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,8 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -26,4 +28,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FirebaseStoragePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,8 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   firebase_storage
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary

- Implement shareable group invite link generation UI in the Group Details page
- Add `GroupInviteLinkBloc` with `GenerateInvite` and `RevokeInvite` event handling following BLoC + Repository pattern
- Add `GroupInviteLinkRepository` interface and `FirestoreGroupInviteLinkRepository` implementation calling `createGroupInvite` and `revokeGroupInvite` Cloud Functions
- Add `InviteLinkSection` widget with generate button, link display, copy-to-clipboard, native share sheet, and revoke functionality
- Integrate into `GroupDetailsPage` with permission-based visibility (`canUserInviteOthers`)

## Changes

### New Files
- `lib/core/domain/repositories/group_invite_link_repository.dart` — Repository interface
- `lib/core/data/repositories/firestore_group_invite_link_repository.dart` — Cloud Functions implementation
- `lib/features/groups/presentation/bloc/group_invite_link/` — BLoC events, states, and bloc
- `lib/features/groups/presentation/widgets/invite_link_section.dart` — UI widget

### Modified Files
- `lib/core/domain/exceptions/repository_exceptions.dart` — Added `GroupInviteLinkException`
- `lib/core/utils/error_messages.dart` — Added `GroupInviteLinkErrorMessages`
- `lib/core/services/service_locator.dart` — Registered repository and BLoC
- `lib/features/groups/presentation/pages/group_details_page.dart` — Integrated `InviteLinkSection`
- `lib/l10n/app_{en,fr,de,es,it}.arb` — Added 12 localization strings in 5 languages
- `pubspec.yaml` — Added `share_plus` dependency

### Test Files
- `test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart` — 18 unit tests
- `test/widget/features/groups/presentation/widgets/invite_link_section_test.dart` — 12 widget tests
- `test/widget/features/groups/presentation/pages/group_details_page_test.dart` — Updated for new BLoC provider

## Test plan

- [x] 18 BLoC unit tests covering all state transitions, error handling, and event equality
- [x] 12 widget tests covering initial state, loading, generated link, copy, share, revoke, error and revoked snackbars
- [x] All 3144 existing unit + widget tests still pass (0 regressions)
- [x] `flutter analyze` passes with 0 new warnings
- [ ] Manual test: verify generate button calls Cloud Function and displays link
- [ ] Manual test: verify copy button copies URL to clipboard
- [ ] Manual test: verify share button opens native share sheet
- [ ] Manual test: verify revoke button disables the link
- [ ] Manual test: verify only eligible members see the invite section