### PR TITLE
Story 17.8.2: Account Status Model & Firestore Schema

### DIFF
--- a/docs/epic-17/story-17.8.2/ACCOUNT_STATUS_SCHEMA.md
+++ b/docs/epic-17/story-17.8.2/ACCOUNT_STATUS_SCHEMA.md
@@ -1,0 +1,141 @@
+# Story 17.8.2 — Account Status Model & Firestore Schema
+
+## Overview
+
+This document describes the account status data model, Firestore schema additions, and migration plan for enforcing email verification grace periods.
+
+## AccountStatus Enum
+
+```dart
+enum AccountStatus {
+  active,               // Email verified OR within 7-day grace period
+  pendingVerification,  // Within 7-day grace period, email not verified
+  restricted,           // Past 7 days, email not verified
+  scheduledForDeletion, // Past 30 days, email not verified
+}
+```
+
+## Firestore Schema (`users/{userId}`)
+
+### New Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `emailVerifiedAt` | `timestamp?` | `null` | When email was verified (null if not verified) |
+| `accountStatus` | `string` | `"pendingVerification"` | Current account status enum value |
+| `gracePeriodExpiresAt` | `timestamp` | 7 days after creation | When the 7-day grace period expires |
+| `deletionScheduledAt` | `timestamp?` | `null` | 30 days after creation (set when restricted) |
+
+### Existing Fields Used
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `createdAt` | `timestamp` | When account was created (serves as `accountCreatedAt`) |
+| `isEmailVerified` | `boolean` | Whether email has been verified |
+
+## Grace Period Timeline
+
+| Period | Duration | `accountStatus` | Behavior |
+|--------|----------|-----------------|----------|
+| Active | 0-7 days | `pendingVerification` | Full access. Warning banner shown. |
+| Restricted | 7-30 days | `restricted` | Limited access. Only profile, settings, group viewing. |
+| Deletion | 30+ days | `scheduledForDeletion` | Account deleted by scheduled Cloud Function. |
+| Verified | Any time | `active` | Full access. No restrictions. |
+
+## Status Computation
+
+The `computeAccountStatus()` function in `lib/core/domain/entities/account_status.dart` computes the status purely from:
+- `isEmailVerified` (boolean)
+- `accountCreatedAt` (DateTime)
+
+This allows both client-side computation and server-side enforcement via Cloud Functions.
+
+## Cloud Function Changes
+
+### `createUserDocument` (Auth onCreate trigger)
+
+Updated to set new fields when a user account is created:
+
+```typescript
+emailVerifiedAt: isVerified ? serverTimestamp() : null,
+accountStatus: isVerified ? "active" : "pendingVerification",
+gracePeriodExpiresAt: Timestamp.fromDate(now + 7 days),
+deletionScheduledAt: null,
+```
+
+## Migration Plan for Existing Users
+
+### Strategy: Lazy Migration + Backfill Script
+
+**Phase 1: Lazy Migration (Immediate)**
+- New `UserModel` fields have safe defaults (`accountStatus: pendingVerification`, others: `null`)
+- Existing users without these fields will get defaults when their document is read
+- The `AccountStatusBloc` computes status from `isEmailVerified` and `createdAt` regardless of stored `accountStatus`
+
+**Phase 2: Backfill Script (Before Story 17.8.4)**
+- Run a one-time Cloud Function to backfill existing user documents:
+  - Users with `isEmailVerified: true`: Set `emailVerifiedAt = createdAt`, `accountStatus = "active"`
+  - Users with `isEmailVerified: false`: Compute status from `createdAt` and set fields accordingly
+  - Set `gracePeriodExpiresAt = createdAt + 7 days` for all users
+  - Set `deletionScheduledAt = createdAt + 30 days` for users past 30 days
+
+**Phase 3: Scheduled Functions (Story 17.8.4)**
+- Daily Cloud Function to update `accountStatus` based on time elapsed
+- Separate function to delete accounts past 30 days
+
+### Backfill Script (To Be Implemented in Story 17.8.4)
+
+```typescript
+// backfillAccountStatus.ts (one-time migration)
+const usersSnapshot = await admin.firestore().collection('users').get();
+
+for (const doc of usersSnapshot.docs) {
+  const data = doc.data();
+  const createdAt = data.createdAt?.toDate() || new Date();
+  const isVerified = data.isEmailVerified || false;
+
+  const gracePeriodExpiresAt = new Date(createdAt.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  let accountStatus = 'pendingVerification';
+  let emailVerifiedAt = null;
+  let deletionScheduledAt = null;
+
+  if (isVerified) {
+    accountStatus = 'active';
+    emailVerifiedAt = data.createdAt; // Best estimate
+  } else {
+    const daysSinceCreation = (Date.now() - createdAt.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSinceCreation > 30) {
+      accountStatus = 'scheduledForDeletion';
+      deletionScheduledAt = new Date(createdAt.getTime() + 30 * 24 * 60 * 60 * 1000);
+    } else if (daysSinceCreation > 7) {
+      accountStatus = 'restricted';
+    }
+  }
+
+  await doc.ref.update({
+    emailVerifiedAt,
+    accountStatus,
+    gracePeriodExpiresAt: admin.firestore.Timestamp.fromDate(gracePeriodExpiresAt),
+    deletionScheduledAt,
+  });
+}
+```
+
+## File Structure
+
+```
+lib/core/domain/entities/account_status.dart          # Enum + computation logic
+lib/core/data/models/user_model.dart                   # Freezed model with new fields
+lib/core/presentation/bloc/account_status/             # BLoC for status management
+  account_status_bloc.dart
+  account_status_event.dart
+  account_status_state.dart
+functions/src/createUserDocument.ts                     # Updated Cloud Function
+```
+
+## Testing
+
+- `test/unit/core/domain/entities/account_status_test.dart` — Pure function tests
+- `test/unit/core/presentation/bloc/account_status/account_status_bloc_test.dart` — BLoC state tests
+- `test/unit/core/data/models/user_model_test.dart` — Serialization tests for new fields

