### PR TITLE
fix(community): show correct error message when searching non-existent user

### DIFF
--- a/lib/features/friends/presentation/bloc/friend_bloc.dart
+++ b/lib/features/friends/presentation/bloc/friend_bloc.dart
@@ -199,6 +199,7 @@ class FriendBloc extends Bloc<FriendEvent, FriendState> {
           hasPendingRequest: false,
           requestDirection: null,
           searchedEmail: event.email,
+          isSelfSearch: true,
         ));
         return;
       }

--- a/lib/features/friends/presentation/bloc/friend_state.dart
+++ b/lib/features/friends/presentation/bloc/friend_state.dart
@@ -31,6 +31,7 @@ class FriendState with _$FriendState {
     required bool hasPendingRequest,
     String? requestDirection,
     required String searchedEmail,
+    @Default(false) bool isSelfSearch,
   }) = FriendSearchResult;
 
   /// Status check result state

--- a/lib/features/friends/presentation/bloc/friend_state.freezed.dart
+++ b/lib/features/friends/presentation/bloc/friend_state.freezed.dart
@@ -34,6 +34,7 @@ mixin _$FriendState {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -57,6 +58,7 @@ mixin _$FriendState {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -80,6 +82,7 @@ mixin _$FriendState {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -203,6 +206,7 @@ class _$FriendInitialImpl implements FriendInitial {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -230,6 +234,7 @@ class _$FriendInitialImpl implements FriendInitial {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -257,6 +262,7 @@ class _$FriendInitialImpl implements FriendInitial {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -382,6 +388,7 @@ class _$FriendLoadingImpl implements FriendLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -409,6 +416,7 @@ class _$FriendLoadingImpl implements FriendLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -436,6 +444,7 @@ class _$FriendLoadingImpl implements FriendLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -645,6 +654,7 @@ class _$FriendLoadedImpl implements FriendLoaded {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -672,6 +682,7 @@ class _$FriendLoadedImpl implements FriendLoaded {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -699,6 +710,7 @@ class _$FriendLoadedImpl implements FriendLoaded {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -839,6 +851,7 @@ class _$FriendSearchLoadingImpl implements FriendSearchLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -866,6 +879,7 @@ class _$FriendSearchLoadingImpl implements FriendSearchLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -893,6 +907,7 @@ class _$FriendSearchLoadingImpl implements FriendSearchLoading {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -973,6 +988,7 @@ abstract class _$$FriendSearchResultImplCopyWith<$Res> {
     bool hasPendingRequest,
     String? requestDirection,
     String searchedEmail,
+    bool isSelfSearch,
   });
 
   $UserEntityCopyWith<$Res>? get user;
@@ -997,6 +1013,7 @@ class __$$FriendSearchResultImplCopyWithImpl<$Res>
     Object? hasPendingRequest = null,
     Object? requestDirection = freezed,
     Object? searchedEmail = null,
+    Object? isSelfSearch = null,
   }) {
     return _then(
       _$FriendSearchResultImpl(
@@ -1020,6 +1037,10 @@ class __$$FriendSearchResultImplCopyWithImpl<$Res>
             ? _value.searchedEmail
             : searchedEmail // ignore: cast_nullable_to_non_nullable
                   as String,
+        isSelfSearch: null == isSelfSearch
+            ? _value.isSelfSearch
+            : isSelfSearch // ignore: cast_nullable_to_non_nullable
+                  as bool,
       ),
     );
   }
@@ -1048,6 +1069,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
     required this.hasPendingRequest,
     this.requestDirection,
     required this.searchedEmail,
+    this.isSelfSearch = false,
   });
 
   @override
@@ -1060,10 +1082,13 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
   final String? requestDirection;
   @override
   final String searchedEmail;
+  @override
+  @JsonKey()
+  final bool isSelfSearch;
 
   @override
   String toString() {
-    return 'FriendState.searchResult(user: $user, isFriend: $isFriend, hasPendingRequest: $hasPendingRequest, requestDirection: $requestDirection, searchedEmail: $searchedEmail)';
+    return 'FriendState.searchResult(user: $user, isFriend: $isFriend, hasPendingRequest: $hasPendingRequest, requestDirection: $requestDirection, searchedEmail: $searchedEmail, isSelfSearch: $isSelfSearch)';
   }
 
   @override
@@ -1079,7 +1104,9 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
             (identical(other.requestDirection, requestDirection) ||
                 other.requestDirection == requestDirection) &&
             (identical(other.searchedEmail, searchedEmail) ||
-                other.searchedEmail == searchedEmail));
+                other.searchedEmail == searchedEmail) &&
+            (identical(other.isSelfSearch, isSelfSearch) ||
+                other.isSelfSearch == isSelfSearch));
   }
 
   @override
@@ -1090,6 +1117,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
     hasPendingRequest,
     requestDirection,
     searchedEmail,
+    isSelfSearch,
   );
 
   /// Create a copy of FriendState
