### PR TITLE
Story 17.5: Deep Link Handling in Flutter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,27 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!-- App Links for deep linking (invite links) -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="https"
+                    android:host="playwithme.app"
+                    android:pathPrefix="/invite"/>
+            </intent-filter>
+
+            <!-- Custom URL scheme fallback -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="playwithme"
+                    android:host="invite"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/docs/epic-17/story-17.5/DEEP_LINK_HANDLING.md
+++ b/docs/epic-17/story-17.5/DEEP_LINK_HANDLING.md
@@ -1,0 +1,78 @@
+# Story 17.5 — Deep Link Handling in Flutter
+
+## Overview
+
+Implements deep link handling for invite links using native App Links (Android) and Universal Links (iOS). Firebase Dynamic Links is deprecated (August 2025), so this uses the `app_links` package instead.
+
+## Architecture
+
+### Link Format
+```
+https://playwithme.app/invite/{token}
+playwithme://invite/{token}  (fallback custom scheme)
+```
+
+### Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `DeepLinkService` | `lib/core/services/deep_link_service.dart` | Abstract interface for deep link handling |
+| `AppLinksDeepLinkService` | `lib/core/services/app_links_deep_link_service.dart` | Implementation using `app_links` package |
+| `PendingInviteStorage` | `lib/core/services/pending_invite_storage.dart` | SharedPreferences storage for pending tokens |
+| `DeepLinkBloc` | `lib/core/presentation/bloc/deep_link/` | BLoC managing deep link state |
+| `RouteGenerator` | `lib/app/route_generator.dart` | Centralized route generation with deep link support |
+
+### Data Flow
+
+```
+Deep Link URL → AppLinksDeepLinkService → DeepLinkBloc → PendingInviteStorage
+                                                ↓
+                                        UI (Auth check)
+                                                ↓
+                              Authenticated: process invite (Story 17.6)
+                              Unauthenticated: store token → auth flow
+```
+
+### Link Handling Scenarios
+
+| Scenario | Behavior |
+|----------|----------|
+| Cold start with deep link | `getInitialInviteToken()` extracts token → stored → BLoC emits `DeepLinkPendingInvite` |
+| Foreground deep link | `inviteTokenStream` emits token → BLoC stores and emits |
+| App restart with stored token | `PendingInviteStorage.retrieve()` returns token → BLoC emits pending state |
+| After invite processed | `ClearPendingInvite` event → storage cleared → `DeepLinkNoInvite` state |
+
+## Routing Refactor
+
+Replaced `routes:` map with `onGenerateRoute` in `play_with_me_app.dart`:
+
+- All existing routes preserved (`/login`, `/register`, `/forgot-password`, `/my-community`)
+- Deep link routes handled (`/invite/{token}`)
+- Unknown routes show localized "Page Not Found" page
+
+## Platform Configuration
+
+### Android
+- Intent filter for `https://playwithme.app/invite/*` with `autoVerify=true`
+- Custom URL scheme fallback: `playwithme://invite/*`
+- Digital Asset Links file (`assetlinks.json`) needs deployment to web host
+
+### iOS
+- Associated Domains entitlement: `applinks:playwithme.app`
+- Custom URL scheme: `playwithme`
+- Apple App Site Association file needs deployment to web host
+
+## Testing
+
+- **Unit tests**: `PendingInviteStorage` (4 tests), `DeepLinkBloc` (7 tests), `RouteGenerator` (9 tests)
+- **Integration tests**: Deep link flow with Firebase Emulator (deferred to Story 17.6+)
+
+## Dependencies
+
+- `app_links: ^6.4.0` — Native App Links / Universal Links handling
+
+## What's Next
+
+- **Story 17.6**: Auth routing — process pending invite after authentication
+- **Story 17.7**: Account creation with invite context
+- **Story 17.11**: Deferred deep linking evaluation (Branch.io)

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -726,6 +727,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -748,6 +750,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -826,6 +829,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -923,6 +927,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1020,6 +1025,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1114,6 +1120,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1205,6 +1212,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1296,6 +1304,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1385,6 +1394,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1474,6 +1484,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1563,6 +1574,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,5 +49,20 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.playwithme.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>playwithme</string>
+			</array>
+		</dict>
+	</array>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:playwithme.app</string>
+	</array>
+</dict>
+</plist>