--- a/lib/core/data/models/user_model.freezed.dart
+++ b/lib/core/data/models/user_model.freezed.dart
@@ -33,7 +33,14 @@ mixin _$UserModel {
   @TimestampConverter()
   DateTime? get updatedAt => throw _privateConstructorUsedError;
   bool get isAnonymous =>
-      throw _privateConstructorUsedError; // Extended fields for full user profile
+      throw _privateConstructorUsedError; // Account status fields (Story 17.8.2)
+  @TimestampConverter()
+  DateTime? get emailVerifiedAt => throw _privateConstructorUsedError;
+  AccountStatus get accountStatus => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get gracePeriodExpiresAt => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get deletionScheduledAt => throw _privateConstructorUsedError; // Extended fields for full user profile
   String? get firstName => throw _privateConstructorUsedError;
   String? get lastName => throw _privateConstructorUsedError;
   String? get phoneNumber => throw _privateConstructorUsedError;
@@ -105,6 +112,10 @@ abstract class $UserModelCopyWith<$Res> {
     @TimestampConverter() DateTime? lastSignInAt,
     @TimestampConverter() DateTime? updatedAt,
     bool isAnonymous,
+    @TimestampConverter() DateTime? emailVerifiedAt,
+    AccountStatus accountStatus,
+    @TimestampConverter() DateTime? gracePeriodExpiresAt,
+    @TimestampConverter() DateTime? deletionScheduledAt,
     String? firstName,
     String? lastName,
     String? phoneNumber,
@@ -171,6 +182,10 @@ class _$UserModelCopyWithImpl<$Res, $Val extends UserModel>
     Object? lastSignInAt = freezed,
     Object? updatedAt = freezed,
     Object? isAnonymous = null,
+    Object? emailVerifiedAt = freezed,
+    Object? accountStatus = null,
+    Object? gracePeriodExpiresAt = freezed,
+    Object? deletionScheduledAt = freezed,
     Object? firstName = freezed,
     Object? lastName = freezed,
     Object? phoneNumber = freezed,
@@ -244,6 +259,22 @@ class _$UserModelCopyWithImpl<$Res, $Val extends UserModel>
                 ? _value.isAnonymous
                 : isAnonymous // ignore: cast_nullable_to_non_nullable
                       as bool,
+            emailVerifiedAt: freezed == emailVerifiedAt
+                ? _value.emailVerifiedAt
+                : emailVerifiedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            accountStatus: null == accountStatus
+                ? _value.accountStatus
+                : accountStatus // ignore: cast_nullable_to_non_nullable
+                      as AccountStatus,
+            gracePeriodExpiresAt: freezed == gracePeriodExpiresAt
+                ? _value.gracePeriodExpiresAt
+                : gracePeriodExpiresAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            deletionScheduledAt: freezed == deletionScheduledAt
+                ? _value.deletionScheduledAt
+                : deletionScheduledAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
             firstName: freezed == firstName
                 ? _value.firstName
                 : firstName // ignore: cast_nullable_to_non_nullable
@@ -461,6 +492,10 @@ abstract class _$$UserModelImplCopyWith<$Res>
     @TimestampConverter() DateTime? lastSignInAt,
     @TimestampConverter() DateTime? updatedAt,
     bool isAnonymous,
+    @TimestampConverter() DateTime? emailVerifiedAt,
+    AccountStatus accountStatus,
+    @TimestampConverter() DateTime? gracePeriodExpiresAt,
+    @TimestampConverter() DateTime? deletionScheduledAt,
     String? firstName,
     String? lastName,
     String? phoneNumber,
@@ -530,6 +565,10 @@ class __$$UserModelImplCopyWithImpl<$Res>
     Object? lastSignInAt = freezed,
     Object? updatedAt = freezed,
     Object? isAnonymous = null,
+    Object? emailVerifiedAt = freezed,
+    Object? accountStatus = null,
+    Object? gracePeriodExpiresAt = freezed,
+    Object? deletionScheduledAt = freezed,
     Object? firstName = freezed,
     Object? lastName = freezed,
     Object? phoneNumber = freezed,
@@ -603,6 +642,22 @@ class __$$UserModelImplCopyWithImpl<$Res>
             ? _value.isAnonymous
             : isAnonymous // ignore: cast_nullable_to_non_nullable
                   as bool,
+        emailVerifiedAt: freezed == emailVerifiedAt
+            ? _value.emailVerifiedAt
+            : emailVerifiedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        accountStatus: null == accountStatus
+            ? _value.accountStatus
+            : accountStatus // ignore: cast_nullable_to_non_nullable
+                  as AccountStatus,
+        gracePeriodExpiresAt: freezed == gracePeriodExpiresAt
+            ? _value.gracePeriodExpiresAt
+            : gracePeriodExpiresAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        deletionScheduledAt: freezed == deletionScheduledAt
+            ? _value.deletionScheduledAt
+            : deletionScheduledAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
         firstName: freezed == firstName
             ? _value.firstName
             : firstName // ignore: cast_nullable_to_non_nullable
@@ -757,6 +812,10 @@ class _$UserModelImpl extends _UserModel {
     @TimestampConverter() this.lastSignInAt,
     @TimestampConverter() this.updatedAt,
     required this.isAnonymous,
+    @TimestampConverter() this.emailVerifiedAt,
+    this.accountStatus = AccountStatus.pendingVerification,
+    @TimestampConverter() this.gracePeriodExpiresAt,
+    @TimestampConverter() this.deletionScheduledAt,
     this.firstName,
     this.lastName,
     this.phoneNumber,
@@ -822,6 +881,19 @@ class _$UserModelImpl extends _UserModel {
   final DateTime? updatedAt;
   @override
   final bool isAnonymous;
+  // Account status fields (Story 17.8.2)
+  @override
+  @TimestampConverter()
+  final DateTime? emailVerifiedAt;
+  @override
+  @JsonKey()
+  final AccountStatus accountStatus;
+  @override
+  @TimestampConverter()
+  final DateTime? gracePeriodExpiresAt;
+  @override
+  @TimestampConverter()
+  final DateTime? deletionScheduledAt;
   // Extended fields for full user profile
   @override
   final String? firstName;
@@ -958,7 +1030,7 @@ class _$UserModelImpl extends _UserModel {
 
   @override
   String toString() {
-    return 'UserModel(uid: $uid, email: $email, displayName: $displayName, photoUrl: $photoUrl, isEmailVerified: $isEmailVerified, createdAt: $createdAt, lastSignInAt: $lastSignInAt, updatedAt: $updatedAt, isAnonymous: $isAnonymous, firstName: $firstName, lastName: $lastName, phoneNumber: $phoneNumber, dateOfBirth: $dateOfBirth, location: $location, bio: $bio, groupIds: $groupIds, gameIds: $gameIds, friendIds: $friendIds, friendCount: $friendCount, friendsLastUpdated: $friendsLastUpdated, notificationsEnabled: $notificationsEnabled, emailNotifications: $emailNotifications, pushNotifications: $pushNotifications, privacyLevel: $privacyLevel, showEmail: $showEmail, showPhoneNumber: $showPhoneNumber, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, totalScore: $totalScore, currentStreak: $currentStreak, recentGameIds: $recentGameIds, lastGameDate: $lastGameDate, teammateStats: $teammateStats, eloRating: $eloRating, eloLastUpdated: $eloLastUpdated, eloPeak: $eloPeak, eloPeakDate: $eloPeakDate, eloGamesPlayed: $eloGamesPlayed, nemesis: $nemesis, bestWin: $bestWin, pointStats: $pointStats, roleBasedStats: $roleBasedStats)';
+    return 'UserModel(uid: $uid, email: $email, displayName: $displayName, photoUrl: $photoUrl, isEmailVerified: $isEmailVerified, createdAt: $createdAt, lastSignInAt: $lastSignInAt, updatedAt: $updatedAt, isAnonymous: $isAnonymous, emailVerifiedAt: $emailVerifiedAt, accountStatus: $accountStatus, gracePeriodExpiresAt: $gracePeriodExpiresAt, deletionScheduledAt: $deletionScheduledAt, firstName: $firstName, lastName: $lastName, phoneNumber: $phoneNumber, dateOfBirth: $dateOfBirth, location: $location, bio: $bio, groupIds: $groupIds, gameIds: $gameIds, friendIds: $friendIds, friendCount: $friendCount, friendsLastUpdated: $friendsLastUpdated, notificationsEnabled: $notificationsEnabled, emailNotifications: $emailNotifications, pushNotifications: $pushNotifications, privacyLevel: $privacyLevel, showEmail: $showEmail, showPhoneNumber: $showPhoneNumber, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, totalScore: $totalScore, currentStreak: $currentStreak, recentGameIds: $recentGameIds, lastGameDate: $lastGameDate, teammateStats: $teammateStats, eloRating: $eloRating, eloLastUpdated: $eloLastUpdated, eloPeak: $eloPeak, eloPeakDate: $eloPeakDate, eloGamesPlayed: $eloGamesPlayed, nemesis: $nemesis, bestWin: $bestWin, pointStats: $pointStats, roleBasedStats: $roleBasedStats)';
   }
 
   @override
@@ -982,6 +1054,14 @@ class _$UserModelImpl extends _UserModel {
                 other.updatedAt == updatedAt) &&
             (identical(other.isAnonymous, isAnonymous) ||
                 other.isAnonymous == isAnonymous) &&
+            (identical(other.emailVerifiedAt, emailVerifiedAt) ||
+                other.emailVerifiedAt == emailVerifiedAt) &&
+            (identical(other.accountStatus, accountStatus) ||
+                other.accountStatus == accountStatus) &&
+            (identical(other.gracePeriodExpiresAt, gracePeriodExpiresAt) ||
+                other.gracePeriodExpiresAt == gracePeriodExpiresAt) &&
+            (identical(other.deletionScheduledAt, deletionScheduledAt) ||
+                other.deletionScheduledAt == deletionScheduledAt) &&
             (identical(other.firstName, firstName) ||
                 other.firstName == firstName) &&
             (identical(other.lastName, lastName) ||
@@ -1065,6 +1145,10 @@ class _$UserModelImpl extends _UserModel {
     lastSignInAt,
     updatedAt,
     isAnonymous,
+    emailVerifiedAt,
+    accountStatus,
+    gracePeriodExpiresAt,
+    deletionScheduledAt,
     firstName,
     lastName,
     phoneNumber,
@@ -1126,6 +1210,10 @@ abstract class _UserModel extends UserModel {
     @TimestampConverter() final DateTime? lastSignInAt,
     @TimestampConverter() final DateTime? updatedAt,
     required final bool isAnonymous,
+    @TimestampConverter() final DateTime? emailVerifiedAt,
+    final AccountStatus accountStatus,
+    @TimestampConverter() final DateTime? gracePeriodExpiresAt,
+    @TimestampConverter() final DateTime? deletionScheduledAt,
     final String? firstName,
     final String? lastName,
     final String? phoneNumber,
@@ -1186,7 +1274,18 @@ abstract class _UserModel extends UserModel {
   @TimestampConverter()
   DateTime? get updatedAt;
   @override
-  bool get isAnonymous; // Extended fields for full user profile
+  bool get isAnonymous; // Account status fields (Story 17.8.2)
+  @override
+  @TimestampConverter()
+  DateTime? get emailVerifiedAt;
+  @override
+  AccountStatus get accountStatus;
+  @override
+  @TimestampConverter()
+  DateTime? get gracePeriodExpiresAt;
+  @override
+  @TimestampConverter()
+  DateTime? get deletionScheduledAt; // Extended fields for full user profile
   @override
   String? get firstName;
   @override

--- a/lib/core/data/models/user_model.g.dart
+++ b/lib/core/data/models/user_model.g.dart
@@ -18,6 +18,16 @@ _$UserModelImpl _$$UserModelImplFromJson(
   lastSignInAt: const TimestampConverter().fromJson(json['lastSignInAt']),
   updatedAt: const TimestampConverter().fromJson(json['updatedAt']),
   isAnonymous: json['isAnonymous'] as bool,
+  emailVerifiedAt: const TimestampConverter().fromJson(json['emailVerifiedAt']),
+  accountStatus:
+      $enumDecodeNullable(_$AccountStatusEnumMap, json['accountStatus']) ??
+      AccountStatus.pendingVerification,
+  gracePeriodExpiresAt: const TimestampConverter().fromJson(
+    json['gracePeriodExpiresAt'],
+  ),
+  deletionScheduledAt: const TimestampConverter().fromJson(
+    json['deletionScheduledAt'],
+  ),
   firstName: json['firstName'] as String?,
   lastName: json['lastName'] as String?,
   phoneNumber: json['phoneNumber'] as String?,
@@ -90,6 +100,16 @@ Map<String, dynamic> _$$UserModelImplToJson(
   'lastSignInAt': const TimestampConverter().toJson(instance.lastSignInAt),
   'updatedAt': const TimestampConverter().toJson(instance.updatedAt),
   'isAnonymous': instance.isAnonymous,
+  'emailVerifiedAt': const TimestampConverter().toJson(
+    instance.emailVerifiedAt,
+  ),
+  'accountStatus': _$AccountStatusEnumMap[instance.accountStatus]!,
+  'gracePeriodExpiresAt': const TimestampConverter().toJson(
+    instance.gracePeriodExpiresAt,
+  ),
+  'deletionScheduledAt': const TimestampConverter().toJson(
+    instance.deletionScheduledAt,
+  ),
   'firstName': instance.firstName,
   'lastName': instance.lastName,
   'phoneNumber': instance.phoneNumber,
@@ -126,6 +146,13 @@ Map<String, dynamic> _$$UserModelImplToJson(
   'bestWin': instance.bestWin,
   'pointStats': instance.pointStats,
   'roleBasedStats': instance.roleBasedStats,
+};
+
+const _$AccountStatusEnumMap = {
+  AccountStatus.active: 'active',
+  AccountStatus.pendingVerification: 'pendingVerification',
+  AccountStatus.restricted: 'restricted',
+  AccountStatus.scheduledForDeletion: 'scheduledForDeletion',
 };
 
 const _$UserPrivacyLevelEnumMap = {

--- a/lib/core/domain/entities/account_status.dart
+++ b/lib/core/domain/entities/account_status.dart
@@ -1,3 +1,5 @@
+import 'package:json_annotation/json_annotation.dart';
+
 /// Account status based on email verification and account age.
 ///
 /// Used to enforce the grace period policy:
@@ -6,15 +8,19 @@
 /// - 30+ days: Scheduled for deletion
 enum AccountStatus {
   /// Email verified OR within 7-day grace period with verified email
+  @JsonValue('active')
   active,
 
   /// Within 7-day grace period, email not verified
+  @JsonValue('pendingVerification')
   pendingVerification,
 
   /// Past 7 days, email not verified
+  @JsonValue('restricted')
   restricted,
 
   /// Past 30 days, email not verified
+  @JsonValue('scheduledForDeletion')
   scheduledForDeletion,
 }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -556,5 +556,12 @@
   "verifyEmailWarning": "Bestätigen Sie Ihre E-Mail, um Ihr Konto zu behalten. Noch {daysRemaining} Tage.",
   "verifyNow": "Jetzt bestätigen",
   "dismiss": "Schließen",
-  "emailVerifiedSuccess": "E-Mail erfolgreich bestätigt!"
+  "emailVerifiedSuccess": "E-Mail erfolgreich bestätigt!",
+
+  "accountRestricted": "Ihr Konto ist eingeschränkt. Bestätigen Sie Ihre E-Mail, um den vollen Zugang wiederherzustellen. {daysUntilDeletion} Tage bis zur Kontolöschung.",
+  "accountScheduledForDeletion": "Ihr Konto ist zur Löschung vorgesehen. Bestätigen Sie jetzt Ihre E-Mail, um Ihr Konto zu behalten.",
+  "accountStatusActive": "Aktiv",
+  "accountStatusPendingVerification": "Bestätigung ausstehend",
+  "accountStatusRestricted": "Eingeschränkt",
+  "accountStatusScheduledForDeletion": "Löschung geplant"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2647,5 +2647,41 @@
   "emailVerifiedSuccess": "Email verified successfully!",
   "@emailVerifiedSuccess": {
     "description": "Success message shown when email verification is confirmed"
+  },
+
+  "accountRestricted": "Your account is restricted. Verify your email to regain full access. {daysUntilDeletion} days until account deletion.",
+  "@accountRestricted": {
+    "description": "Warning message shown when account is restricted due to unverified email past grace period",
+    "placeholders": {
+      "daysUntilDeletion": {
+        "type": "int",
+        "description": "Number of days until account is permanently deleted"
+      }
+    }
+  },
+
+  "accountScheduledForDeletion": "Your account is scheduled for deletion. Verify your email now to keep your account.",
+  "@accountScheduledForDeletion": {
+    "description": "Warning message shown when account is past 30 days without email verification"
+  },
+
+  "accountStatusActive": "Active",
+  "@accountStatusActive": {
+    "description": "Label for active account status"
+  },
+
+  "accountStatusPendingVerification": "Pending Verification",
+  "@accountStatusPendingVerification": {
+    "description": "Label for pending verification account status"
+  },
+
+  "accountStatusRestricted": "Restricted",
+  "@accountStatusRestricted": {
+    "description": "Label for restricted account status"
+  },
+
+  "accountStatusScheduledForDeletion": "Scheduled for Deletion",
+  "@accountStatusScheduledForDeletion": {
+    "description": "Label for scheduled-for-deletion account status"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -556,5 +556,12 @@
   "verifyEmailWarning": "Verifica tu email para conservar tu cuenta. {daysRemaining} días restantes.",
   "verifyNow": "Verificar ahora",
   "dismiss": "Cerrar",
-  "emailVerifiedSuccess": "¡Email verificado exitosamente!"
+  "emailVerifiedSuccess": "¡Email verificado exitosamente!",
+
+  "accountRestricted": "Tu cuenta está restringida. Verifica tu email para recuperar el acceso completo. {daysUntilDeletion} días hasta la eliminación de la cuenta.",
+  "accountScheduledForDeletion": "Tu cuenta está programada para eliminación. Verifica tu email ahora para conservar tu cuenta.",
+  "accountStatusActive": "Activa",
+  "accountStatusPendingVerification": "Verificación pendiente",
+  "accountStatusRestricted": "Restringida",
+  "accountStatusScheduledForDeletion": "Eliminación programada"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -556,5 +556,12 @@
   "verifyEmailWarning": "Vérifiez votre email pour conserver votre compte. {daysRemaining} jours restants.",
   "verifyNow": "Vérifier maintenant",
   "dismiss": "Fermer",
-  "emailVerifiedSuccess": "Email vérifié avec succès !"
+  "emailVerifiedSuccess": "Email vérifié avec succès !",
+
+  "accountRestricted": "Votre compte est restreint. Vérifiez votre email pour retrouver un accès complet. {daysUntilDeletion} jours avant la suppression du compte.",
+  "accountScheduledForDeletion": "Votre compte est prévu pour suppression. Vérifiez votre email maintenant pour conserver votre compte.",
+  "accountStatusActive": "Actif",
+  "accountStatusPendingVerification": "Vérification en attente",
+  "accountStatusRestricted": "Restreint",
+  "accountStatusScheduledForDeletion": "Suppression prévue"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -556,5 +556,12 @@
   "verifyEmailWarning": "Verifica la tua email per mantenere il tuo account. {daysRemaining} giorni rimanenti.",
   "verifyNow": "Verifica ora",
   "dismiss": "Chiudi",
-  "emailVerifiedSuccess": "Email verificata con successo!"
+  "emailVerifiedSuccess": "Email verificata con successo!",
+
+  "accountRestricted": "Il tuo account è limitato. Verifica la tua email per riottenere l'accesso completo. {daysUntilDeletion} giorni alla cancellazione dell'account.",
+  "accountScheduledForDeletion": "Il tuo account è in programma per la cancellazione. Verifica la tua email ora per mantenere il tuo account.",
+  "accountStatusActive": "Attivo",
+  "accountStatusPendingVerification": "Verifica in sospeso",
+  "accountStatusRestricted": "Limitato",
+  "accountStatusScheduledForDeletion": "Cancellazione programmata"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3373,6 +3373,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Email verified successfully!'**
   String get emailVerifiedSuccess;
+
+  /// Warning message shown when account is restricted due to unverified email past grace period
+  ///
+  /// In en, this message translates to:
+  /// **'Your account is restricted. Verify your email to regain full access. {daysUntilDeletion} days until account deletion.'**
+  String accountRestricted(int daysUntilDeletion);
+
+  /// Warning message shown when account is past 30 days without email verification
+  ///
+  /// In en, this message translates to:
+  /// **'Your account is scheduled for deletion. Verify your email now to keep your account.'**
+  String get accountScheduledForDeletion;
+
+  /// Label for active account status
+  ///
+  /// In en, this message translates to:
+  /// **'Active'**
+  String get accountStatusActive;
+
+  /// Label for pending verification account status
+  ///
+  /// In en, this message translates to:
+  /// **'Pending Verification'**
+  String get accountStatusPendingVerification;
+
+  /// Label for restricted account status
+  ///
+  /// In en, this message translates to:
+  /// **'Restricted'**
+  String get accountStatusRestricted;
+
+  /// Label for scheduled-for-deletion account status
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled for Deletion'**
+  String get accountStatusScheduledForDeletion;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1839,4 +1839,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get emailVerifiedSuccess => 'E-Mail erfolgreich bestätigt!';
+
+  @override
+  String accountRestricted(int daysUntilDeletion) {
+    return 'Ihr Konto ist eingeschränkt. Bestätigen Sie Ihre E-Mail, um den vollen Zugang wiederherzustellen. $daysUntilDeletion Tage bis zur Kontolöschung.';
+  }
+
+  @override
+  String get accountScheduledForDeletion =>
+      'Ihr Konto ist zur Löschung vorgesehen. Bestätigen Sie jetzt Ihre E-Mail, um Ihr Konto zu behalten.';
+
+  @override
+  String get accountStatusActive => 'Aktiv';
+
+  @override
+  String get accountStatusPendingVerification => 'Bestätigung ausstehend';
+
+  @override
+  String get accountStatusRestricted => 'Eingeschränkt';
+
+  @override
+  String get accountStatusScheduledForDeletion => 'Löschung geplant';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1808,4 +1808,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get emailVerifiedSuccess => 'Email verified successfully!';
+
+  @override
+  String accountRestricted(int daysUntilDeletion) {
+    return 'Your account is restricted. Verify your email to regain full access. $daysUntilDeletion days until account deletion.';
+  }
+
+  @override
+  String get accountScheduledForDeletion =>
+      'Your account is scheduled for deletion. Verify your email now to keep your account.';
+
+  @override
+  String get accountStatusActive => 'Active';
+
+  @override
+  String get accountStatusPendingVerification => 'Pending Verification';
+
+  @override
+  String get accountStatusRestricted => 'Restricted';
+
+  @override
+  String get accountStatusScheduledForDeletion => 'Scheduled for Deletion';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1832,4 +1832,25 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get emailVerifiedSuccess => '¡Email verificado exitosamente!';
+
+  @override
+  String accountRestricted(int daysUntilDeletion) {
+    return 'Tu cuenta está restringida. Verifica tu email para recuperar el acceso completo. $daysUntilDeletion días hasta la eliminación de la cuenta.';
+  }
+
+  @override
+  String get accountScheduledForDeletion =>
+      'Tu cuenta está programada para eliminación. Verifica tu email ahora para conservar tu cuenta.';
+
+  @override
+  String get accountStatusActive => 'Activa';
+
+  @override
+  String get accountStatusPendingVerification => 'Verificación pendiente';
+
+  @override
+  String get accountStatusRestricted => 'Restringida';
+
+  @override
+  String get accountStatusScheduledForDeletion => 'Eliminación programada';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1842,4 +1842,25 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get emailVerifiedSuccess => 'Email vérifié avec succès !';
+
+  @override
+  String accountRestricted(int daysUntilDeletion) {
+    return 'Votre compte est restreint. Vérifiez votre email pour retrouver un accès complet. $daysUntilDeletion jours avant la suppression du compte.';
+  }
+
+  @override
+  String get accountScheduledForDeletion =>
+      'Votre compte est prévu pour suppression. Vérifiez votre email maintenant pour conserver votre compte.';
+
+  @override
+  String get accountStatusActive => 'Actif';
+
+  @override
+  String get accountStatusPendingVerification => 'Vérification en attente';
+
+  @override
+  String get accountStatusRestricted => 'Restreint';
+
+  @override
+  String get accountStatusScheduledForDeletion => 'Suppression prévue';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1827,4 +1827,25 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get emailVerifiedSuccess => 'Email verificata con successo!';
+
+  @override
+  String accountRestricted(int daysUntilDeletion) {
+    return 'Il tuo account è limitato. Verifica la tua email per riottenere l\'accesso completo. $daysUntilDeletion giorni alla cancellazione dell\'account.';
+  }
+
+  @override
+  String get accountScheduledForDeletion =>
+      'Il tuo account è in programma per la cancellazione. Verifica la tua email ora per mantenere il tuo account.';
+
+  @override
+  String get accountStatusActive => 'Attivo';
+
+  @override
+  String get accountStatusPendingVerification => 'Verifica in sospeso';
+
+  @override
+  String get accountStatusRestricted => 'Limitato';
+
+  @override
+  String get accountStatusScheduledForDeletion => 'Cancellazione programmata';
 }


### PR DESCRIPTION
## Summary

- Added account status fields (`emailVerifiedAt`, `accountStatus`, `gracePeriodExpiresAt`, `deletionScheduledAt`) to the core `UserModel` with Freezed serialization support
- Updated `createUserDocument` Cloud Function to initialize new account status fields when a user account is created
- Added `@JsonValue` annotations to `AccountStatus` enum for proper Firestore serialization
- Added localized strings for restricted and scheduled-for-deletion account states in all 5 languages (EN, FR, DE, ES, IT)
- Added comprehensive unit tests for new fields (serialization, deserialization, defaults, backward compatibility)
- Created migration plan documentation for existing users

## Test plan

- [x] All 2519 unit tests pass (9 new tests added)
- [x] All widget tests pass
- [x] `flutter analyze` passes with 0 new warnings
- [x] Cloud Functions compile and deploy successfully to dev/stg/prod
- [x] Backward compatibility verified — existing user documents without new fields get safe defaults
- [x] All `AccountStatus` enum values serialize/deserialize correctly

Closes #479