@@ -1121,6 +1149,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -1133,6 +1162,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
       hasPendingRequest,
       requestDirection,
       searchedEmail,
+      isSelfSearch,
     );
   }
 
@@ -1154,6 +1184,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -1166,6 +1197,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
       hasPendingRequest,
       requestDirection,
       searchedEmail,
+      isSelfSearch,
     );
   }
 
@@ -1187,6 +1219,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -1201,6 +1234,7 @@ class _$FriendSearchResultImpl implements FriendSearchResult {
         hasPendingRequest,
         requestDirection,
         searchedEmail,
+        isSelfSearch,
       );
     }
     return orElse();
@@ -1263,6 +1297,7 @@ abstract class FriendSearchResult implements FriendState {
     required final bool hasPendingRequest,
     final String? requestDirection,
     required final String searchedEmail,
+    final bool isSelfSearch,
   }) = _$FriendSearchResultImpl;
 
   UserEntity? get user;
@@ -1270,6 +1305,7 @@ abstract class FriendSearchResult implements FriendState {
   bool get hasPendingRequest;
   String? get requestDirection;
   String get searchedEmail;
+  bool get isSelfSearch;
 
   /// Create a copy of FriendState
   /// with the given fields replaced by the non-null parameter values.
@@ -1378,6 +1414,7 @@ class _$FriendStatusResultImpl implements FriendStatusResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -1405,6 +1442,7 @@ class _$FriendStatusResultImpl implements FriendStatusResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -1432,6 +1470,7 @@ class _$FriendStatusResultImpl implements FriendStatusResult {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -1594,6 +1633,7 @@ class _$FriendErrorImpl implements FriendError {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -1621,6 +1661,7 @@ class _$FriendErrorImpl implements FriendError {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -1648,6 +1689,7 @@ class _$FriendErrorImpl implements FriendError {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,
@@ -1812,6 +1854,7 @@ class _$FriendActionSuccessImpl implements FriendActionSuccess {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )
     searchResult,
     required TResult Function(FriendshipStatusResult status) statusResult,
@@ -1839,6 +1882,7 @@ class _$FriendActionSuccessImpl implements FriendActionSuccess {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult? Function(FriendshipStatusResult status)? statusResult,
@@ -1866,6 +1910,7 @@ class _$FriendActionSuccessImpl implements FriendActionSuccess {
       bool hasPendingRequest,
       String? requestDirection,
       String searchedEmail,
+      bool isSelfSearch,
     )?
     searchResult,
     TResult Function(FriendshipStatusResult status)? statusResult,

--- a/lib/features/friends/presentation/pages/add_friend_page.dart
+++ b/lib/features/friends/presentation/pages/add_friend_page.dart
@@ -181,7 +181,7 @@ class _AddFriendPageState extends State<AddFriendPage> {
               _buildEmptyState(context, l10n),
           searchLoading: () => const Center(child: CircularProgressIndicator()),
           searchResult: (user, isFriend, hasPendingRequest, requestDirection,
-              searchedEmail) {
+              searchedEmail, isSelfSearch) {
             return ListView(
               padding: const EdgeInsets.all(16),
               children: [
@@ -191,6 +191,7 @@ class _AddFriendPageState extends State<AddFriendPage> {
                   hasPendingRequest: hasPendingRequest,
                   requestDirection: requestDirection,
                   searchedEmail: searchedEmail,
+                  isSelfSearch: isSelfSearch,
                   onSendRequest: user != null
                       ? () {
                           context.read<FriendBloc>().add(

--- a/lib/features/friends/presentation/pages/my_community_page.dart
+++ b/lib/features/friends/presentation/pages/my_community_page.dart
@@ -120,7 +120,7 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
                   loading: () {},
                   loaded: (friends, receivedRequests, sentRequests) {},
                   searchLoading: () {},
-                  searchResult: (user, isFriend, hasPendingRequest, requestDirection, searchedEmail) {},
+                  searchResult: (user, isFriend, hasPendingRequest, requestDirection, searchedEmail, isSelfSearch) {},
                   statusResult: (status) {},
                   error: (message) {
                     ScaffoldMessenger.of(context).showSnackBar(
@@ -202,7 +202,7 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
                 );
               },
               searchLoading: () => const Center(child: CircularProgressIndicator()),
-              searchResult: (user, isFriend, hasPendingRequest, requestDirection, searchedEmail) =>
+              searchResult: (user, isFriend, hasPendingRequest, requestDirection, searchedEmail, isSelfSearch) =>
                   const Center(child: CircularProgressIndicator()),
               statusResult: (status) => const Center(child: CircularProgressIndicator()),
               error: (message) {

--- a/lib/features/friends/presentation/widgets/search_result_tile.dart
+++ b/lib/features/friends/presentation/widgets/search_result_tile.dart
@@ -12,6 +12,8 @@ class SearchResultTile extends StatelessWidget {
   final VoidCallback? onSendRequest;
   final VoidCallback? onAcceptRequest;
 
+  final bool isSelfSearch;
+
   const SearchResultTile({
     super.key,
     required this.user,
@@ -19,6 +21,7 @@ class SearchResultTile extends StatelessWidget {
     required this.hasPendingRequest,
     this.requestDirection,
     required this.searchedEmail,
+    this.isSelfSearch = false,
     this.onSendRequest,
     this.onAcceptRequest,
   });
@@ -29,7 +32,7 @@ class SearchResultTile extends StatelessWidget {
     final theme = Theme.of(context);
 
     // Handle case where user searches for their own email
-    if (user == null && searchedEmail.isNotEmpty) {
+    if (user == null && isSelfSearch) {
       return Card(
         margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
         child: Padding(

--- a/test/unit/features/friends/presentation/bloc/friend_bloc_test.dart
+++ b/test/unit/features/friends/presentation/bloc/friend_bloc_test.dart
@@ -510,7 +510,7 @@ void main() {
       );
 
       blocTest<FriendBloc, FriendState>(
-        'emits [searchLoading, searchResult] with null user when searching own email',
+        'emits [searchLoading, searchResult] with isSelfSearch true when searching own email',
         build: () {
           when(() => mockAuthRepository.currentUser).thenReturn(testUser);
           return friendBloc;
@@ -526,6 +526,35 @@ void main() {
             hasPendingRequest: false,
             requestDirection: null,
             searchedEmail: 'test@example.com',
+            isSelfSearch: true,
+          ),
+        ],
+      );
+
+      blocTest<FriendBloc, FriendState>(
+        'emits [searchLoading, searchResult] with isSelfSearch false when user not found',
+        build: () {
+          when(() => mockAuthRepository.currentUser).thenReturn(testUser);
+          when(() => mockFriendRepository.searchUserByEmail('unknown@example.com'))
+              .thenAnswer((_) async => UserSearchResult(
+                    user: null,
+                    isFriend: false,
+                    hasPendingRequest: false,
+                  ));
+          return friendBloc;
+        },
+        act: (bloc) => bloc.add(
+          const FriendEvent.searchRequested(email: 'unknown@example.com'),
+        ),
+        expect: () => [
+          const FriendState.searchLoading(),
+          const FriendState.searchResult(
+            user: null,
+            isFriend: false,
+            hasPendingRequest: false,
+            requestDirection: null,
+            searchedEmail: 'unknown@example.com',
+            isSelfSearch: false,
           ),
         ],
       );

--- a/test/widget/features/friends/presentation/pages/add_friend_page_test.dart
+++ b/test/widget/features/friends/presentation/pages/add_friend_page_test.dart
@@ -402,13 +402,15 @@ void main() {
         expect(find.byType(ListView), findsOneWidget);
       });
 
-      testWidgets('displays result when user not found', (tester) async {
+      testWidgets('displays user-not-found message when user not found',
+          (tester) async {
         when(() => mockFriendBloc.state).thenReturn(
           const FriendState.searchResult(
             user: null,
             isFriend: false,
             hasPendingRequest: false,
             searchedEmail: 'notfound@example.com',
+            isSelfSearch: false,
           ),
         );
 
@@ -416,6 +418,28 @@ void main() {
         await tester.pump();
 
         expect(find.byType(ListView), findsOneWidget);
+        expect(find.byIcon(Icons.person_search), findsOneWidget);
+        expect(find.textContaining('notfound@example.com'), findsOneWidget);
+      });
+
+      testWidgets('displays cannot-add-yourself message when searching own email',
+          (tester) async {
+        when(() => mockFriendBloc.state).thenReturn(
+          const FriendState.searchResult(
+            user: null,
+            isFriend: false,
+            hasPendingRequest: false,
+            searchedEmail: 'test@example.com',
+            isSelfSearch: true,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pump();
+
+        expect(find.byType(ListView), findsOneWidget);
+        expect(find.byIcon(Icons.info_outline), findsOneWidget);
+        expect(find.text('You cannot add yourself as a friend'), findsOneWidget);
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes #502

- When searching for an email that doesn't exist in My Community, the app was incorrectly showing **"You cannot add yourself as a friend"** instead of **"No user found with email: {email}"**
- Root cause: `SearchResultTile` used `user == null && searchedEmail.isNotEmpty` which matched both the self-search case and the not-found case, making the "user not found" branch dead code
- Fix: added `isSelfSearch: bool` to `FriendSearchResult` state; `FriendBloc` sets it to `true` only for self-searches; `SearchResultTile` now uses the flag to display the right message

## Test plan

- [ ] Search for your own email → still shows "You cannot add yourself as a friend"
- [ ] Search for an email not registered in the app → now correctly shows "No user found with email: {email}" + "Make sure the email is correct"
- [ ] Search for a valid user → user card shown with Add button (unchanged)
- [ ] All unit and widget tests pass (`flutter test test/unit/features/friends/ test/widget/features/friends/`)