--- a/lib/app/play_with_me_app.dart
+++ b/lib/app/play_with_me_app.dart
@@ -2,14 +2,15 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:play_with_me/app/route_generator.dart';
 import 'package:play_with_me/core/config/environment_config.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_event.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
-import 'package:play_with_me/features/auth/presentation/pages/registration_page.dart';
-import 'package:play_with_me/features/auth/presentation/pages/password_reset_page.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/login/login_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/registration/registration_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/password_reset/password_reset_bloc.dart';
@@ -66,6 +67,9 @@ class PlayWithMeApp extends StatelessWidget {
         ),
         BlocProvider<PasswordResetBloc>(
           create: (context) => sl<PasswordResetBloc>(),
+        ),
+        BlocProvider<DeepLinkBloc>(
+          create: (context) => sl<DeepLinkBloc>()..add(const InitializeDeepLinks()),
         ),
         BlocProvider<LocalePreferencesBloc>(
           create: (context) => LocalePreferencesBloc(
@@ -131,12 +135,7 @@ class PlayWithMeApp extends StatelessWidget {
                 }
               },
             ),
-            routes: {
-              '/login': (context) => const LoginPage(),
-              '/register': (context) => const RegistrationPage(),
-              '/forgot-password': (context) => const PasswordResetPage(),
-              '/my-community': (context) => const MyCommunityPage(),
-            },
+            onGenerateRoute: RouteGenerator.generateRoute,
           );
         },
       ),

--- a/lib/app/route_generator.dart
+++ b/lib/app/route_generator.dart
@@ -1,0 +1,61 @@
+// Generates routes for the app, including deep link handling for /invite/{token}.
+import 'package:flutter/material.dart';
+import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
+import 'package:play_with_me/features/auth/presentation/pages/registration_page.dart';
+import 'package:play_with_me/features/auth/presentation/pages/password_reset_page.dart';
+import 'package:play_with_me/features/friends/presentation/pages/my_community_page.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class RouteGenerator {
+  static Route<dynamic> generateRoute(RouteSettings settings) {
+    final uri = Uri.tryParse(settings.name ?? '');
+    final routeName = settings.name;
+
+    // Handle deep link routes: /invite/{token}
+    if (uri != null && uri.pathSegments.length == 2 && uri.pathSegments[0] == 'invite') {
+      // Deep link invite route — no dedicated page yet.
+      // The DeepLinkBloc handles token extraction and storage.
+      // For now, redirect to login page so auth flow can proceed.
+      return _buildRoute(const LoginPage(), settings);
+    }
+
+    // Standard named routes
+    switch (routeName) {
+      case '/login':
+        return _buildRoute(const LoginPage(), settings);
+      case '/register':
+        return _buildRoute(const RegistrationPage(), settings);
+      case '/forgot-password':
+        return _buildRoute(const PasswordResetPage(), settings);
+      case '/my-community':
+        return _buildRoute(const MyCommunityPage(), settings);
+      default:
+        return _buildRoute(const _UnknownRoutePage(), settings);
+    }
+  }
+
+  static MaterialPageRoute<dynamic> _buildRoute(
+    Widget page,
+    RouteSettings settings,
+  ) {
+    return MaterialPageRoute(
+      builder: (_) => page,
+      settings: settings,
+    );
+  }
+}
+
+class _UnknownRoutePage extends StatelessWidget {
+  const _UnknownRoutePage();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.pageNotFound)),
+      body: Center(
+        child: Text(l10n.pageNotFoundMessage),
+      ),
+    );
+  }
+}

