### PR TITLE
Story 18.3: Android — Rename package to org.gatherli.app & update deep linking

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace = "com.playwithme.play_with_me"
+    namespace = "org.gatherli.app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -22,7 +22,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.playwithme.play_with_me"
+        applicationId = "org.gatherli.app"
         minSdk = 23  // Firebase requires minimum API 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -35,11 +35,6 @@ android {
             dimension = "environment"
             applicationIdSuffix = ".dev"
             versionNameSuffix = "-dev"
-        }
-        create("stg") {
-            dimension = "environment"
-            applicationIdSuffix = ".stg"
-            versionNameSuffix = "-stg"
         }
         create("prod") {
             dimension = "environment"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
-        android:label="play_with_me"
+        android:label="Gatherli"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
 
@@ -46,7 +46,7 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
                     android:scheme="https"
-                    android:host="playwithme.app"
+                    android:host="gatherli.org"
                     android:pathPrefix="/invite"/>
             </intent-filter>
 
@@ -56,7 +56,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
-                    android:scheme="playwithme"
+                    android:scheme="gatherli"
                     android:host="invite"/>
             </intent-filter>
         </activity>

--- a/android/app/src/main/kotlin/org/gatherli/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/gatherli/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.playwithme.play_with_me
+package org.gatherli.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/lib/core/services/app_links_deep_link_service.dart
+++ b/lib/core/services/app_links_deep_link_service.dart
@@ -55,16 +55,16 @@ class AppLinksDeepLinkService implements DeepLinkService {
     debugPrint('[DeepLinkService] Parsing URI: $uri');
     final segments = uri.pathSegments;
 
-    // HTTPS: https://playwithme.app/invite/{token}
-    //   host=playwithme.app, pathSegments=[invite, token]
+    // HTTPS: https://gatherli.org/invite/{token}
+    //   host=gatherli.org, pathSegments=[invite, token]
     if (segments.length == 2 && segments[0] == 'invite') {
       final token = segments[1];
       if (token.isNotEmpty) return token;
     }
 
-    // Custom scheme: playwithme://invite/{token}
+    // Custom scheme: gatherli://invite/{token}
     //   host=invite, pathSegments=[token]
-    if (uri.scheme == 'playwithme' &&
+    if (uri.scheme == 'gatherli' &&
         uri.host == 'invite' &&
         segments.length == 1) {
       final token = segments[0];

--- a/test/unit/core/services/app_links_deep_link_service_test.dart
+++ b/test/unit/core/services/app_links_deep_link_service_test.dart
@@ -1,0 +1,184 @@
+// Validates AppLinksDeepLinkService correctly extracts invite tokens from
+// HTTPS (gatherli.org) and custom scheme (gatherli://) deep link URIs.
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/services/app_links_deep_link_service.dart';
+
+class MockAppLinks extends Mock implements AppLinks {}
+
+void main() {
+  late MockAppLinks mockAppLinks;
+  late StreamController<Uri> linkStreamController;
+
+  setUp(() {
+    mockAppLinks = MockAppLinks();
+    linkStreamController = StreamController<Uri>.broadcast();
+    when(() => mockAppLinks.uriLinkStream)
+        .thenAnswer((_) => linkStreamController.stream);
+  });
+
+  tearDown(() {
+    linkStreamController.close();
+  });
+
+  AppLinksDeepLinkService buildService() {
+    return AppLinksDeepLinkService(appLinks: mockAppLinks);
+  }
+
+  group('AppLinksDeepLinkService', () {
+    group('getInitialInviteToken — HTTPS deep links (gatherli.org)', () {
+      test('extracts token from https://gatherli.org/invite/{token}', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('https://gatherli.org/invite/abc123'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, 'abc123');
+        service.dispose();
+      });
+
+      test('returns null when HTTPS path has no invite segment', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('https://gatherli.org/other/abc123'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+
+      test('returns null when HTTPS invite token is empty', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('https://gatherli.org/invite/'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+
+      test('returns null when HTTPS path has too many segments', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async =>
+              Uri.parse('https://gatherli.org/invite/abc123/extra'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+    });
+
+    group('getInitialInviteToken — custom scheme (gatherli://)', () {
+      test('extracts token from gatherli://invite/{token}', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('gatherli://invite/xyz789'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, 'xyz789');
+        service.dispose();
+      });
+
+      test('returns null when custom scheme host is not invite', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('gatherli://other/xyz789'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+
+      test('returns null for unknown scheme', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('playwithme://invite/abc123'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+
+      test('returns null when custom scheme token is empty', () async {
+        when(() => mockAppLinks.getInitialLink()).thenAnswer(
+          (_) async => Uri.parse('gatherli://invite/'),
+        );
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+    });
+
+    group('getInitialInviteToken — null / error handling', () {
+      test('returns null when no initial link', () async {
+        when(() => mockAppLinks.getInitialLink())
+            .thenAnswer((_) async => null);
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+
+      test('returns null when getInitialLink throws', () async {
+        when(() => mockAppLinks.getInitialLink())
+            .thenThrow(Exception('platform error'));
+        final service = buildService();
+        final token = await service.getInitialInviteToken();
+        expect(token, isNull);
+        service.dispose();
+      });
+    });
+
+    group('inviteTokenStream — foreground deep links', () {
+      test('emits token when HTTPS deep link received on stream', () async {
+        when(() => mockAppLinks.getInitialLink())
+            .thenAnswer((_) async => null);
+        final service = buildService();
+
+        expectLater(service.inviteTokenStream, emits('stream-token-https'));
+
+        linkStreamController
+            .add(Uri.parse('https://gatherli.org/invite/stream-token-https'));
+
+        await Future.delayed(const Duration(milliseconds: 50));
+        service.dispose();
+      });
+
+      test('emits token when custom scheme deep link received on stream',
+          () async {
+        when(() => mockAppLinks.getInitialLink())
+            .thenAnswer((_) async => null);
+        final service = buildService();
+
+        expectLater(service.inviteTokenStream, emits('stream-token-custom'));
+
+        linkStreamController
+            .add(Uri.parse('gatherli://invite/stream-token-custom'));
+
+        await Future.delayed(const Duration(milliseconds: 50));
+        service.dispose();
+      });
+
+      test('does not emit for unrecognised URIs', () async {
+        when(() => mockAppLinks.getInitialLink())
+            .thenAnswer((_) async => null);
+        final service = buildService();
+
+        final emitted = <String?>[];
+        final sub = service.inviteTokenStream.listen(emitted.add);
+
+        linkStreamController.add(Uri.parse('https://example.com/other/path'));
+
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(emitted, isEmpty);
+        await sub.cancel();
+        service.dispose();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Update `namespace` and `applicationId` from `com.playwithme.play_with_me` to `org.gatherli.app` in `build.gradle.kts`
- Remove `stg` product flavor (dev + prod only going forward)
- Update `android:label` from `play_with_me` to `Gatherli` in `AndroidManifest.xml`
- Update App Links host from `playwithme.app` → `gatherli.org`
- Update custom URL scheme from `playwithme://` → `gatherli://`
- Move Kotlin source from `com/playwithme/play_with_me/` → `org/gatherli/app/`
- Update package declaration in `MainActivity.kt`
- Update deep link service scheme check from `playwithme` → `gatherli`

## New Application IDs

| Flavor | Application ID |
|--------|---------------|
| dev | `org.gatherli.app.dev` |
| prod | `org.gatherli.app` |

## Tests

Added `test/unit/core/services/app_links_deep_link_service_test.dart` with 13 tests covering:
- HTTPS deep link extraction (`https://gatherli.org/invite/{token}`)
- Custom scheme extraction (`gatherli://invite/{token}`)
- Edge cases: empty tokens, wrong paths, unknown schemes, null/error handling
- Foreground stream emission for both link types

All existing tests pass (2780+ tests, 0 failures).

## Test plan

- [ ] `flutter test test/unit/` passes
- [ ] `flutter test test/widget/` passes
- [ ] `flutter analyze` shows no new errors or warnings in modified files
- [ ] `flutter build apk --flavor dev` succeeds