### PR TITLE
fix(tests): update Firebase project IDs from playwithme to gatherli

### DIFF
--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -27,11 +27,11 @@ class EnvironmentConfig {
   static String get firebaseProjectId {
     switch (_environment) {
       case Environment.dev:
-        return 'playwithme-dev';
+        return 'gatherli-dev';
       case Environment.stg:
         return 'playwithme-stg';
       case Environment.prod:
-        return 'playwithme-prod';
+        return 'gatherli-prod';
     }
   }
 

--- a/test/helpers/ci_test_helper.dart
+++ b/test/helpers/ci_test_helper.dart
@@ -24,11 +24,11 @@ class CITestHelper {
     // Real project IDs used in both CI and local environments
     switch (environment) {
       case Environment.dev:
-        return 'playwithme-dev';
+        return 'gatherli-dev';
       case Environment.stg:
         return 'playwithme-stg';
       case Environment.prod:
-        return 'playwithme-prod';
+        return 'gatherli-prod';
     }
   }
 

--- a/test/unit/core/config/environment_config_test.dart
+++ b/test/unit/core/config/environment_config_test.dart
@@ -57,7 +57,7 @@ void main() {
     group('Firebase Project IDs', () {
       test('should return correct Firebase project ID for development', () {
         EnvironmentConfig.setEnvironment(Environment.dev);
-        expect(EnvironmentConfig.firebaseProjectId, 'playwithme-dev');
+        expect(EnvironmentConfig.firebaseProjectId, 'gatherli-dev');
       });
 
       test('should return correct Firebase project ID for staging', () {
@@ -67,7 +67,7 @@ void main() {
 
       test('should return correct Firebase project ID for production', () {
         EnvironmentConfig.setEnvironment(Environment.prod);
-        expect(EnvironmentConfig.firebaseProjectId, 'playwithme-prod');
+        expect(EnvironmentConfig.firebaseProjectId, 'gatherli-prod');
       });
     });
 
@@ -94,7 +94,7 @@ void main() {
         expect(EnvironmentConfig.environment, Environment.prod);
         expect(EnvironmentConfig.isProduction, true);
         expect(EnvironmentConfig.environmentName, 'Production');
-        expect(EnvironmentConfig.firebaseProjectId, 'playwithme-prod');
+        expect(EnvironmentConfig.firebaseProjectId, 'gatherli-prod');
         expect(EnvironmentConfig.appSuffix, '');
       });
     });


### PR DESCRIPTION
## Summary

Fixes 2 failing integration tests caused by Story 18.2 (Firebase infrastructure migration to Gatherli) not updating the project ID references in the test helpers and config.

## Root Cause

`EnvironmentConfig.firebaseProjectId` and `CITestHelper.getExpectedProjectId()` still returned `playwithme-dev` and `playwithme-prod` after the Firebase projects were migrated to `gatherli-dev` and `gatherli-prod`.

## Changes

- `lib/core/config/environment_config.dart` — update `firebaseProjectId` to return `gatherli-dev` / `gatherli-prod`
- `test/helpers/ci_test_helper.dart` — update `getExpectedProjectId()` for dev and prod
- `test/unit/core/config/environment_config_test.dart` — update assertions for dev and prod project IDs

> Note: `stg` remains mapped to `playwithme-stg` as the `Environment.stg` enum still exists and has no Gatherli equivalent. Full stg cleanup is tracked in Story 18.5.

## Test plan

- [ ] `flutter test test/integration/` — all 10 tests pass (was 8/10)
- [ ] `flutter test test/unit/` — all tests pass
- [ ] `flutter test test/widget/` — all tests pass