### PR TITLE
fix(notifications): enable push notifications on physical iOS devices

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -263,6 +263,11 @@
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1100;
+						SystemCapabilities = {
+							com.apple.Push = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:playwithme.app</string>


### PR DESCRIPTION
## Summary

Closes #500

Push notifications worked on Android emulators but never delivered on physical iPhones because **the `aps-environment` entitlement was missing** from `ios/Runner/Runner.entitlements`. Without it, APNs never issues an APNS token; without an APNS token, `firebase_messaging` cannot obtain an FCM token; with no FCM token in Firestore, every Cloud Function (`onGameCreated`, `onInvitationCreated`, `onFriendRequestSent`, etc.) finds an empty `fcmTokens` array and silently skips the notification.

### Changes

| File | What changed | Why |
|------|-------------|-----|
| `ios/Runner/Runner.entitlements` | Added `aps-environment = development` | **Primary fix** — grants the app the APNs entitlement so iOS issues an APNS token |
| `ios/Runner.xcodeproj/project.pbxproj` | Added `SystemCapabilities.com.apple.Push.enabled = 1` to the Runner target | Registers Push Notifications capability in Xcode; prevents capability mismatch warnings |
| `lib/features/notifications/data/services/notification_service.dart` | Moved `onTokenRefresh.listen()` before `_initializeFcmToken()`; increased APNS retry 3 → 5; improved log messages | Eliminates a race condition where a token-refresh event could be missed; clearer diagnostics for future debugging |
| `test/unit/.../notification_service_test.dart` | +5 unit tests; removed pre-existing `unused_import` warning | Covers permission-denied early return and `saveTokenToFirestore` persistence contract |

### Test plan

- [x] `flutter test test/unit/` — 2527 passed, 3 skipped (was 2522 before; 5 new tests added)
- [x] `flutter analyze` — 66 warnings (was 67; reduced by fixing pre-existing unused import, introduced zero new warnings)
- [ ] Physical iPhone: grant notification permissions → trigger a game creation → verify push notification is received (requires physical device with valid Apple provisioning profile that includes Push Notifications)

### Notes for reviewer

- The `aps-environment = development` value is correct for **Debug and Release** builds. For App Store / TestFlight distribution, Xcode's code-signing pipeline automatically upgrades the entitlement to `production` based on the distribution certificate type.
- The `associated-domains` deep-link entitlement is **preserved** in the entitlements file.

Authored-by: Babas10 <etienne.dubois91@gmail.com>