### PR TITLE
fix(groups): show displayName for invite-link users in group details

### DIFF
--- a/functions/src/getUsersByIds.ts
+++ b/functions/src/getUsersByIds.ts
@@ -16,6 +16,8 @@ export interface PublicUserData {
   displayName: string | null;
   email: string;
   photoUrl: string | null;
+  firstName: string | null;
+  lastName: string | null;
 }
 
 /**
@@ -108,6 +110,8 @@ export async function getUsersByIdsHandler(
             displayName: userData.displayName || null,
             email: userData.email || "",
             photoUrl: userData.photoUrl || null,
+            firstName: userData.firstName || null,
+            lastName: userData.lastName || null,
           });
         }
       }

--- a/functions/test/getUsersByIds.test.ts
+++ b/functions/test/getUsersByIds.test.ts
@@ -127,6 +127,8 @@ describe("getUsersByIds", () => {
           displayName: "User One",
           email: "user1@example.com",
           photoUrl: "https://example.com/photo1.jpg",
+          firstName: "User",
+          lastName: "One",
           // Sensitive fields that should not be returned
           passwordHash: "secret",
           tokens: ["token1"],
@@ -139,6 +141,8 @@ describe("getUsersByIds", () => {
           displayName: "User Two",
           email: "user2@example.com",
           photoUrl: null,
+          firstName: "User",
+          lastName: "Two",
         }),
       },
       {
@@ -172,18 +176,24 @@ describe("getUsersByIds", () => {
       displayName: "User One",
       email: "user1@example.com",
       photoUrl: "https://example.com/photo1.jpg",
+      firstName: "User",
+      lastName: "One",
     });
     expect(result.users[1]).toEqual({
       uid: "user2",
       displayName: "User Two",
       email: "user2@example.com",
       photoUrl: null,
+      firstName: "User",
+      lastName: "Two",
     });
     expect(result.users[2]).toEqual({
       uid: "user3",
       displayName: null,
       email: "user3@example.com",
       photoUrl: null,
+      firstName: null,
+      lastName: null,
     });
 
     // Verify sensitive fields are NOT returned
@@ -209,6 +219,8 @@ describe("getUsersByIds", () => {
           displayName: "User One",
           email: "user1@example.com",
           photoUrl: null,
+          firstName: "User",
+          lastName: "One",
         }),
       },
       {
@@ -223,6 +235,8 @@ describe("getUsersByIds", () => {
           displayName: "User Three",
           email: "user3@example.com",
           photoUrl: null,
+          firstName: "User",
+          lastName: "Three",
         }),
       },
     ];

--- a/lib/core/data/repositories/firestore_user_repository.dart
+++ b/lib/core/data/repositories/firestore_user_repository.dart
@@ -120,6 +120,8 @@ class FirestoreUserRepository implements UserRepository {
           email: userData['email'] as String,
           displayName: userData['displayName'] as String?,
           photoUrl: userData['photoUrl'] as String?,
+          firstName: userData['firstName'] as String?,
+          lastName: userData['lastName'] as String?,
           isEmailVerified: false, // Not returned by Cloud Function
           isAnonymous: false, // Not returned by Cloud Function
         );
@@ -373,6 +375,8 @@ class FirestoreUserRepository implements UserRepository {
           email: userData['email'] as String,
           displayName: userData['displayName'] as String?,
           photoUrl: userData['photoUrl'] as String?,
+          firstName: userData['firstName'] as String?,
+          lastName: userData['lastName'] as String?,
           isEmailVerified: false, // Not returned by Cloud Function
           isAnonymous: false, // Not returned by Cloud Function
         );

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -449,7 +449,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
                           child: member.photoUrl == null
                               ? Text(
                                   _getInitials(
-                                      member.displayName ?? member.email),
+                                      member.fullDisplayName),
                                   style: TextStyle(
                                       fontWeight: FontWeight.bold,
                                       color: Color(0xFF004E64)),
@@ -457,7 +457,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent> {
                               : null,
                         ),
                         title: Text(
-                          member.displayName ?? member.email,
+                          member.fullDisplayName,
                           style: const TextStyle(fontWeight: FontWeight.w500),
                         ),
                         trailing: const SizedBox(

--- a/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
+++ b/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
@@ -37,7 +37,7 @@ class MemberListItemWithFriendship extends StatelessWidget {
             user.photoUrl != null ? NetworkImage(user.photoUrl!) : null,
         child: user.photoUrl == null
             ? Text(
-                _getInitials(user.displayName ?? user.email),
+                _getInitials(user.fullDisplayName),
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   color: Color(0xFF004E64),
@@ -49,7 +49,7 @@ class MemberListItemWithFriendship extends StatelessWidget {
         children: [
           Flexible(
             child: Text(
-              user.displayName ?? user.email,
+              user.fullDisplayName,
               style: const TextStyle(fontWeight: FontWeight.w500),
               overflow: TextOverflow.ellipsis,
             ),
@@ -92,7 +92,7 @@ class MemberListItemWithFriendship extends StatelessWidget {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (user.displayName != null) Text(user.email),
+          if (user.fullDisplayName != user.email) Text(user.email),
           if (!isCurrentUser) _buildFriendshipStatus(context),
         ],
       ),

--- a/test/unit/core/data/repositories/firestore_user_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_user_repository_test.dart
@@ -627,12 +627,16 @@ void main() {
               'email': 'user1@example.com',
               'displayName': 'User 1',
               'photoUrl': null,
+              'firstName': 'User',
+              'lastName': 'One',
             },
             {
               'uid': 'user-2',
               'email': 'user2@example.com',
               'displayName': 'User 2',
               'photoUrl': null,
+              'firstName': 'User',
+              'lastName': 'Two',
             },
           ],
         });
@@ -641,6 +645,8 @@ void main() {
 
         expect(result.length, 2);
         expect(result.map((u) => u.displayName), containsAll(['User 1', 'User 2']));
+        expect(result[0].firstName, 'User');
+        expect(result[0].lastName, 'One');
         verify(() => mockFunctions.httpsCallable('getUsersByIds')).called(1);
       });
 
@@ -842,12 +848,16 @@ void main() {
               'email': 'user1@example.com',
               'displayName': 'User 1',
               'photoUrl': null,
+              'firstName': 'User',
+              'lastName': 'One',
             },
             {
               'uid': 'user-2',
               'email': 'user2@example.com',
               'displayName': 'User 2',
               'photoUrl': null,
+              'firstName': 'User',
+              'lastName': 'Two',
             },
           ],
         });
@@ -856,6 +866,39 @@ void main() {
 
         expect(result.length, 2);
         expect(result.map((u) => u.uid), containsAll(['user-1', 'user-2']));
+        expect(result[0].firstName, 'User');
+        expect(result[0].lastName, 'One');
+        expect(result[1].firstName, 'User');
+        expect(result[1].lastName, 'Two');
+      });
+
+      test('returns users with firstName/lastName even when displayName is null', () async {
+        final mockCallable = MockHttpsCallable();
+        final mockResult = MockHttpsCallableResult<Map<String, dynamic>>();
+
+        when(() => mockFunctions.httpsCallable('getUsersByIds'))
+            .thenReturn(mockCallable);
+        when(() => mockCallable.call(any())).thenAnswer((_) async => mockResult);
+        when(() => mockResult.data).thenReturn({
+          'users': [
+            {
+              'uid': 'user-1',
+              'email': 'user1@example.com',
+              'displayName': null,
+              'photoUrl': null,
+              'firstName': 'Etienne',
+              'lastName': 'Dubois',
+            },
+          ],
+        });
+
+        final result = await repository.getUsersByIds(['user-1']);
+
+        expect(result.length, 1);
+        expect(result.first.displayName, isNull);
+        expect(result.first.firstName, 'Etienne');
+        expect(result.first.lastName, 'Dubois');
+        expect(result.first.fullDisplayName, 'Etienne Dubois');
       });
 
       test('throws UserException on Cloud Function error', () async {


### PR DESCRIPTION
## Summary

- **Root cause**: `getUsersByIds` Cloud Function did not return `firstName`/`lastName` fields, so invite-link users (who may have null `displayName`) showed only their email in the group member list
- Updated `getUsersByIds` Cloud Function to include `firstName` and `lastName` in the response
- Updated Dart repository (`getUsersByIds` and `getUsersInGroup`) to extract these fields
- Updated UI (`MemberListItemWithFriendship`, `GroupDetailsPage`) to use `fullDisplayName` which falls back to `firstName + lastName` when `displayName` is null

Fixes #498

## Files Changed

| File | Change |
|------|--------|
| `functions/src/getUsersByIds.ts` | Added `firstName`/`lastName` to `PublicUserData` interface and response |
| `lib/core/data/repositories/firestore_user_repository.dart` | Extract `firstName`/`lastName` from Cloud Function response |
| `lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart` | Use `user.fullDisplayName` instead of `user.displayName ?? user.email` |
| `lib/features/groups/presentation/pages/group_details_page.dart` | Use `member.fullDisplayName` in loading state |
| `functions/test/getUsersByIds.test.ts` | Updated tests to verify firstName/lastName in response |
| `test/unit/core/data/repositories/firestore_user_repository_test.dart` | Added tests for firstName/lastName extraction |

## Test plan

- [x] Cloud Function unit tests pass (9/9)
- [x] Dart unit tests pass (57/57 in repository test file)
- [x] Widget tests pass (20/20 for group details page)
- [x] Full test suite passes (2744+ tests, 0 failures)
- [x] `flutter analyze` clean (no new warnings)
- [x] Cloud Functions deployed to dev, staging, and production