### PR TITLE
Story 17.7: Implement invite-based account creation flow

### DIFF
--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -57,6 +57,7 @@ import 'package:play_with_me/core/services/deep_link_service.dart';
 import 'package:play_with_me/core/services/app_links_deep_link_service.dart';
 import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_bloc.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -370,6 +371,16 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<GroupInviteLinkBloc>()) {
     sl.registerFactory<GroupInviteLinkBloc>(
       () => GroupInviteLinkBloc(repository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<InviteRegistrationBloc>()) {
+    sl.registerFactory<InviteRegistrationBloc>(
+      () => InviteRegistrationBloc(
+        authRepository: sl(),
+        groupInviteLinkRepository: sl(),
+        pendingInviteStorage: sl(),
+      ),
     );
   }
 

--- a/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart
+++ b/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart
@@ -1,0 +1,202 @@
+// BLoC for invite-based account creation with automatic group join.
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+import 'package:play_with_me/features/auth/domain/repositories/auth_repository.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart';
+
+class InviteRegistrationBloc
+    extends Bloc<InviteRegistrationEvent, InviteRegistrationState> {
+  final AuthRepository _authRepository;
+  final GroupInviteLinkRepository _groupInviteLinkRepository;
+  final PendingInviteStorage _pendingInviteStorage;
+
+  InviteRegistrationBloc({
+    required AuthRepository authRepository,
+    required GroupInviteLinkRepository groupInviteLinkRepository,
+    required PendingInviteStorage pendingInviteStorage,
+  })  : _authRepository = authRepository,
+        _groupInviteLinkRepository = groupInviteLinkRepository,
+        _pendingInviteStorage = pendingInviteStorage,
+        super(const InviteRegistrationInitial()) {
+    on<InviteRegistrationSubmitted>(_onSubmitted);
+    on<InviteRegistrationFormReset>(_onFormReset);
+  }
+
+  Future<void> _onSubmitted(
+    InviteRegistrationSubmitted event,
+    Emitter<InviteRegistrationState> emit,
+  ) async {
+    emit(const InviteRegistrationCreatingAccount());
+
+    try {
+      // Validate input
+      final validationError = _validateInput(event);
+      if (validationError != null) {
+        emit(InviteRegistrationFailure(message: validationError));
+        return;
+      }
+
+      // Step 1: Create Firebase Auth account
+      debugPrint(
+          '🔐 InviteRegistrationBloc: Creating account for ${event.email}');
+      await _authRepository.createUserWithEmailAndPassword(
+        email: event.email.trim(),
+        password: event.password,
+      );
+      debugPrint('✅ InviteRegistrationBloc: Account created');
+
+      // Step 2: Update display name
+      try {
+        await _authRepository.updateUserProfile(
+          displayName: event.displayName.trim(),
+        );
+        debugPrint('✅ InviteRegistrationBloc: Display name updated');
+      } catch (e) {
+        debugPrint(
+            '⚠️ InviteRegistrationBloc: Failed to update display name: $e');
+      }
+
+      // Step 3: Send email verification (non-blocking)
+      try {
+        await _authRepository.sendEmailVerification();
+        debugPrint('✅ InviteRegistrationBloc: Verification email sent');
+      } catch (e) {
+        debugPrint(
+            '⚠️ InviteRegistrationBloc: Failed to send verification: $e');
+      }
+
+      // Step 4: Join group via invite token
+      emit(const InviteRegistrationJoiningGroup());
+      debugPrint(
+          '🔐 InviteRegistrationBloc: Joining group with token: ${event.token}');
+
+      try {
+        final joinResult = await _groupInviteLinkRepository.joinGroupViaInvite(
+          token: event.token,
+        );
+
+        // Step 5: Clear pending invite
+        await _pendingInviteStorage.clear();
+        debugPrint(
+            '✅ InviteRegistrationBloc: Joined group ${joinResult.groupName}');
+
+        emit(InviteRegistrationSuccess(
+          groupId: joinResult.groupId,
+          groupName: joinResult.groupName,
+        ));
+      } on GroupInviteLinkException catch (e) {
+        // Token expired or invalid — account was still created successfully
+        await _pendingInviteStorage.clear();
+        if (e.code == 'failed-precondition') {
+          debugPrint(
+              '⚠️ InviteRegistrationBloc: Token expired during registration');
+          emit(const InviteRegistrationTokenExpired());
+        } else {
+          emit(InviteRegistrationFailure(
+            message: e.message,
+            errorCode: e.code,
+          ));
+        }
+      }
+    } catch (error) {
+      final errorMessage = _mapFirebaseError(error.toString());
+      final errorCode = _extractErrorCode(error.toString());
+      debugPrint(
+          '❌ InviteRegistrationBloc: Registration failed: $errorMessage');
+      emit(InviteRegistrationFailure(
+        message: errorMessage,
+        errorCode: errorCode,
+      ));
+    }
+  }
+
+  void _onFormReset(
+    InviteRegistrationFormReset event,
+    Emitter<InviteRegistrationState> emit,
+  ) {
+    emit(const InviteRegistrationInitial());
+  }
+
+  String? _validateInput(InviteRegistrationSubmitted event) {
+    if (event.fullName.trim().isEmpty) {
+      return 'Full name is required';
+    }
+    if (event.fullName.trim().length < 2) {
+      return 'Full name must be at least 2 characters';
+    }
+    if (event.displayName.trim().isEmpty) {
+      return 'Display name is required';
+    }
+    if (event.displayName.trim().length < 3) {
+      return 'Display name must be at least 3 characters';
+    }
+    if (event.displayName.trim().length > 30) {
+      return 'Display name must be at most 30 characters';
+    }
+    if (event.email.trim().isEmpty) {
+      return 'Email is required';
+    }
+    if (!_isValidEmail(event.email)) {
+      return 'Please enter a valid email address';
+    }
+    if (event.password.isEmpty) {
+      return 'Password is required';
+    }
+    if (event.password.length < 8) {
+      return 'Password must be at least 8 characters';
+    }
+    if (!event.password.contains(RegExp(r'[A-Z]'))) {
+      return 'Password must contain at least 1 uppercase letter';
+    }
+    if (!event.password.contains(RegExp(r'[0-9]'))) {
+      return 'Password must contain at least 1 number';
+    }
+    if (event.password != event.confirmPassword) {
+      return 'Passwords do not match';
+    }
+    return null;
+  }
+
+  bool _isValidEmail(String email) {
+    return RegExp(r'^[\w\+\-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(email);
+  }
+
+  String _mapFirebaseError(String error) {
+    if (error.contains('email-already-in-use')) {
+      return 'An account with this email already exists. Try logging in instead.';
+    }
+    if (error.contains('weak-password')) {
+      return 'Password is too weak. Use at least 8 characters.';
+    }
+    if (error.contains('invalid-email')) {
+      return 'Please enter a valid email address.';
+    }
+    if (error.contains('network-request-failed') ||
+        error.contains('network')) {
+      return 'Unable to connect. Please check your connection and try again.';
+    }
+    // Clean up error prefix
+    String cleanError = error;
+    if (cleanError.startsWith('Exception: ')) {
+      cleanError = cleanError.substring(11);
+    }
+    if (cleanError.startsWith('Exception: ')) {
+      cleanError = cleanError.substring(11);
+    }
+    return cleanError;
+  }
+
+  String? _extractErrorCode(String error) {
+    if (error.contains('email-already-in-use')) return 'email-already-in-use';
+    if (error.contains('weak-password')) return 'weak-password';
+    if (error.contains('invalid-email')) return 'invalid-email';
+    if (error.contains('network-request-failed')) {
+      return 'network-request-failed';
+    }
+    return null;
+  }
+}

--- a/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart
+++ b/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart
@@ -1,0 +1,43 @@
+// Events for the InviteRegistrationBloc.
+import 'package:equatable/equatable.dart';
+
+sealed class InviteRegistrationEvent extends Equatable {
+  const InviteRegistrationEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to submit the invite registration form.
+class InviteRegistrationSubmitted extends InviteRegistrationEvent {
+  final String fullName;
+  final String displayName;
+  final String email;
+  final String password;
+  final String confirmPassword;
+  final String token;
+
+  const InviteRegistrationSubmitted({
+    required this.fullName,
+    required this.displayName,
+    required this.email,
+    required this.password,
+    required this.confirmPassword,
+    required this.token,
+  });
+
+  @override
+  List<Object?> get props => [
+        fullName,
+        displayName,
+        email,
+        password,
+        confirmPassword,
+        token,
+      ];
+}
+
+/// Event to reset the invite registration form state.
+class InviteRegistrationFormReset extends InviteRegistrationEvent {
+  const InviteRegistrationFormReset();
+}

--- a/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart
+++ b/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart
@@ -1,0 +1,58 @@
+// States for the InviteRegistrationBloc.
+import 'package:equatable/equatable.dart';
+
+sealed class InviteRegistrationState extends Equatable {
+  const InviteRegistrationState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Initial state of the invite registration form.
+class InviteRegistrationInitial extends InviteRegistrationState {
+  const InviteRegistrationInitial();
+}
+
+/// State when account is being created.
+class InviteRegistrationCreatingAccount extends InviteRegistrationState {
+  const InviteRegistrationCreatingAccount();
+}
+
+/// State when account was created and now joining group.
+class InviteRegistrationJoiningGroup extends InviteRegistrationState {
+  const InviteRegistrationJoiningGroup();
+}
+
+/// State when registration and group join succeeded.
+class InviteRegistrationSuccess extends InviteRegistrationState {
+  final String groupId;
+  final String groupName;
+
+  const InviteRegistrationSuccess({
+    required this.groupId,
+    required this.groupName,
+  });
+
+  @override
+  List<Object?> get props => [groupId, groupName];
+}
+
+/// State when registration fails.
+class InviteRegistrationFailure extends InviteRegistrationState {
+  final String message;
+  final String? errorCode;
+
+  const InviteRegistrationFailure({
+    required this.message,
+    this.errorCode,
+  });
+
+  @override
+  List<Object?> get props => [message, errorCode];
+}
+
+/// State when invite token expired during registration.
+/// Account was created but group join failed due to expired token.
+class InviteRegistrationTokenExpired extends InviteRegistrationState {
+  const InviteRegistrationTokenExpired();
+}

--- a/lib/features/invitations/presentation/pages/invite_onboarding_page.dart
+++ b/lib/features/invitations/presentation/pages/invite_onboarding_page.dart
@@ -5,6 +5,7 @@ import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_bloc.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_event.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_state.dart';
+import 'package:play_with_me/features/invitations/presentation/pages/invite_registration_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
 class InviteOnboardingPage extends StatelessWidget {
@@ -99,8 +100,15 @@ class InviteOnboardingPage extends StatelessWidget {
         const Spacer(),
         FilledButton(
           onPressed: () {
-            // Navigate to registration (Story 17.7 will implement InviteRegistrationPage)
-            Navigator.of(context).pushNamed('/register');
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => InviteRegistrationPage(
+                  token: token,
+                  groupName: state.groupName,
+                  inviterName: state.inviterName,
+                ),
+              ),
+            );
           },
           style: FilledButton.styleFrom(
             minimumSize: const Size.fromHeight(48),

--- a/lib/features/invitations/presentation/pages/invite_registration_page.dart
+++ b/lib/features/invitations/presentation/pages/invite_registration_page.dart
@@ -1,0 +1,354 @@
+// Registration page for users who arrived via an invite link.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/features/auth/presentation/widgets/auth_form_field.dart';
+import 'package:play_with_me/features/auth/presentation/widgets/auth_button.dart';
+import 'package:play_with_me/features/groups/presentation/pages/group_details_page.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class InviteRegistrationPage extends StatefulWidget {
+  final String token;
+  final String groupName;
+  final String inviterName;
+  final InviteRegistrationBloc? blocOverride;
+
+  const InviteRegistrationPage({
+    super.key,
+    required this.token,
+    required this.groupName,
+    required this.inviterName,
+    this.blocOverride,
+  });
+
+  @override
+  State<InviteRegistrationPage> createState() =>
+      _InviteRegistrationPageState();
+}
+
+class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _fullNameController = TextEditingController();
+  final _displayNameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+
+  @override
+  void dispose() {
+    _fullNameController.dispose();
+    _displayNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return BlocProvider<InviteRegistrationBloc>(
+      create: (_) =>
+          widget.blocOverride ?? GetIt.instance<InviteRegistrationBloc>(),
+      child: Builder(
+        builder: (blocContext) => Scaffold(
+          appBar: AppBar(
+            title: Text(l10n.createAccount),
+          ),
+          body: BlocListener<InviteRegistrationBloc, InviteRegistrationState>(
+            listener: _onStateChange,
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24.0),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _buildGroupContextBanner(blocContext, l10n),
+                    const SizedBox(height: 24),
+                    _buildFullNameField(l10n),
+                    const SizedBox(height: 16),
+                    _buildDisplayNameField(l10n),
+                    const SizedBox(height: 16),
+                    _buildEmailField(l10n),
+                    const SizedBox(height: 16),
+                    _buildPasswordField(l10n),
+                    const SizedBox(height: 4),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 12),
+                      child: Text(
+                        l10n.passwordRequirementsHint,
+                        style:
+                            Theme.of(blocContext).textTheme.bodySmall?.copyWith(
+                                  color: AppColors.textMuted,
+                                ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildConfirmPasswordField(l10n),
+                    const SizedBox(height: 32),
+                    _buildSubmitButton(blocContext, l10n),
+                    const SizedBox(height: 16),
+                    _buildLoginLink(blocContext, l10n),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGroupContextBanner(BuildContext context, AppLocalizations l10n) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          l10n.createAccountToJoin,
+          style: Theme.of(context).textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+        Card(
+          elevation: 2,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.groupName,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  l10n.invitedBy(widget.inviterName),
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: AppColors.textMuted,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFullNameField(AppLocalizations l10n) {
+    return AuthFormField(
+      controller: _fullNameController,
+      hintText: l10n.fullNameHint,
+      textInputAction: TextInputAction.next,
+      prefixIcon: Icons.badge,
+      validator: (value) {
+        if (value == null || value.trim().isEmpty) {
+          return l10n.fullNameRequired;
+        }
+        if (value.trim().length < 2) {
+          return l10n.fullNameTooShort;
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildDisplayNameField(AppLocalizations l10n) {
+    return AuthFormField(
+      controller: _displayNameController,
+      hintText: l10n.displayNameHintRequired,
+      textInputAction: TextInputAction.next,
+      prefixIcon: Icons.person,
+      validator: (value) {
+        if (value == null || value.trim().isEmpty) {
+          return l10n.displayNameRequired;
+        }
+        if (value.trim().length < 3) {
+          return l10n.displayNameTooShortInvite;
+        }
+        if (value.trim().length > 30) {
+          return l10n.displayNameTooLongInvite;
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildEmailField(AppLocalizations l10n) {
+    return AuthFormField(
+      controller: _emailController,
+      hintText: l10n.emailHint,
+      keyboardType: TextInputType.emailAddress,
+      textInputAction: TextInputAction.next,
+      prefixIcon: Icons.email,
+      validator: (value) {
+        if (value == null || value.trim().isEmpty) {
+          return l10n.emailRequired;
+        }
+        if (!RegExp(r'^[\w\+\-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
+          return l10n.validEmailRequired;
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildPasswordField(AppLocalizations l10n) {
+    return AuthFormField(
+      controller: _passwordController,
+      hintText: l10n.passwordHint,
+      obscureText: _obscurePassword,
+      textInputAction: TextInputAction.next,
+      prefixIcon: Icons.lock,
+      suffixIcon: IconButton(
+        icon: Icon(
+          _obscurePassword ? Icons.visibility : Icons.visibility_off,
+        ),
+        onPressed: () {
+          setState(() {
+            _obscurePassword = !_obscurePassword;
+          });
+        },
+      ),
+      validator: (value) {
+        if (value == null || value.trim().isEmpty) {
+          return l10n.passwordRequired;
+        }
+        if (value.length < 8) {
+          return l10n.passwordTooShortInvite;
+        }
+        if (!value.contains(RegExp(r'[A-Z]'))) {
+          return l10n.passwordMissingUppercase;
+        }
+        if (!value.contains(RegExp(r'[0-9]'))) {
+          return l10n.passwordMissingNumber;
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildConfirmPasswordField(AppLocalizations l10n) {
+    return AuthFormField(
+      controller: _confirmPasswordController,
+      hintText: l10n.confirmPassword,
+      obscureText: _obscureConfirmPassword,
+      textInputAction: TextInputAction.done,
+      prefixIcon: Icons.lock,
+      suffixIcon: IconButton(
+        icon: Icon(
+          _obscureConfirmPassword ? Icons.visibility : Icons.visibility_off,
+        ),
+        onPressed: () {
+          setState(() {
+            _obscureConfirmPassword = !_obscureConfirmPassword;
+          });
+        },
+      ),
+      validator: (value) {
+        if (value == null || value.trim().isEmpty) {
+          return l10n.pleaseConfirmPassword;
+        }
+        if (value != _passwordController.text) {
+          return l10n.passwordsDoNotMatch;
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildSubmitButton(BuildContext blocContext, AppLocalizations l10n) {
+    return BlocBuilder<InviteRegistrationBloc, InviteRegistrationState>(
+      builder: (context, state) {
+        final isLoading = state is InviteRegistrationCreatingAccount ||
+            state is InviteRegistrationJoiningGroup;
+        final buttonText = state is InviteRegistrationJoiningGroup
+            ? l10n.accountCreatedJoiningGroup
+            : state is InviteRegistrationCreatingAccount
+                ? l10n.creatingAccount
+                : l10n.createAccountAndJoin;
+
+        return AuthButton(
+          text: buttonText,
+          isLoading: isLoading,
+          onPressed: () => _submitRegistration(blocContext),
+        );
+      },
+    );
+  }
+
+  Widget _buildLoginLink(BuildContext context, AppLocalizations l10n) {
+    return Center(
+      child: TextButton(
+        onPressed: () {
+          Navigator.of(context).pushReplacementNamed('/login');
+        },
+        child: Text(l10n.alreadyHaveAccountLogin),
+      ),
+    );
+  }
+
+  void _submitRegistration(BuildContext blocContext) {
+    if (_formKey.currentState!.validate()) {
+      blocContext.read<InviteRegistrationBloc>().add(
+            InviteRegistrationSubmitted(
+              fullName: _fullNameController.text.trim(),
+              displayName: _displayNameController.text.trim(),
+              email: _emailController.text.trim(),
+              password: _passwordController.text,
+              confirmPassword: _confirmPasswordController.text,
+              token: widget.token,
+            ),
+          );
+    }
+  }
+
+  void _onStateChange(BuildContext context, InviteRegistrationState state) {
+    final l10n = AppLocalizations.of(context)!;
+
+    if (state is InviteRegistrationFailure) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(state.message),
+            backgroundColor: Colors.red,
+          ),
+        );
+    } else if (state is InviteRegistrationSuccess) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.groupJoinedSuccess(state.groupName)),
+          backgroundColor: Colors.green,
+        ),
+      );
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(
+          builder: (_) => GroupDetailsPage(groupId: state.groupId),
+        ),
+        (route) => route.isFirst,
+      );
+    } else if (state is InviteRegistrationTokenExpired) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.inviteExpiredDuringRegistration),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      Navigator.of(context).pushNamedAndRemoveUntil(
+        '/login',
+        (route) => false,
+      );
+    }
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -529,5 +529,27 @@
   "alreadyAMember": "Du bist bereits Mitglied dieser Gruppe",
   "continueToApp": "Weiter zur App",
   "validatingInvite": "Einladung wird überprüft...",
-  "joiningGroup": "Gruppe wird beigetreten..."
+  "joiningGroup": "Gruppe wird beigetreten...",
+
+  "createAccountToJoin": "Erstellen Sie Ihr Konto zum Beitreten:",
+  "fullNameHint": "Vollständiger Name",
+  "fullNameRequired": "Vollständiger Name ist erforderlich",
+  "fullNameTooShort": "Der vollständige Name muss mindestens 2 Zeichen lang sein",
+  "displayNameHintRequired": "Anzeigename",
+  "displayNameRequired": "Anzeigename ist erforderlich",
+  "displayNameTooShortInvite": "Der Anzeigename muss mindestens 3 Zeichen lang sein",
+  "displayNameTooLongInvite": "Der Anzeigename darf höchstens 30 Zeichen lang sein",
+  "passwordRequirementsHint": "Mindestens 8 Zeichen, 1 Großbuchstabe, 1 Zahl",
+  "passwordTooShortInvite": "Das Passwort muss mindestens 8 Zeichen lang sein",
+  "passwordMissingUppercase": "Das Passwort muss mindestens 1 Großbuchstaben enthalten",
+  "passwordMissingNumber": "Das Passwort muss mindestens 1 Zahl enthalten",
+  "createAccountAndJoin": "Konto erstellen und beitreten",
+  "alreadyHaveAccountLogin": "Bereits ein Konto? Anmelden",
+  "accountCreatedJoiningGroup": "Konto erstellt! Gruppe beitreten...",
+  "inviteExpiredDuringRegistration": "Der Einladungslink ist abgelaufen, aber Ihr Konto wurde erfolgreich erstellt.",
+  "emailAlreadyInUse": "Ein Konto mit dieser E-Mail existiert bereits. Versuchen Sie sich anzumelden.",
+  "weakPasswordError": "Das Passwort ist zu schwach. Verwenden Sie mindestens 8 Zeichen.",
+  "invalidEmailError": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+  "networkError": "Verbindung nicht möglich. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+  "creatingAccount": "Konto wird erstellt..."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2517,5 +2517,110 @@
   "joiningGroup": "Joining group...",
   "@joiningGroup": {
     "description": "Loading message while joining a group"
+  },
+
+  "createAccountToJoin": "Create your account to join:",
+  "@createAccountToJoin": {
+    "description": "Header text on invite registration page"
+  },
+
+  "fullNameHint": "Full Name",
+  "@fullNameHint": {
+    "description": "Hint text for full name field"
+  },
+
+  "fullNameRequired": "Full name is required",
+  "@fullNameRequired": {
+    "description": "Validation error when full name is empty"
+  },
+
+  "fullNameTooShort": "Full name must be at least 2 characters",
+  "@fullNameTooShort": {
+    "description": "Validation error when full name is too short"
+  },
+
+  "displayNameHintRequired": "Display Name",
+  "@displayNameHintRequired": {
+    "description": "Hint text for required display name field"
+  },
+
+  "displayNameRequired": "Display name is required",
+  "@displayNameRequired": {
+    "description": "Validation error when display name is empty"
+  },
+
+  "displayNameTooShortInvite": "Display name must be at least 3 characters",
+  "@displayNameTooShortInvite": {
+    "description": "Validation error when display name is too short on invite registration"
+  },
+
+  "displayNameTooLongInvite": "Display name must be at most 30 characters",
+  "@displayNameTooLongInvite": {
+    "description": "Validation error when display name is too long on invite registration"
+  },
+
+  "passwordRequirementsHint": "At least 8 characters, 1 uppercase letter, 1 number",
+  "@passwordRequirementsHint": {
+    "description": "Helper text explaining password requirements"
+  },
+
+  "passwordTooShortInvite": "Password must be at least 8 characters",
+  "@passwordTooShortInvite": {
+    "description": "Validation error when password is too short on invite registration"
+  },
+
+  "passwordMissingUppercase": "Password must contain at least 1 uppercase letter",
+  "@passwordMissingUppercase": {
+    "description": "Validation error when password has no uppercase letter"
+  },
+
+  "passwordMissingNumber": "Password must contain at least 1 number",
+  "@passwordMissingNumber": {
+    "description": "Validation error when password has no number"
+  },
+
+  "createAccountAndJoin": "Create Account & Join",
+  "@createAccountAndJoin": {
+    "description": "Button text to create account and join group"
+  },
+
+  "alreadyHaveAccountLogin": "Already have an account? Log in",
+  "@alreadyHaveAccountLogin": {
+    "description": "Link text for existing users on invite registration page"
+  },
+
+  "accountCreatedJoiningGroup": "Account created! Joining group...",
+  "@accountCreatedJoiningGroup": {
+    "description": "Loading message after account creation while joining group"
+  },
+
+  "inviteExpiredDuringRegistration": "The invite link has expired, but your account was created successfully.",
+  "@inviteExpiredDuringRegistration": {
+    "description": "Message when invite expires during registration"
+  },
+
+  "emailAlreadyInUse": "An account with this email already exists. Try logging in instead.",
+  "@emailAlreadyInUse": {
+    "description": "Error when email is already registered"
+  },
+
+  "weakPasswordError": "Password is too weak. Use at least 8 characters.",
+  "@weakPasswordError": {
+    "description": "Error when password is too weak"
+  },
+
+  "invalidEmailError": "Please enter a valid email address.",
+  "@invalidEmailError": {
+    "description": "Error when email format is invalid"
+  },
+
+  "networkError": "Unable to connect. Please check your connection and try again.",
+  "@networkError": {
+    "description": "Error when network connection fails"
+  },
+
+  "creatingAccount": "Creating account...",
+  "@creatingAccount": {
+    "description": "Loading message while creating account"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -529,5 +529,27 @@
   "alreadyAMember": "Ya eres miembro de este grupo",
   "continueToApp": "Continuar a la app",
   "validatingInvite": "Validando invitación...",
-  "joiningGroup": "Uniéndose al grupo..."
+  "joiningGroup": "Uniéndose al grupo...",
+
+  "createAccountToJoin": "Crea tu cuenta para unirte:",
+  "fullNameHint": "Nombre completo",
+  "fullNameRequired": "El nombre completo es obligatorio",
+  "fullNameTooShort": "El nombre completo debe tener al menos 2 caracteres",
+  "displayNameHintRequired": "Nombre de usuario",
+  "displayNameRequired": "El nombre de usuario es obligatorio",
+  "displayNameTooShortInvite": "El nombre de usuario debe tener al menos 3 caracteres",
+  "displayNameTooLongInvite": "El nombre de usuario debe tener como máximo 30 caracteres",
+  "passwordRequirementsHint": "Al menos 8 caracteres, 1 mayúscula, 1 número",
+  "passwordTooShortInvite": "La contraseña debe tener al menos 8 caracteres",
+  "passwordMissingUppercase": "La contraseña debe contener al menos 1 letra mayúscula",
+  "passwordMissingNumber": "La contraseña debe contener al menos 1 número",
+  "createAccountAndJoin": "Crear cuenta y unirse",
+  "alreadyHaveAccountLogin": "¿Ya tienes una cuenta? Inicia sesión",
+  "accountCreatedJoiningGroup": "¡Cuenta creada! Uniéndose al grupo...",
+  "inviteExpiredDuringRegistration": "El enlace de invitación ha expirado, pero tu cuenta fue creada exitosamente.",
+  "emailAlreadyInUse": "Ya existe una cuenta con este correo electrónico. Intenta iniciar sesión.",
+  "weakPasswordError": "La contraseña es demasiado débil. Usa al menos 8 caracteres.",
+  "invalidEmailError": "Por favor ingresa una dirección de correo electrónico válida.",
+  "networkError": "No se puede conectar. Verifica tu conexión e inténtalo de nuevo.",
+  "creatingAccount": "Creando cuenta..."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -529,5 +529,27 @@
   "alreadyAMember": "Vous êtes déjà membre de ce groupe",
   "continueToApp": "Continuer vers l'application",
   "validatingInvite": "Validation de l'invitation...",
-  "joiningGroup": "Rejoint le groupe..."
+  "joiningGroup": "Rejoint le groupe...",
+
+  "createAccountToJoin": "Créez votre compte pour rejoindre :",
+  "fullNameHint": "Nom complet",
+  "fullNameRequired": "Le nom complet est requis",
+  "fullNameTooShort": "Le nom complet doit comporter au moins 2 caractères",
+  "displayNameHintRequired": "Nom d'affichage",
+  "displayNameRequired": "Le nom d'affichage est requis",
+  "displayNameTooShortInvite": "Le nom d'affichage doit comporter au moins 3 caractères",
+  "displayNameTooLongInvite": "Le nom d'affichage doit comporter au maximum 30 caractères",
+  "passwordRequirementsHint": "Au moins 8 caractères, 1 majuscule, 1 chiffre",
+  "passwordTooShortInvite": "Le mot de passe doit comporter au moins 8 caractères",
+  "passwordMissingUppercase": "Le mot de passe doit contenir au moins 1 majuscule",
+  "passwordMissingNumber": "Le mot de passe doit contenir au moins 1 chiffre",
+  "createAccountAndJoin": "Créer un compte et rejoindre",
+  "alreadyHaveAccountLogin": "Vous avez déjà un compte ? Connectez-vous",
+  "accountCreatedJoiningGroup": "Compte créé ! Rejoindre le groupe...",
+  "inviteExpiredDuringRegistration": "Le lien d'invitation a expiré, mais votre compte a été créé avec succès.",
+  "emailAlreadyInUse": "Un compte avec cet email existe déjà. Essayez de vous connecter.",
+  "weakPasswordError": "Le mot de passe est trop faible. Utilisez au moins 8 caractères.",
+  "invalidEmailError": "Veuillez entrer une adresse email valide.",
+  "networkError": "Impossible de se connecter. Veuillez vérifier votre connexion et réessayer.",
+  "creatingAccount": "Création du compte..."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -529,5 +529,27 @@
   "alreadyAMember": "Sei già membro di questo gruppo",
   "continueToApp": "Continua all'app",
   "validatingInvite": "Convalida dell'invito...",
-  "joiningGroup": "Entrando nel gruppo..."
+  "joiningGroup": "Entrando nel gruppo...",
+
+  "createAccountToJoin": "Crea il tuo account per unirti:",
+  "fullNameHint": "Nome completo",
+  "fullNameRequired": "Il nome completo è obbligatorio",
+  "fullNameTooShort": "Il nome completo deve avere almeno 2 caratteri",
+  "displayNameHintRequired": "Nome visualizzato",
+  "displayNameRequired": "Il nome visualizzato è obbligatorio",
+  "displayNameTooShortInvite": "Il nome visualizzato deve avere almeno 3 caratteri",
+  "displayNameTooLongInvite": "Il nome visualizzato deve avere al massimo 30 caratteri",
+  "passwordRequirementsHint": "Almeno 8 caratteri, 1 lettera maiuscola, 1 numero",
+  "passwordTooShortInvite": "La password deve avere almeno 8 caratteri",
+  "passwordMissingUppercase": "La password deve contenere almeno 1 lettera maiuscola",
+  "passwordMissingNumber": "La password deve contenere almeno 1 numero",
+  "createAccountAndJoin": "Crea account e unisciti",
+  "alreadyHaveAccountLogin": "Hai già un account? Accedi",
+  "accountCreatedJoiningGroup": "Account creato! Entrando nel gruppo...",
+  "inviteExpiredDuringRegistration": "Il link di invito è scaduto, ma il tuo account è stato creato con successo.",
+  "emailAlreadyInUse": "Esiste già un account con questa email. Prova ad accedere.",
+  "weakPasswordError": "La password è troppo debole. Usa almeno 8 caratteri.",
+  "invalidEmailError": "Inserisci un indirizzo email valido.",
+  "networkError": "Impossibile connettersi. Controlla la tua connessione e riprova.",
+  "creatingAccount": "Creazione account..."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3223,6 +3223,132 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Joining group...'**
   String get joiningGroup;
+
+  /// Header text on invite registration page
+  ///
+  /// In en, this message translates to:
+  /// **'Create your account to join:'**
+  String get createAccountToJoin;
+
+  /// Hint text for full name field
+  ///
+  /// In en, this message translates to:
+  /// **'Full Name'**
+  String get fullNameHint;
+
+  /// Validation error when full name is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Full name is required'**
+  String get fullNameRequired;
+
+  /// Validation error when full name is too short
+  ///
+  /// In en, this message translates to:
+  /// **'Full name must be at least 2 characters'**
+  String get fullNameTooShort;
+
+  /// Hint text for required display name field
+  ///
+  /// In en, this message translates to:
+  /// **'Display Name'**
+  String get displayNameHintRequired;
+
+  /// Validation error when display name is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Display name is required'**
+  String get displayNameRequired;
+
+  /// Validation error when display name is too short on invite registration
+  ///
+  /// In en, this message translates to:
+  /// **'Display name must be at least 3 characters'**
+  String get displayNameTooShortInvite;
+
+  /// Validation error when display name is too long on invite registration
+  ///
+  /// In en, this message translates to:
+  /// **'Display name must be at most 30 characters'**
+  String get displayNameTooLongInvite;
+
+  /// Helper text explaining password requirements
+  ///
+  /// In en, this message translates to:
+  /// **'At least 8 characters, 1 uppercase letter, 1 number'**
+  String get passwordRequirementsHint;
+
+  /// Validation error when password is too short on invite registration
+  ///
+  /// In en, this message translates to:
+  /// **'Password must be at least 8 characters'**
+  String get passwordTooShortInvite;
+
+  /// Validation error when password has no uppercase letter
+  ///
+  /// In en, this message translates to:
+  /// **'Password must contain at least 1 uppercase letter'**
+  String get passwordMissingUppercase;
+
+  /// Validation error when password has no number
+  ///
+  /// In en, this message translates to:
+  /// **'Password must contain at least 1 number'**
+  String get passwordMissingNumber;
+
+  /// Button text to create account and join group
+  ///
+  /// In en, this message translates to:
+  /// **'Create Account & Join'**
+  String get createAccountAndJoin;
+
+  /// Link text for existing users on invite registration page
+  ///
+  /// In en, this message translates to:
+  /// **'Already have an account? Log in'**
+  String get alreadyHaveAccountLogin;
+
+  /// Loading message after account creation while joining group
+  ///
+  /// In en, this message translates to:
+  /// **'Account created! Joining group...'**
+  String get accountCreatedJoiningGroup;
+
+  /// Message when invite expires during registration
+  ///
+  /// In en, this message translates to:
+  /// **'The invite link has expired, but your account was created successfully.'**
+  String get inviteExpiredDuringRegistration;
+
+  /// Error when email is already registered
+  ///
+  /// In en, this message translates to:
+  /// **'An account with this email already exists. Try logging in instead.'**
+  String get emailAlreadyInUse;
+
+  /// Error when password is too weak
+  ///
+  /// In en, this message translates to:
+  /// **'Password is too weak. Use at least 8 characters.'**
+  String get weakPasswordError;
+
+  /// Error when email format is invalid
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a valid email address.'**
+  String get invalidEmailError;
+
+  /// Error when network connection fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to connect. Please check your connection and try again.'**
+  String get networkError;
+
+  /// Loading message while creating account
+  ///
+  /// In en, this message translates to:
+  /// **'Creating account...'**
+  String get creatingAccount;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1749,4 +1749,80 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get joiningGroup => 'Gruppe wird beigetreten...';
+
+  @override
+  String get createAccountToJoin => 'Erstellen Sie Ihr Konto zum Beitreten:';
+
+  @override
+  String get fullNameHint => 'Vollständiger Name';
+
+  @override
+  String get fullNameRequired => 'Vollständiger Name ist erforderlich';
+
+  @override
+  String get fullNameTooShort =>
+      'Der vollständige Name muss mindestens 2 Zeichen lang sein';
+
+  @override
+  String get displayNameHintRequired => 'Anzeigename';
+
+  @override
+  String get displayNameRequired => 'Anzeigename ist erforderlich';
+
+  @override
+  String get displayNameTooShortInvite =>
+      'Der Anzeigename muss mindestens 3 Zeichen lang sein';
+
+  @override
+  String get displayNameTooLongInvite =>
+      'Der Anzeigename darf höchstens 30 Zeichen lang sein';
+
+  @override
+  String get passwordRequirementsHint =>
+      'Mindestens 8 Zeichen, 1 Großbuchstabe, 1 Zahl';
+
+  @override
+  String get passwordTooShortInvite =>
+      'Das Passwort muss mindestens 8 Zeichen lang sein';
+
+  @override
+  String get passwordMissingUppercase =>
+      'Das Passwort muss mindestens 1 Großbuchstaben enthalten';
+
+  @override
+  String get passwordMissingNumber =>
+      'Das Passwort muss mindestens 1 Zahl enthalten';
+
+  @override
+  String get createAccountAndJoin => 'Konto erstellen und beitreten';
+
+  @override
+  String get alreadyHaveAccountLogin => 'Bereits ein Konto? Anmelden';
+
+  @override
+  String get accountCreatedJoiningGroup =>
+      'Konto erstellt! Gruppe beitreten...';
+
+  @override
+  String get inviteExpiredDuringRegistration =>
+      'Der Einladungslink ist abgelaufen, aber Ihr Konto wurde erfolgreich erstellt.';
+
+  @override
+  String get emailAlreadyInUse =>
+      'Ein Konto mit dieser E-Mail existiert bereits. Versuchen Sie sich anzumelden.';
+
+  @override
+  String get weakPasswordError =>
+      'Das Passwort ist zu schwach. Verwenden Sie mindestens 8 Zeichen.';
+
+  @override
+  String get invalidEmailError =>
+      'Bitte geben Sie eine gültige E-Mail-Adresse ein.';
+
+  @override
+  String get networkError =>
+      'Verbindung nicht möglich. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.';
+
+  @override
+  String get creatingAccount => 'Konto wird erstellt...';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1723,4 +1723,75 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get joiningGroup => 'Joining group...';
+
+  @override
+  String get createAccountToJoin => 'Create your account to join:';
+
+  @override
+  String get fullNameHint => 'Full Name';
+
+  @override
+  String get fullNameRequired => 'Full name is required';
+
+  @override
+  String get fullNameTooShort => 'Full name must be at least 2 characters';
+
+  @override
+  String get displayNameHintRequired => 'Display Name';
+
+  @override
+  String get displayNameRequired => 'Display name is required';
+
+  @override
+  String get displayNameTooShortInvite =>
+      'Display name must be at least 3 characters';
+
+  @override
+  String get displayNameTooLongInvite =>
+      'Display name must be at most 30 characters';
+
+  @override
+  String get passwordRequirementsHint =>
+      'At least 8 characters, 1 uppercase letter, 1 number';
+
+  @override
+  String get passwordTooShortInvite => 'Password must be at least 8 characters';
+
+  @override
+  String get passwordMissingUppercase =>
+      'Password must contain at least 1 uppercase letter';
+
+  @override
+  String get passwordMissingNumber => 'Password must contain at least 1 number';
+
+  @override
+  String get createAccountAndJoin => 'Create Account & Join';
+
+  @override
+  String get alreadyHaveAccountLogin => 'Already have an account? Log in';
+
+  @override
+  String get accountCreatedJoiningGroup => 'Account created! Joining group...';
+
+  @override
+  String get inviteExpiredDuringRegistration =>
+      'The invite link has expired, but your account was created successfully.';
+
+  @override
+  String get emailAlreadyInUse =>
+      'An account with this email already exists. Try logging in instead.';
+
+  @override
+  String get weakPasswordError =>
+      'Password is too weak. Use at least 8 characters.';
+
+  @override
+  String get invalidEmailError => 'Please enter a valid email address.';
+
+  @override
+  String get networkError =>
+      'Unable to connect. Please check your connection and try again.';
+
+  @override
+  String get creatingAccount => 'Creating account...';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1742,4 +1742,80 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get joiningGroup => 'Uniéndose al grupo...';
+
+  @override
+  String get createAccountToJoin => 'Crea tu cuenta para unirte:';
+
+  @override
+  String get fullNameHint => 'Nombre completo';
+
+  @override
+  String get fullNameRequired => 'El nombre completo es obligatorio';
+
+  @override
+  String get fullNameTooShort =>
+      'El nombre completo debe tener al menos 2 caracteres';
+
+  @override
+  String get displayNameHintRequired => 'Nombre de usuario';
+
+  @override
+  String get displayNameRequired => 'El nombre de usuario es obligatorio';
+
+  @override
+  String get displayNameTooShortInvite =>
+      'El nombre de usuario debe tener al menos 3 caracteres';
+
+  @override
+  String get displayNameTooLongInvite =>
+      'El nombre de usuario debe tener como máximo 30 caracteres';
+
+  @override
+  String get passwordRequirementsHint =>
+      'Al menos 8 caracteres, 1 mayúscula, 1 número';
+
+  @override
+  String get passwordTooShortInvite =>
+      'La contraseña debe tener al menos 8 caracteres';
+
+  @override
+  String get passwordMissingUppercase =>
+      'La contraseña debe contener al menos 1 letra mayúscula';
+
+  @override
+  String get passwordMissingNumber =>
+      'La contraseña debe contener al menos 1 número';
+
+  @override
+  String get createAccountAndJoin => 'Crear cuenta y unirse';
+
+  @override
+  String get alreadyHaveAccountLogin => '¿Ya tienes una cuenta? Inicia sesión';
+
+  @override
+  String get accountCreatedJoiningGroup =>
+      '¡Cuenta creada! Uniéndose al grupo...';
+
+  @override
+  String get inviteExpiredDuringRegistration =>
+      'El enlace de invitación ha expirado, pero tu cuenta fue creada exitosamente.';
+
+  @override
+  String get emailAlreadyInUse =>
+      'Ya existe una cuenta con este correo electrónico. Intenta iniciar sesión.';
+
+  @override
+  String get weakPasswordError =>
+      'La contraseña es demasiado débil. Usa al menos 8 caracteres.';
+
+  @override
+  String get invalidEmailError =>
+      'Por favor ingresa una dirección de correo electrónico válida.';
+
+  @override
+  String get networkError =>
+      'No se puede conectar. Verifica tu conexión e inténtalo de nuevo.';
+
+  @override
+  String get creatingAccount => 'Creando cuenta...';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1752,4 +1752,80 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get joiningGroup => 'Rejoint le groupe...';
+
+  @override
+  String get createAccountToJoin => 'Créez votre compte pour rejoindre :';
+
+  @override
+  String get fullNameHint => 'Nom complet';
+
+  @override
+  String get fullNameRequired => 'Le nom complet est requis';
+
+  @override
+  String get fullNameTooShort =>
+      'Le nom complet doit comporter au moins 2 caractères';
+
+  @override
+  String get displayNameHintRequired => 'Nom d\'affichage';
+
+  @override
+  String get displayNameRequired => 'Le nom d\'affichage est requis';
+
+  @override
+  String get displayNameTooShortInvite =>
+      'Le nom d\'affichage doit comporter au moins 3 caractères';
+
+  @override
+  String get displayNameTooLongInvite =>
+      'Le nom d\'affichage doit comporter au maximum 30 caractères';
+
+  @override
+  String get passwordRequirementsHint =>
+      'Au moins 8 caractères, 1 majuscule, 1 chiffre';
+
+  @override
+  String get passwordTooShortInvite =>
+      'Le mot de passe doit comporter au moins 8 caractères';
+
+  @override
+  String get passwordMissingUppercase =>
+      'Le mot de passe doit contenir au moins 1 majuscule';
+
+  @override
+  String get passwordMissingNumber =>
+      'Le mot de passe doit contenir au moins 1 chiffre';
+
+  @override
+  String get createAccountAndJoin => 'Créer un compte et rejoindre';
+
+  @override
+  String get alreadyHaveAccountLogin =>
+      'Vous avez déjà un compte ? Connectez-vous';
+
+  @override
+  String get accountCreatedJoiningGroup =>
+      'Compte créé ! Rejoindre le groupe...';
+
+  @override
+  String get inviteExpiredDuringRegistration =>
+      'Le lien d\'invitation a expiré, mais votre compte a été créé avec succès.';
+
+  @override
+  String get emailAlreadyInUse =>
+      'Un compte avec cet email existe déjà. Essayez de vous connecter.';
+
+  @override
+  String get weakPasswordError =>
+      'Le mot de passe est trop faible. Utilisez au moins 8 caractères.';
+
+  @override
+  String get invalidEmailError => 'Veuillez entrer une adresse email valide.';
+
+  @override
+  String get networkError =>
+      'Impossible de se connecter. Veuillez vérifier votre connexion et réessayer.';
+
+  @override
+  String get creatingAccount => 'Création du compte...';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1738,4 +1738,79 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get joiningGroup => 'Entrando nel gruppo...';
+
+  @override
+  String get createAccountToJoin => 'Crea il tuo account per unirti:';
+
+  @override
+  String get fullNameHint => 'Nome completo';
+
+  @override
+  String get fullNameRequired => 'Il nome completo è obbligatorio';
+
+  @override
+  String get fullNameTooShort =>
+      'Il nome completo deve avere almeno 2 caratteri';
+
+  @override
+  String get displayNameHintRequired => 'Nome visualizzato';
+
+  @override
+  String get displayNameRequired => 'Il nome visualizzato è obbligatorio';
+
+  @override
+  String get displayNameTooShortInvite =>
+      'Il nome visualizzato deve avere almeno 3 caratteri';
+
+  @override
+  String get displayNameTooLongInvite =>
+      'Il nome visualizzato deve avere al massimo 30 caratteri';
+
+  @override
+  String get passwordRequirementsHint =>
+      'Almeno 8 caratteri, 1 lettera maiuscola, 1 numero';
+
+  @override
+  String get passwordTooShortInvite =>
+      'La password deve avere almeno 8 caratteri';
+
+  @override
+  String get passwordMissingUppercase =>
+      'La password deve contenere almeno 1 lettera maiuscola';
+
+  @override
+  String get passwordMissingNumber =>
+      'La password deve contenere almeno 1 numero';
+
+  @override
+  String get createAccountAndJoin => 'Crea account e unisciti';
+
+  @override
+  String get alreadyHaveAccountLogin => 'Hai già un account? Accedi';
+
+  @override
+  String get accountCreatedJoiningGroup =>
+      'Account creato! Entrando nel gruppo...';
+
+  @override
+  String get inviteExpiredDuringRegistration =>
+      'Il link di invito è scaduto, ma il tuo account è stato creato con successo.';
+
+  @override
+  String get emailAlreadyInUse =>
+      'Esiste già un account con questa email. Prova ad accedere.';
+
+  @override
+  String get weakPasswordError =>
+      'La password è troppo debole. Usa almeno 8 caratteri.';
+
+  @override
+  String get invalidEmailError => 'Inserisci un indirizzo email valido.';
+
+  @override
+  String get networkError =>
+      'Impossibile connettersi. Controlla la tua connessione e riprova.';
+
+  @override
+  String get creatingAccount => 'Creazione account...';
 }

--- a/test/unit/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc_test.dart
+++ b/test/unit/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc_test.dart
@@ -1,0 +1,537 @@
+// Validates InviteRegistrationBloc emits correct states for invite-based account creation and group joining.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/core/services/pending_invite_storage.dart';
+import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
+import 'package:play_with_me/features/auth/domain/repositories/auth_repository.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockGroupInviteLinkRepository extends Mock
+    implements GroupInviteLinkRepository {}
+
+class MockPendingInviteStorage extends Mock implements PendingInviteStorage {}
+
+class FakeUserEntity extends Fake implements UserEntity {
+  @override
+  String get uid => 'user-123';
+
+  @override
+  String get email => 'test@example.com';
+}
+
+void main() {
+  late MockAuthRepository mockAuthRepo;
+  late MockGroupInviteLinkRepository mockInviteRepo;
+  late MockPendingInviteStorage mockStorage;
+
+  setUp(() {
+    mockAuthRepo = MockAuthRepository();
+    mockInviteRepo = MockGroupInviteLinkRepository();
+    mockStorage = MockPendingInviteStorage();
+  });
+
+  InviteRegistrationBloc buildBloc() {
+    return InviteRegistrationBloc(
+      authRepository: mockAuthRepo,
+      groupInviteLinkRepository: mockInviteRepo,
+      pendingInviteStorage: mockStorage,
+    );
+  }
+
+  const validEvent = InviteRegistrationSubmitted(
+    fullName: 'John Doe',
+    displayName: 'JohnD',
+    email: 'john@example.com',
+    password: 'Password1',
+    confirmPassword: 'Password1',
+    token: 'test-token',
+  );
+
+  const joinResult = (
+    groupId: 'group-123',
+    groupName: 'Beach Volleyball Crew',
+    alreadyMember: false,
+  );
+
+  void stubSuccessfulRegistration() {
+    when(() => mockAuthRepo.createUserWithEmailAndPassword(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        )).thenAnswer((_) async => FakeUserEntity());
+    when(() => mockAuthRepo.updateUserProfile(
+          displayName: any(named: 'displayName'),
+        )).thenAnswer((_) async {});
+    when(() => mockAuthRepo.sendEmailVerification())
+        .thenAnswer((_) async {});
+    when(() => mockInviteRepo.joinGroupViaInvite(token: any(named: 'token')))
+        .thenAnswer((_) async => joinResult);
+    when(() => mockStorage.clear()).thenAnswer((_) async {});
+  }
+
+  group('InviteRegistrationBloc', () {
+    test('initial state is InviteRegistrationInitial', () {
+      final bloc = buildBloc();
+      expect(bloc.state, const InviteRegistrationInitial());
+      bloc.close();
+    });
+
+    group('InviteRegistrationSubmitted', () {
+      group('successful flow', () {
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits [creatingAccount, joiningGroup, success] on successful registration and join',
+          setUp: stubSuccessfulRegistration,
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationJoiningGroup(),
+            const InviteRegistrationSuccess(
+              groupId: 'group-123',
+              groupName: 'Beach Volleyball Crew',
+            ),
+          ],
+          verify: (_) {
+            verify(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: 'john@example.com',
+                  password: 'Password1',
+                )).called(1);
+            verify(() => mockAuthRepo.updateUserProfile(
+                  displayName: 'JohnD',
+                )).called(1);
+            verify(() => mockAuthRepo.sendEmailVerification()).called(1);
+            verify(() =>
+                    mockInviteRepo.joinGroupViaInvite(token: 'test-token'))
+                .called(1);
+            verify(() => mockStorage.clear()).called(1);
+          },
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'succeeds even when display name update fails',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenAnswer((_) async => FakeUserEntity());
+            when(() => mockAuthRepo.updateUserProfile(
+                  displayName: any(named: 'displayName'),
+                )).thenThrow(Exception('Profile update failed'));
+            when(() => mockAuthRepo.sendEmailVerification())
+                .thenAnswer((_) async {});
+            when(() =>
+                    mockInviteRepo.joinGroupViaInvite(token: any(named: 'token')))
+                .thenAnswer((_) async => joinResult);
+            when(() => mockStorage.clear()).thenAnswer((_) async {});
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationJoiningGroup(),
+            const InviteRegistrationSuccess(
+              groupId: 'group-123',
+              groupName: 'Beach Volleyball Crew',
+            ),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'succeeds even when email verification fails',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenAnswer((_) async => FakeUserEntity());
+            when(() => mockAuthRepo.updateUserProfile(
+                  displayName: any(named: 'displayName'),
+                )).thenAnswer((_) async {});
+            when(() => mockAuthRepo.sendEmailVerification())
+                .thenThrow(Exception('Verification failed'));
+            when(() =>
+                    mockInviteRepo.joinGroupViaInvite(token: any(named: 'token')))
+                .thenAnswer((_) async => joinResult);
+            when(() => mockStorage.clear()).thenAnswer((_) async {});
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationJoiningGroup(),
+            const InviteRegistrationSuccess(
+              groupId: 'group-123',
+              groupName: 'Beach Volleyball Crew',
+            ),
+          ],
+        );
+      });
+
+      group('validation errors', () {
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when full name is empty',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: '',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Full name is required'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when full name is too short',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'J',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Full name must be at least 2 characters'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when display name is empty',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: '',
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Display name is required'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when display name is too short',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JD',
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Display name must be at least 3 characters'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when display name is too long',
+          build: buildBloc,
+          act: (bloc) => bloc.add(InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'A' * 31,
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Display name must be at most 30 characters'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when email is empty',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: '',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Email is required'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when email is invalid',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: 'not-an-email',
+            password: 'Password1',
+            confirmPassword: 'Password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Please enter a valid email address'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when password is too short',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'Pass1',
+            confirmPassword: 'Pass1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Password must be at least 8 characters'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when password has no uppercase',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'password1',
+            confirmPassword: 'password1',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message:
+                    'Password must contain at least 1 uppercase letter'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when password has no number',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'Password',
+            confirmPassword: 'Password',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message:
+                    'Password must contain at least 1 number'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when passwords do not match',
+          build: buildBloc,
+          act: (bloc) => bloc.add(const InviteRegistrationSubmitted(
+            fullName: 'John Doe',
+            displayName: 'JohnD',
+            email: 'john@example.com',
+            password: 'Password1',
+            confirmPassword: 'Password2',
+            token: 'test-token',
+          )),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+                message: 'Passwords do not match'),
+          ],
+        );
+      });
+
+      group('Firebase errors', () {
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure with email-already-in-use error',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenThrow(
+                Exception('email-already-in-use'));
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+              message:
+                  'An account with this email already exists. Try logging in instead.',
+              errorCode: 'email-already-in-use',
+            ),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure with weak-password error',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenThrow(Exception('weak-password'));
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+              message:
+                  'Password is too weak. Use at least 8 characters.',
+              errorCode: 'weak-password',
+            ),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure with invalid-email error',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenThrow(Exception('invalid-email'));
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+              message: 'Please enter a valid email address.',
+              errorCode: 'invalid-email',
+            ),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure with network error',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenThrow(Exception('network-request-failed'));
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(
+              message:
+                  'Unable to connect. Please check your connection and try again.',
+              errorCode: 'network-request-failed',
+            ),
+          ],
+        );
+      });
+
+      group('token expired during join', () {
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits [creatingAccount, joiningGroup, tokenExpired] when token expires during join',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenAnswer((_) async => FakeUserEntity());
+            when(() => mockAuthRepo.updateUserProfile(
+                  displayName: any(named: 'displayName'),
+                )).thenAnswer((_) async {});
+            when(() => mockAuthRepo.sendEmailVerification())
+                .thenAnswer((_) async {});
+            when(() =>
+                    mockInviteRepo.joinGroupViaInvite(token: any(named: 'token')))
+                .thenThrow(GroupInviteLinkException(
+              'Token has expired',
+              code: 'failed-precondition',
+            ));
+            when(() => mockStorage.clear()).thenAnswer((_) async {});
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationJoiningGroup(),
+            const InviteRegistrationTokenExpired(),
+          ],
+          verify: (_) {
+            verify(() => mockStorage.clear()).called(1);
+          },
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when join fails with non-precondition error',
+          setUp: () {
+            when(() => mockAuthRepo.createUserWithEmailAndPassword(
+                  email: any(named: 'email'),
+                  password: any(named: 'password'),
+                )).thenAnswer((_) async => FakeUserEntity());
+            when(() => mockAuthRepo.updateUserProfile(
+                  displayName: any(named: 'displayName'),
+                )).thenAnswer((_) async {});
+            when(() => mockAuthRepo.sendEmailVerification())
+                .thenAnswer((_) async {});
+            when(() =>
+                    mockInviteRepo.joinGroupViaInvite(token: any(named: 'token')))
+                .thenThrow(GroupInviteLinkException(
+              'Server error',
+              code: 'internal',
+            ));
+            when(() => mockStorage.clear()).thenAnswer((_) async {});
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(validEvent),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationJoiningGroup(),
+            const InviteRegistrationFailure(
+              message: 'Server error',
+              errorCode: 'internal',
+            ),
+          ],
+        );
+      });
+    });
+
+    group('InviteRegistrationFormReset', () {
+      blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+        'emits [initial] on form reset',
+        build: buildBloc,
+        seed: () => const InviteRegistrationFailure(
+            message: 'Some error'),
+        act: (bloc) => bloc.add(const InviteRegistrationFormReset()),
+        expect: () => [const InviteRegistrationInitial()],
+      );
+    });
+  });
+}

--- a/test/widget/features/invitations/presentation/pages/invite_registration_page_test.dart
+++ b/test/widget/features/invitations/presentation/pages/invite_registration_page_test.dart
@@ -1,0 +1,417 @@
+// Validates InviteRegistrationPage renders form fields, group context, validation, and state transitions correctly.
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart';
+import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart';
+import 'package:play_with_me/features/invitations/presentation/pages/invite_registration_page.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockInviteRegistrationBloc
+    extends MockBloc<InviteRegistrationEvent, InviteRegistrationState>
+    implements InviteRegistrationBloc {}
+
+void main() {
+  late MockInviteRegistrationBloc mockBloc;
+
+  setUpAll(() {
+    registerFallbackValue(const InviteRegistrationFormReset());
+    registerFallbackValue(const InviteRegistrationInitial());
+  });
+
+  setUp(() {
+    mockBloc = MockInviteRegistrationBloc();
+    when(() => mockBloc.state).thenReturn(const InviteRegistrationInitial());
+  });
+
+  tearDown(() {
+    mockBloc.close();
+  });
+
+  Widget createTestWidget({
+    String token = 'test-token',
+    String groupName = 'Beach Volleyball Crew',
+    String inviterName = 'Etienne',
+  }) {
+    return MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      routes: {
+        '/login': (_) => const Scaffold(body: Text('Login Page')),
+      },
+      home: InviteRegistrationPage(
+        token: token,
+        groupName: groupName,
+        inviterName: inviterName,
+        blocOverride: mockBloc,
+      ),
+    );
+  }
+
+  /// Helper to scroll the submit button into view and tap it.
+  Future<void> scrollAndTapSubmit(WidgetTester tester) async {
+    final submitButton = find.text('Create Account & Join');
+    await tester.ensureVisible(submitButton);
+    await tester.pumpAndSettle();
+    await tester.tap(submitButton);
+    await tester.pumpAndSettle();
+  }
+
+  group('InviteRegistrationPage', () {
+    group('renders correctly', () {
+      testWidgets('shows group context banner with group name and inviter',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Create your account to join:'), findsOneWidget);
+        expect(find.text('Beach Volleyball Crew'), findsOneWidget);
+        expect(find.text('Invited by Etienne'), findsOneWidget);
+      });
+
+      testWidgets('shows all form fields', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Full Name'), findsOneWidget);
+        expect(find.text('Display Name'), findsOneWidget);
+        expect(find.text('Email'), findsOneWidget);
+        expect(find.text('Password'), findsOneWidget);
+        // Confirm Password might need scrolling
+        await tester.ensureVisible(find.text('Confirm Password'));
+        expect(find.text('Confirm Password'), findsOneWidget);
+      });
+
+      testWidgets('shows password requirements hint', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.ensureVisible(
+          find.text('At least 8 characters, 1 uppercase letter, 1 number'),
+        );
+
+        expect(
+          find.text('At least 8 characters, 1 uppercase letter, 1 number'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows create account and join button', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.ensureVisible(find.text('Create Account & Join'));
+
+        expect(find.text('Create Account & Join'), findsOneWidget);
+      });
+
+      testWidgets('shows already have account link', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.ensureVisible(
+            find.text('Already have an account? Log in'));
+
+        expect(
+            find.text('Already have an account? Log in'), findsOneWidget);
+      });
+
+      testWidgets('shows app bar with Create Account title', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text('Create Account'), findsOneWidget);
+      });
+    });
+
+    group('form validation', () {
+      testWidgets('validates full name is required', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Full name is required'), findsOneWidget);
+      });
+
+      testWidgets('validates full name minimum length', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'J');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Full name must be at least 2 characters'),
+            findsOneWidget);
+      });
+
+      testWidgets('validates display name is required', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Display name is required'), findsOneWidget);
+      });
+
+      testWidgets('validates display name minimum length', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JD');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Display name must be at least 3 characters'),
+            findsOneWidget);
+      });
+
+      testWidgets('validates email is required', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Email is required'), findsOneWidget);
+      });
+
+      testWidgets('validates password is required', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Password is required'), findsOneWidget);
+      });
+
+      testWidgets('validates password minimum length', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        // Need to scroll to see password field first
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Password'), 'Pass1');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Password must be at least 8 characters'),
+            findsOneWidget);
+      });
+
+      testWidgets('validates password requires uppercase', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Password'), 'password1');
+        await scrollAndTapSubmit(tester);
+
+        expect(
+            find.text('Password must contain at least 1 uppercase letter'),
+            findsOneWidget);
+      });
+
+      testWidgets('validates password requires number', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Password'), 'Password');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Password must contain at least 1 number'),
+            findsOneWidget);
+      });
+
+      testWidgets('validates confirm password matches', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Password'), 'Password1');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Confirm Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Confirm Password'),
+            'Password2');
+        await scrollAndTapSubmit(tester);
+
+        expect(find.text('Passwords do not match'), findsOneWidget);
+      });
+    });
+
+    group('state-driven behavior', () {
+      testWidgets('shows loading indicator when creating account',
+          (tester) async {
+        when(() => mockBloc.state)
+            .thenReturn(const InviteRegistrationCreatingAccount());
+
+        await tester.pumpWidget(createTestWidget());
+
+        // AuthButton shows CircularProgressIndicator when isLoading is true
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('shows loading indicator when joining group',
+          (tester) async {
+        when(() => mockBloc.state)
+            .thenReturn(const InviteRegistrationJoiningGroup());
+
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('shows error snackbar on failure', (tester) async {
+        final controller =
+            StreamController<InviteRegistrationState>.broadcast();
+        whenListen(
+          mockBloc,
+          controller.stream,
+          initialState: const InviteRegistrationInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+
+        controller.add(const InviteRegistrationFailure(
+          message: 'An account with this email already exists.',
+        ));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          find.text('An account with this email already exists.'),
+          findsOneWidget,
+        );
+
+        controller.close();
+      });
+
+      testWidgets('shows token expired snackbar and navigates to login',
+          (tester) async {
+        final controller =
+            StreamController<InviteRegistrationState>.broadcast();
+        whenListen(
+          mockBloc,
+          controller.stream,
+          initialState: const InviteRegistrationInitial(),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+
+        controller.add(const InviteRegistrationTokenExpired());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          find.text(
+              'The invite link has expired, but your account was created successfully.'),
+          findsOneWidget,
+        );
+
+        // Should navigate to login
+        await tester.pumpAndSettle();
+        expect(find.text('Login Page'), findsOneWidget);
+
+        controller.close();
+      });
+    });
+
+    group('navigation', () {
+      testWidgets('already have account link navigates to login',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        final link = find.text('Already have an account? Log in');
+        await tester.ensureVisible(link);
+        await tester.pumpAndSettle();
+        await tester.tap(link);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Login Page'), findsOneWidget);
+      });
+    });
+
+    group('form submission', () {
+      testWidgets('dispatches event when form is valid and submitted',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Full Name'), 'John Doe');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Display Name'), 'JohnD');
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Email'), 'john@example.com');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Password'), 'Password1');
+        await tester.ensureVisible(
+            find.widgetWithText(TextFormField, 'Confirm Password'));
+        await tester.enterText(
+            find.widgetWithText(TextFormField, 'Confirm Password'),
+            'Password1');
+
+        await scrollAndTapSubmit(tester);
+
+        verify(() => mockBloc.add(const InviteRegistrationSubmitted(
+              fullName: 'John Doe',
+              displayName: 'JohnD',
+              email: 'john@example.com',
+              password: 'Password1',
+              confirmPassword: 'Password1',
+              token: 'test-token',
+            ))).called(1);
+      });
+
+      testWidgets('does not dispatch event when form is invalid',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Submit without filling fields
+        await scrollAndTapSubmit(tester);
+
+        verifyNever(() => mockBloc.add(any()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implements `InviteRegistrationPage` with group context banner showing the group name and inviter
- Creates `InviteRegistrationBloc` handling the full registration + automatic group join flow
- Adds form validation for Full Name (2+ chars), Display Name (3-30 chars), Email, Password (8+ chars, 1 uppercase, 1 number), and Confirm Password
- Handles all error scenarios: email-already-in-use, weak-password, invalid-email, network errors, and token expiration during registration
- Updates `InviteOnboardingPage` to navigate to the new `InviteRegistrationPage` with token and group context
- Adds localization strings to all 5 ARB files (EN, FR, DE, ES, IT)

## Changes
### New Files
- `lib/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart`
- `lib/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart`
- `lib/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart`
- `lib/features/invitations/presentation/pages/invite_registration_page.dart`
- `test/unit/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc_test.dart`
- `test/widget/features/invitations/presentation/pages/invite_registration_page_test.dart`

### Modified Files
- `lib/core/services/service_locator.dart` — Register `InviteRegistrationBloc`
- `lib/features/invitations/presentation/pages/invite_onboarding_page.dart` — Navigate to `InviteRegistrationPage` instead of `/register`
- `lib/l10n/app_*.arb` — Add new localization strings
- `test/widget/.../invite_onboarding_page_test.dart` — Update tests for new navigation

## Test plan
- [x] 22 unit tests for InviteRegistrationBloc (validation, Firebase errors, token expiration, form reset)
- [x] 23 widget tests for InviteRegistrationPage (rendering, form validation, state transitions, navigation)
- [x] Updated InviteOnboardingPage tests for new navigation behavior
- [x] `flutter analyze` passes with 0 new warnings
- [x] All 3242 tests pass (0 failures, 3 pre-existing skips)

Closes #469