--- a/lib/core/presentation/bloc/deep_link/deep_link_bloc.dart
+++ b/lib/core/presentation/bloc/deep_link/deep_link_bloc.dart
@@ -1,0 +1,77 @@
+// BLoC for managing deep link state and pending invites.
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_event.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_state.dart';
+import 'package:play_with_me/core/services/deep_link_service.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+
+class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
+  final DeepLinkService _deepLinkService;
+  final PendingInviteStorage _pendingInviteStorage;
+  StreamSubscription<String?>? _tokenSubscription;
+
+  DeepLinkBloc({
+    required DeepLinkService deepLinkService,
+    required PendingInviteStorage pendingInviteStorage,
+  })  : _deepLinkService = deepLinkService,
+        _pendingInviteStorage = pendingInviteStorage,
+        super(const DeepLinkInitial()) {
+    on<InitializeDeepLinks>(_onInitialize);
+    on<InviteTokenReceived>(_onInviteTokenReceived);
+    on<ClearPendingInvite>(_onClearPendingInvite);
+  }
+
+  Future<void> _onInitialize(
+    InitializeDeepLinks event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    // Check for stored pending invite first
+    final storedToken = await _pendingInviteStorage.retrieve();
+    if (storedToken != null) {
+      emit(DeepLinkPendingInvite(token: storedToken));
+      return;
+    }
+
+    // Check for initial deep link (cold start)
+    final initialToken = await _deepLinkService.getInitialInviteToken();
+    if (initialToken != null) {
+      await _pendingInviteStorage.store(initialToken);
+      emit(DeepLinkPendingInvite(token: initialToken));
+    } else {
+      emit(const DeepLinkNoInvite());
+    }
+
+    // Listen for foreground deep links
+    _tokenSubscription = _deepLinkService.inviteTokenStream.listen(
+      (token) {
+        if (token != null) {
+          add(InviteTokenReceived(token));
+        }
+      },
+    );
+  }
+
+  Future<void> _onInviteTokenReceived(
+    InviteTokenReceived event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    await _pendingInviteStorage.store(event.token);
+    emit(DeepLinkPendingInvite(token: event.token));
+  }
+
+  Future<void> _onClearPendingInvite(
+    ClearPendingInvite event,
+    Emitter<DeepLinkState> emit,
+  ) async {
+    await _pendingInviteStorage.clear();
+    emit(const DeepLinkNoInvite());
+  }
+
+  @override
+  Future<void> close() {
+    _tokenSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/core/presentation/bloc/deep_link/deep_link_event.dart
+++ b/lib/core/presentation/bloc/deep_link/deep_link_event.dart
@@ -1,0 +1,26 @@
+// Events for the DeepLinkBloc.
+import 'package:equatable/equatable.dart';
+
+sealed class DeepLinkEvent extends Equatable {
+  const DeepLinkEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeDeepLinks extends DeepLinkEvent {
+  const InitializeDeepLinks();
+}
+
+class InviteTokenReceived extends DeepLinkEvent {
+  final String token;
+
+  const InviteTokenReceived(this.token);
+
+  @override
+  List<Object?> get props => [token];
+}
+
+class ClearPendingInvite extends DeepLinkEvent {
+  const ClearPendingInvite();
+}

--- a/lib/core/presentation/bloc/deep_link/deep_link_state.dart
+++ b/lib/core/presentation/bloc/deep_link/deep_link_state.dart
@@ -1,0 +1,26 @@
+// States for the DeepLinkBloc.
+import 'package:equatable/equatable.dart';
+
+sealed class DeepLinkState extends Equatable {
+  const DeepLinkState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class DeepLinkInitial extends DeepLinkState {
+  const DeepLinkInitial();
+}
+
+class DeepLinkPendingInvite extends DeepLinkState {
+  final String token;
+
+  const DeepLinkPendingInvite({required this.token});
+
+  @override
+  List<Object?> get props => [token];
+}
+
+class DeepLinkNoInvite extends DeepLinkState {
+  const DeepLinkNoInvite();
+}

--- a/lib/core/services/app_links_deep_link_service.dart
+++ b/lib/core/services/app_links_deep_link_service.dart
@@ -1,0 +1,66 @@
+// App Links / Universal Links implementation of DeepLinkService.
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:play_with_me/core/services/deep_link_service.dart';
+
+class AppLinksDeepLinkService implements DeepLinkService {
+  final AppLinks _appLinks;
+  final StreamController<String?> _tokenController =
+      StreamController<String?>.broadcast();
+  StreamSubscription<Uri>? _linkSubscription;
+
+  AppLinksDeepLinkService({AppLinks? appLinks})
+      : _appLinks = appLinks ?? AppLinks() {
+    _listenForLinks();
+  }
+
+  void _listenForLinks() {
+    _linkSubscription = _appLinks.uriLinkStream.listen(
+      (uri) {
+        final token = _extractToken(uri);
+        if (token != null) {
+          _tokenController.add(token);
+        }
+      },
+      onError: (error) {
+        debugPrint('[DeepLinkService] Link stream error: $error');
+      },
+    );
+  }
+
+  @override
+  Stream<String?> get inviteTokenStream => _tokenController.stream;
+
+  @override
+  Future<String?> getInitialInviteToken() async {
+    try {
+      final initialUri = await _appLinks.getInitialLink();
+      if (initialUri != null) {
+        return _extractToken(initialUri);
+      }
+    } catch (e) {
+      debugPrint('[DeepLinkService] Failed to get initial link: $e');
+    }
+    return null;
+  }
+
+  String? _extractToken(Uri uri) {
+    // Match paths like /invite/{token}
+    final segments = uri.pathSegments;
+    if (segments.length == 2 && segments[0] == 'invite') {
+      final token = segments[1];
+      if (token.isNotEmpty) {
+        return token;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _linkSubscription?.cancel();
+    _tokenController.close();
+  }
+}

--- a/lib/core/services/deep_link_service.dart
+++ b/lib/core/services/deep_link_service.dart
@@ -1,0 +1,6 @@
+// Abstract service for handling deep links and extracting invite tokens.
+abstract class DeepLinkService {
+  Stream<String?> get inviteTokenStream;
+  Future<String?> getInitialInviteToken();
+  void dispose();
+}

--- a/lib/core/services/pending_invite_storage.dart
+++ b/lib/core/services/pending_invite_storage.dart
@@ -1,0 +1,22 @@
+// Stores and retrieves pending invite tokens using SharedPreferences.
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PendingInviteStorage {
+  static const String _key = 'pending_invite_token';
+
+  final SharedPreferences _prefs;
+
+  PendingInviteStorage({required SharedPreferences prefs}) : _prefs = prefs;
+
+  Future<void> store(String token) async {
+    await _prefs.setString(_key, token);
+  }
+
+  Future<String?> retrieve() async {
+    return _prefs.getString(_key);
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_key);
+  }
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -52,6 +52,10 @@ import 'package:play_with_me/features/training/presentation/bloc/training_sessio
 import 'package:play_with_me/features/training/presentation/bloc/exercise/exercise_bloc.dart';
 import 'package:play_with_me/features/training/presentation/bloc/feedback/training_feedback_bloc.dart';
 import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+import 'package:play_with_me/core/services/deep_link_service.dart';
+import 'package:play_with_me/core/services/app_links_deep_link_service.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -216,6 +220,18 @@ Future<void> initializeDependencies() async {
     );
   }
 
+  if (!sl.isRegistered<PendingInviteStorage>()) {
+    sl.registerLazySingleton<PendingInviteStorage>(
+      () => PendingInviteStorage(prefs: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<DeepLinkService>()) {
+    sl.registerLazySingleton<DeepLinkService>(
+      () => AppLinksDeepLinkService(),
+    );
+  }
+
   // Register BLoCs only if not already registered
   if (!sl.isRegistered<AuthenticationBloc>()) {
     sl.registerFactory<AuthenticationBloc>(
@@ -353,6 +369,15 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<GroupInviteLinkBloc>()) {
     sl.registerFactory<GroupInviteLinkBloc>(
       () => GroupInviteLinkBloc(repository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<DeepLinkBloc>()) {
+    sl.registerFactory<DeepLinkBloc>(
+      () => DeepLinkBloc(
+        deepLinkService: sl(),
+        pendingInviteStorage: sl(),
+      ),
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -511,5 +511,7 @@
   "inviteRevoked": "Einladungslink widerrufen",
   "generateInviteError": "Einladungslink konnte nicht erstellt werden",
   "revokeInviteError": "Einladungslink konnte nicht widerrufen werden",
-  "inviteLinkShareMessage": "Tritt meiner Gruppe auf PlayWithMe bei! {url}"
+  "inviteLinkShareMessage": "Tritt meiner Gruppe auf PlayWithMe bei! {url}",
+  "pageNotFound": "Seite nicht gefunden",
+  "pageNotFoundMessage": "Die angeforderte Seite konnte nicht gefunden werden."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2418,5 +2418,15 @@
     "placeholders": {
       "url": {"type": "String"}
     }
+  },
+
+  "pageNotFound": "Page Not Found",
+  "@pageNotFound": {
+    "description": "Title shown when navigating to an unknown route"
+  },
+
+  "pageNotFoundMessage": "The requested page could not be found.",
+  "@pageNotFoundMessage": {
+    "description": "Message shown when navigating to an unknown route"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -511,5 +511,7 @@
   "inviteRevoked": "Enlace de invitación revocado",
   "generateInviteError": "No se pudo generar el enlace de invitación",
   "revokeInviteError": "No se pudo revocar el enlace de invitación",
-  "inviteLinkShareMessage": "¡Únete a mi grupo en PlayWithMe! {url}"
+  "inviteLinkShareMessage": "¡Únete a mi grupo en PlayWithMe! {url}",
+  "pageNotFound": "Página no encontrada",
+  "pageNotFoundMessage": "La página solicitada no se pudo encontrar."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -511,5 +511,7 @@
   "inviteRevoked": "Lien d'invitation révoqué",
   "generateInviteError": "Impossible de générer le lien d'invitation",
   "revokeInviteError": "Impossible de révoquer le lien d'invitation",
-  "inviteLinkShareMessage": "Rejoins mon groupe sur PlayWithMe ! {url}"
+  "inviteLinkShareMessage": "Rejoins mon groupe sur PlayWithMe ! {url}",
+  "pageNotFound": "Page introuvable",
+  "pageNotFoundMessage": "La page demandée est introuvable."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -511,5 +511,7 @@
   "inviteRevoked": "Link di invito revocato",
   "generateInviteError": "Impossibile generare il link di invito",
   "revokeInviteError": "Impossibile revocare il link di invito",
-  "inviteLinkShareMessage": "Unisciti al mio gruppo su PlayWithMe! {url}"
+  "inviteLinkShareMessage": "Unisciti al mio gruppo su PlayWithMe! {url}",
+  "pageNotFound": "Pagina non trovata",
+  "pageNotFoundMessage": "La pagina richiesta non è stata trovata."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3127,6 +3127,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Join my group on PlayWithMe! {url}'**
   String inviteLinkShareMessage(String url);
+
+  /// Title shown when navigating to an unknown route
+  ///
+  /// In en, this message translates to:
+  /// **'Page Not Found'**
+  String get pageNotFound;
+
+  /// Message shown when navigating to an unknown route
+  ///
+  /// In en, this message translates to:
+  /// **'The requested page could not be found.'**
+  String get pageNotFoundMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1695,4 +1695,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String inviteLinkShareMessage(String url) {
     return 'Tritt meiner Gruppe auf PlayWithMe bei! $url';
   }
+
+  @override
+  String get pageNotFound => 'Seite nicht gefunden';
+
+  @override
+  String get pageNotFoundMessage =>
+      'Die angeforderte Seite konnte nicht gefunden werden.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1670,4 +1670,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String inviteLinkShareMessage(String url) {
     return 'Join my group on PlayWithMe! $url';
   }
+
+  @override
+  String get pageNotFound => 'Page Not Found';
+
+  @override
+  String get pageNotFoundMessage => 'The requested page could not be found.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1688,4 +1688,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String inviteLinkShareMessage(String url) {
     return '¡Únete a mi grupo en PlayWithMe! $url';
   }
+
+  @override
+  String get pageNotFound => 'Página no encontrada';
+
+  @override
+  String get pageNotFoundMessage =>
+      'La página solicitada no se pudo encontrar.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1699,4 +1699,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String inviteLinkShareMessage(String url) {
     return 'Rejoins mon groupe sur PlayWithMe ! $url';
   }
+
+  @override
+  String get pageNotFound => 'Page introuvable';
+
+  @override
+  String get pageNotFoundMessage => 'La page demandée est introuvable.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1685,4 +1685,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String inviteLinkShareMessage(String url) {
     return 'Unisciti al mio gruppo su PlayWithMe! $url';
   }
+
+  @override
+  String get pageNotFound => 'Pagina non trovata';
+
+  @override
+  String get pageNotFoundMessage => 'La pagina richiesta non è stata trovata.';
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  gtk
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import cloud_firestore
 import cloud_functions
 import connectivity_plus
@@ -19,6 +20,7 @@ import share_plus
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FirebaseFunctionsPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.13.2"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -639,6 +671,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,9 @@ dependencies:
   # Sharing
   share_plus: ^10.1.4
 
+  # Deep Linking
+  app_links: ^6.4.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/unit/app/route_generator_test.dart
+++ b/test/unit/app/route_generator_test.dart
@@ -1,0 +1,103 @@
+// Validates RouteGenerator generates correct routes for standard and deep link paths.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/app/route_generator.dart';
+import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
+import 'package:play_with_me/features/auth/presentation/pages/registration_page.dart';
+import 'package:play_with_me/features/auth/presentation/pages/password_reset_page.dart';
+import 'package:play_with_me/features/friends/presentation/pages/my_community_page.dart';
+
+void main() {
+  group('RouteGenerator', () {
+    group('standard routes', () {
+      test('generates LoginPage for /login', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/login'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+      });
+
+      test('generates RegistrationPage for /register', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/register'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<RegistrationPage>());
+      });
+
+      test('generates PasswordResetPage for /forgot-password', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/forgot-password'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<PasswordResetPage>());
+      });
+
+      test('generates MyCommunityPage for /my-community', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/my-community'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<MyCommunityPage>());
+      });
+    });
+
+    group('deep link routes', () {
+      test('generates LoginPage for /invite/{token} deep link', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/invite/abc123def456'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+      });
+
+      test('generates LoginPage for invite deep link with complex token', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/invite/R3nD0m-T0k3n_base64url'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+        final pageRoute = route as MaterialPageRoute;
+        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+      });
+    });
+
+    group('unknown routes', () {
+      test('generates unknown route page for unrecognized route', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: '/nonexistent'),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+      });
+
+      test('generates unknown route page for null route name', () {
+        final route = RouteGenerator.generateRoute(
+          const RouteSettings(name: null),
+        );
+
+        expect(route, isA<MaterialPageRoute>());
+      });
+
+      test('preserves route settings', () {
+        const settings = RouteSettings(name: '/login', arguments: 'test-arg');
+        final route = RouteGenerator.generateRoute(settings);
+
+        expect(route.settings, settings);
+      });
+    });
+  });
+}
+
+class MockBuildContext extends Fake implements BuildContext {}

--- a/test/unit/core/presentation/bloc/deep_link/deep_link_bloc_test.dart
+++ b/test/unit/core/presentation/bloc/deep_link/deep_link_bloc_test.dart
@@ -1,0 +1,157 @@
+// Validates DeepLinkBloc emits correct states during initialization, token reception, and clearing.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_event.dart';
+import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_state.dart';
+import 'package:play_with_me/core/services/deep_link_service.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+
+class MockDeepLinkService extends Mock implements DeepLinkService {}
+
+class MockPendingInviteStorage extends Mock implements PendingInviteStorage {}
+
+void main() {
+  late MockDeepLinkService mockDeepLinkService;
+  late MockPendingInviteStorage mockStorage;
+
+  setUp(() {
+    mockDeepLinkService = MockDeepLinkService();
+    mockStorage = MockPendingInviteStorage();
+  });
+
+  DeepLinkBloc buildBloc() {
+    return DeepLinkBloc(
+      deepLinkService: mockDeepLinkService,
+      pendingInviteStorage: mockStorage,
+    );
+  }
+
+  group('DeepLinkBloc', () {
+    test('initial state is DeepLinkInitial', () {
+      when(() => mockDeepLinkService.inviteTokenStream)
+          .thenAnswer((_) => const Stream.empty());
+      final bloc = buildBloc();
+      expect(bloc.state, const DeepLinkInitial());
+      bloc.close();
+    });
+
+    group('InitializeDeepLinks', () {
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'emits [DeepLinkPendingInvite] when stored token exists',
+        setUp: () {
+          when(() => mockStorage.retrieve())
+              .thenAnswer((_) async => 'stored-token');
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => const Stream.empty());
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const InitializeDeepLinks()),
+        expect: () => [
+          const DeepLinkPendingInvite(token: 'stored-token'),
+        ],
+        verify: (_) {
+          verify(() => mockStorage.retrieve()).called(1);
+          verifyNever(() => mockDeepLinkService.getInitialInviteToken());
+        },
+      );
+
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'emits [DeepLinkPendingInvite] when initial deep link token exists',
+        setUp: () {
+          when(() => mockStorage.retrieve()).thenAnswer((_) async => null);
+          when(() => mockDeepLinkService.getInitialInviteToken())
+              .thenAnswer((_) async => 'initial-token');
+          when(() => mockStorage.store('initial-token'))
+              .thenAnswer((_) async {});
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => const Stream.empty());
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const InitializeDeepLinks()),
+        expect: () => [
+          const DeepLinkPendingInvite(token: 'initial-token'),
+        ],
+        verify: (_) {
+          verify(() => mockStorage.store('initial-token')).called(1);
+        },
+      );
+
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'emits [DeepLinkNoInvite] when no stored or initial token exists',
+        setUp: () {
+          when(() => mockStorage.retrieve()).thenAnswer((_) async => null);
+          when(() => mockDeepLinkService.getInitialInviteToken())
+              .thenAnswer((_) async => null);
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => const Stream.empty());
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const InitializeDeepLinks()),
+        expect: () => [
+          const DeepLinkNoInvite(),
+        ],
+      );
+
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'listens to foreground token stream after initialization',
+        setUp: () {
+          when(() => mockStorage.retrieve()).thenAnswer((_) async => null);
+          when(() => mockDeepLinkService.getInitialInviteToken())
+              .thenAnswer((_) async => null);
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => Stream.value('stream-token'));
+          when(() => mockStorage.store('stream-token'))
+              .thenAnswer((_) async {});
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const InitializeDeepLinks()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          const DeepLinkNoInvite(),
+          const DeepLinkPendingInvite(token: 'stream-token'),
+        ],
+      );
+    });
+
+    group('InviteTokenReceived', () {
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'emits [DeepLinkPendingInvite] and stores token',
+        setUp: () {
+          when(() => mockStorage.store('new-token'))
+              .thenAnswer((_) async {});
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => const Stream.empty());
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const InviteTokenReceived('new-token')),
+        expect: () => [
+          const DeepLinkPendingInvite(token: 'new-token'),
+        ],
+        verify: (_) {
+          verify(() => mockStorage.store('new-token')).called(1);
+        },
+      );
+    });
+
+    group('ClearPendingInvite', () {
+      blocTest<DeepLinkBloc, DeepLinkState>(
+        'emits [DeepLinkNoInvite] and clears storage',
+        setUp: () {
+          when(() => mockStorage.clear()).thenAnswer((_) async {});
+          when(() => mockDeepLinkService.inviteTokenStream)
+              .thenAnswer((_) => const Stream.empty());
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const ClearPendingInvite()),
+        expect: () => [
+          const DeepLinkNoInvite(),
+        ],
+        verify: (_) {
+          verify(() => mockStorage.clear()).called(1);
+        },
+      );
+    });
+  });
+}

