### PR TITLE
fix(friends): export missing Cloud Function and auto-refresh requests tab

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -51,6 +51,7 @@ export {
   getFriendships, // Story 11.13
   verifyFriendship, // Story 11.14
   batchCheckFriendship, // Story 11.17
+  batchCheckFriendRequestStatus,
 } from "./friendships";
 
 // Export friendship cache update triggers (Firestore triggers)

--- a/lib/features/friends/presentation/pages/my_community_page.dart
+++ b/lib/features/friends/presentation/pages/my_community_page.dart
@@ -40,6 +40,11 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
   void initState() {
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() {
+      if (_tabController.index == 1 && !_tabController.indexIsChanging) {
+        context.read<FriendBloc>().add(const FriendEvent.loadRequested());
+      }
+    });
   }
 
   @override
@@ -266,7 +271,9 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
               child: const AddFriendPage(),
             ),
           ),
-        );
+        ).then((_) {
+          friendBloc.add(const FriendEvent.loadRequested());
+        });
       },
       icon: const Icon(Icons.person_add),
       label: Text(l10n.addFriend),


### PR DESCRIPTION
## Summary

- **Export missing `batchCheckFriendRequestStatus`** from `functions/src/index.ts` — this Cloud Function was fully implemented but never deployed because it wasn't exported from the entry point. It's called from the group details page to check friend request status of members, and its absence caused silent failures on Android.
- **Auto-refresh requests list on tab switch** — the "Requests" tab in My Community now reloads friend requests when the user navigates to it, instead of showing stale data from the initial load.
- **Auto-refresh on return from AddFriendPage** — after sending a friend request from the Add Friend page, the requests list reloads when navigating back so newly sent requests appear immediately.

## Test plan

- [x] All 3317 unit/widget tests pass (0 failures)
- [x] `flutter analyze` passes with 0 issues
- [x] Cloud Function deployed to stg and prod
- [ ] Manual test: send friend request from group member list on Android -> verify it arrives
- [ ] Manual test: switch to Requests tab -> verify list refreshes with latest data
- [ ] Manual test: send request from Add Friend page -> return -> verify it appears in Sent list

🤖 Generated with [Claude Code](https://claude.com/claude-code)