--- a/test/unit/core/services/pending_invite_storage_test.dart
+++ b/test/unit/core/services/pending_invite_storage_test.dart
@@ -1,0 +1,62 @@
+// Validates PendingInviteStorage stores, retrieves, and clears tokens correctly.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  late MockSharedPreferences mockPrefs;
+  late PendingInviteStorage storage;
+
+  setUp(() {
+    mockPrefs = MockSharedPreferences();
+    storage = PendingInviteStorage(prefs: mockPrefs);
+  });
+
+  group('PendingInviteStorage', () {
+    const testToken = 'abc123def456';
+    const key = 'pending_invite_token';
+
+    group('store', () {
+      test('stores token in SharedPreferences', () async {
+        when(() => mockPrefs.setString(key, testToken))
+            .thenAnswer((_) async => true);
+
+        await storage.store(testToken);
+
+        verify(() => mockPrefs.setString(key, testToken)).called(1);
+      });
+    });
+
+    group('retrieve', () {
+      test('returns stored token when one exists', () async {
+        when(() => mockPrefs.getString(key)).thenReturn(testToken);
+
+        final result = await storage.retrieve();
+
+        expect(result, testToken);
+        verify(() => mockPrefs.getString(key)).called(1);
+      });
+
+      test('returns null when no token is stored', () async {
+        when(() => mockPrefs.getString(key)).thenReturn(null);
+
+        final result = await storage.retrieve();
+
+        expect(result, isNull);
+      });
+    });
+
+    group('clear', () {
+      test('removes token from SharedPreferences', () async {
+        when(() => mockPrefs.remove(key)).thenAnswer((_) async => true);
+
+        await storage.clear();
+
+        verify(() => mockPrefs.remove(key)).called(1);
+      });
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
@@ -16,6 +17,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   CloudFirestorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   cloud_firestore
   connectivity_plus
   file_selector_windows


### PR DESCRIPTION
## Summary

- Implement deep link handling for invite URLs using native App Links (Android) and Universal Links (iOS)
- Refactor app routing from `routes:` map to `onGenerateRoute` via a new `RouteGenerator` class
- Add `DeepLinkBloc` + `DeepLinkService` + `PendingInviteStorage` for managing invite token lifecycle
- Configure platform-specific deep link settings (Android intent filters, iOS Associated Domains)
- Add localization strings for unknown route page in all 5 languages

## Changes

### New Files
| File | Purpose |
|------|---------|
| `lib/core/services/deep_link_service.dart` | Abstract deep link service interface |
| `lib/core/services/app_links_deep_link_service.dart` | `app_links` implementation |
| `lib/core/services/pending_invite_storage.dart` | SharedPreferences storage for pending tokens |
| `lib/core/presentation/bloc/deep_link/` | DeepLinkBloc, events, and states |
| `lib/app/route_generator.dart` | Centralized route generation with deep link support |
| `ios/Runner/Runner.entitlements` | Associated Domains for Universal Links |

### Modified Files
- `pubspec.yaml` — Added `app_links: ^6.4.0`
- `lib/app/play_with_me_app.dart` — Replaced `routes:` with `onGenerateRoute`, added `DeepLinkBloc` provider
- `lib/core/services/service_locator.dart` — Registered new services and bloc
- `android/app/src/main/AndroidManifest.xml` — Added App Links intent filters
- `ios/Runner/Info.plist` — Added custom URL scheme and deep linking flag
- `lib/l10n/app_*.arb` — Added `pageNotFound` and `pageNotFoundMessage` strings
- `test/helpers/test_helpers.dart` — Added mock deep link dependencies

### Tests
- `test/unit/core/services/pending_invite_storage_test.dart` — 4 tests
- `test/unit/core/presentation/bloc/deep_link/deep_link_bloc_test.dart` — 7 tests
- `test/unit/app/route_generator_test.dart` — 9 tests
- All 2428 existing tests still pass (+ 3 pre-existing skips)

## Link Handling Scenarios

| Scenario | Behavior |
|----------|----------|
| Cold start with deep link | Token extracted via `getInitialInviteToken()` → stored → `DeepLinkPendingInvite` |
| Foreground deep link | `inviteTokenStream` emits → BLoC stores token → `DeepLinkPendingInvite` |
| Stored pending token | On init, retrieved from SharedPreferences → emits pending state |
| After processing | `ClearPendingInvite` → storage cleared → `DeepLinkNoInvite` |

## Test plan

- [x] Unit tests for `PendingInviteStorage` (store, retrieve, clear)
- [x] Unit tests for `DeepLinkBloc` (initialization with/without tokens, stream listening, clearing)
- [x] Unit tests for `RouteGenerator` (all standard routes, deep link routes, unknown routes)
- [x] All existing app tests pass with new `DeepLinkBloc` dependency
- [x] `flutter analyze` — 0 new warnings
- [ ] Manual: test deep link on Android device with `adb shell am start -a android.intent.action.VIEW -d "https://playwithme.app/invite/test123"`
- [ ] Manual: test deep link on iOS simulator
- [ ] Manual: verify all existing navigation works after routing refactor

Closes #467