### PR TITLE
feat(config): remove stg environment and update Firebase configs for Gatherli (Story 18.5)

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: 'android,web'
       flavors:
-        description: 'Flavors to build (comma-separated: dev,stg,prod)'
+        description: 'Flavors to build (comma-separated: dev,prod)'
         required: false
         default: 'dev'
 
@@ -45,15 +45,6 @@ jobs:
           FIREBASE_DEV_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_DEV_MESSAGING_SENDER_ID }}
           FIREBASE_DEV_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_DEV_ANDROID_PACKAGE_NAME }}
           FIREBASE_DEV_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_DEV_IOS_BUNDLE_ID }}
-          # Staging environment secrets
-          FIREBASE_STG_PROJECT_ID: ${{ secrets.FIREBASE_STG_PROJECT_ID }}
-          FIREBASE_STG_STORAGE_BUCKET: ${{ secrets.FIREBASE_STG_STORAGE_BUCKET }}
-          FIREBASE_STG_ANDROID_APP_ID: ${{ secrets.FIREBASE_STG_ANDROID_APP_ID }}
-          FIREBASE_STG_IOS_APP_ID: ${{ secrets.FIREBASE_STG_IOS_APP_ID }}
-          FIREBASE_STG_API_KEY: ${{ secrets.FIREBASE_STG_API_KEY }}
-          FIREBASE_STG_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_STG_MESSAGING_SENDER_ID }}
-          FIREBASE_STG_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_STG_ANDROID_PACKAGE_NAME }}
-          FIREBASE_STG_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_STG_IOS_BUNDLE_ID }}
           # Production environment secrets
           FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
           FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
@@ -66,7 +57,6 @@ jobs:
         run: |
           echo "Generating Firebase configurations from GitHub Secrets..."
           dart run tools/generate_firebase_config_from_secrets.dart dev
-          dart run tools/generate_firebase_config_from_secrets.dart stg
           dart run tools/generate_firebase_config_from_secrets.dart prod
           echo "✅ Firebase configurations generated securely from secrets"
 
@@ -76,7 +66,6 @@ jobs:
           name: firebase-configs
           path: |
             lib/core/config/firebase_config_dev.dart
-            lib/core/config/firebase_config_stg.dart
             lib/core/config/firebase_config_prod.dart
             android/app/google-services.json
           retention-days: 1

--- a/ios/Runner/Firebase/copy-firebase-config.sh
+++ b/ios/Runner/Firebase/copy-firebase-config.sh
@@ -8,8 +8,6 @@ echo "Scheme: ${CONFIGURATION}"
 # Determine the flavor based on environment or configuration
 if [[ "${CONFIGURATION}" == *"dev"* ]] || [[ "${FLUTTER_BUILD_MODE}" == *"dev"* ]]; then
     FLAVOR="dev"
-elif [[ "${CONFIGURATION}" == *"stg"* ]] || [[ "${FLUTTER_BUILD_MODE}" == *"stg"* ]]; then
-    FLAVOR="stg"
 elif [[ "${CONFIGURATION}" == *"prod"* ]] || [[ "${FLUTTER_BUILD_MODE}" == *"prod"* ]]; then
     FLAVOR="prod"
 else

--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -1,6 +1,5 @@
 enum Environment {
   dev,
-  stg,
   prod,
 }
 
@@ -17,8 +16,6 @@ class EnvironmentConfig {
     switch (_environment) {
       case Environment.dev:
         return 'Development';
-      case Environment.stg:
-        return 'Staging';
       case Environment.prod:
         return 'Production';
     }
@@ -28,23 +25,18 @@ class EnvironmentConfig {
     switch (_environment) {
       case Environment.dev:
         return 'gatherli-dev';
-      case Environment.stg:
-        return 'playwithme-stg';
       case Environment.prod:
         return 'gatherli-prod';
     }
   }
 
   static bool get isDevelopment => _environment == Environment.dev;
-  static bool get isStaging => _environment == Environment.stg;
   static bool get isProduction => _environment == Environment.prod;
 
   static String get appSuffix {
     switch (_environment) {
       case Environment.dev:
         return ' (Dev)';
-      case Environment.stg:
-        return ' (Staging)';
       case Environment.prod:
         return '';
     }

--- a/lib/core/config/firebase_config_base.dart
+++ b/lib/core/config/firebase_config_base.dart
@@ -25,7 +25,7 @@ abstract class FirebaseConfigBase {
   /// iOS bundle identifier
   String get iosBundleId;
 
-  /// Environment name (dev, stg, prod)
+  /// Environment name (dev, prod)
   String get environment;
 
   /// Display name for the app in this environment
@@ -36,9 +36,6 @@ abstract class FirebaseConfigBase {
 
   /// Whether this is a development environment
   bool get isDevelopment => environment == 'dev';
-
-  /// Whether this is a staging environment
-  bool get isStaging => environment == 'stg';
 
   @override
   String toString() {

--- a/lib/core/config/firebase_config_factory.dart
+++ b/lib/core/config/firebase_config_factory.dart
@@ -8,8 +8,6 @@ class FirebaseConfigFactory {
     switch (EnvironmentConfig.environment) {
       case Environment.dev:
         return _getDevConfig();
-      case Environment.stg:
-        return _getStagingConfig();
       case Environment.prod:
         return _getProductionConfig();
     }
@@ -25,21 +23,6 @@ class FirebaseConfigFactory {
       throw Exception(
         'Development Firebase configuration not found!\n'
         'Please run: dart tools/generate_firebase_config.dart dev\n'
-        'Make sure you have placed google-services.json and GoogleService-Info.plist files in the correct locations.\n'
-        'Error: $e'
-      );
-    }
-  }
-
-  static FirebaseConfigBase _getStagingConfig() {
-    try {
-      // Import will be available after running: dart tools/generate_firebase_config.dart stg
-      final config = _loadGeneratedConfig('stg');
-      return config;
-    } catch (e) {
-      throw Exception(
-        'Staging Firebase configuration not found!\n'
-        'Please run: dart tools/generate_firebase_config.dart stg\n'
         'Make sure you have placed google-services.json and GoogleService-Info.plist files in the correct locations.\n'
         'Error: $e'
       );

--- a/lib/core/config/firebase_config_validator.dart
+++ b/lib/core/config/firebase_config_validator.dart
@@ -5,23 +5,20 @@ import 'dart:io';
 class FirebaseConfigValidator {
   /// Expected bundle IDs for Android configurations
   static const Map<String, String> expectedAndroidBundleIds = {
-    'dev': 'com.playwithme.play_with_me.dev',
-    'stg': 'com.playwithme.play_with_me.stg',
-    'prod': 'com.playwithme.play_with_me',
+    'dev': 'org.gatherli.app.dev',
+    'prod': 'org.gatherli.app',
   };
 
   /// Expected bundle IDs for iOS configurations
   static const Map<String, String> expectediOSBundleIds = {
-    'dev': 'com.playwithme.playWithMe.dev',
-    'stg': 'com.playwithme.playWithMe.stg',
-    'prod': 'com.playwithme.playWithMe',
+    'dev': 'org.gatherli.app.dev',
+    'prod': 'org.gatherli.app',
   };
 
   /// Expected Firebase project IDs
   static const Map<String, String> expectedProjectIds = {
-    'dev': 'playwithme-dev',
-    'stg': 'playwithme-stg',
-    'prod': 'playwithme-prod',
+    'dev': 'gatherli-dev',
+    'prod': 'gatherli-prod',
   };
 
   /// Validates an Android google-services.json configuration
@@ -156,7 +153,7 @@ class FirebaseConfigValidator {
   /// Validates all Firebase configurations for all environments
   static Future<Map<String, ConfigValidationResult>> validateAllConfigs() async {
     final results = <String, ConfigValidationResult>{};
-    const environments = ['dev', 'stg', 'prod'];
+    const environments = ['dev', 'prod'];
 
     for (final env in environments) {
       // Validate Android config

--- a/lib/core/services/firebase_options_provider.dart
+++ b/lib/core/services/firebase_options_provider.dart
@@ -2,7 +2,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:play_with_me/core/config/environment_config.dart';
 import 'package:play_with_me/core/config/firebase_config_dev.dart';
-import 'package:play_with_me/core/config/firebase_config_stg.dart';
 import 'package:play_with_me/core/config/firebase_config_prod.dart';
 
 /// Provides Firebase options for different environments
@@ -17,8 +16,6 @@ class FirebaseOptionsProvider {
     switch (environment) {
       case Environment.dev:
         return _getDevOptions();
-      case Environment.stg:
-        return _getStagingOptions();
       case Environment.prod:
         return _getProdOptions();
     }
@@ -27,21 +24,6 @@ class FirebaseOptionsProvider {
   /// Development environment Firebase options
   static FirebaseOptions _getDevOptions() {
     final config = FirebaseConfigDev();
-    return FirebaseOptions(
-      apiKey: config.apiKey,
-      appId: defaultTargetPlatform == TargetPlatform.android
-          ? config.androidAppId
-          : config.iosAppId,
-      messagingSenderId: config.messagingSenderId,
-      projectId: config.projectId,
-      storageBucket: config.storageBucket,
-      authDomain: '${config.projectId}.firebaseapp.com',
-    );
-  }
-
-  /// Staging environment Firebase options
-  static FirebaseOptions _getStagingOptions() {
-    final config = FirebaseConfigStg();
     return FirebaseOptions(
       apiKey: config.apiKey,
       appId: defaultTargetPlatform == TargetPlatform.android

--- a/lib/core/widgets/environment_indicator.dart
+++ b/lib/core/widgets/environment_indicator.dart
@@ -120,8 +120,6 @@ class EnvironmentIndicator extends StatelessWidget {
     switch (EnvironmentConfig.environment) {
       case Environment.dev:
         return Colors.red.shade600;
-      case Environment.stg:
-        return Colors.orange.shade600;
       case Environment.prod:
         return Colors.green.shade600;
     }
@@ -131,8 +129,6 @@ class EnvironmentIndicator extends StatelessWidget {
     switch (EnvironmentConfig.environment) {
       case Environment.dev:
         return Icons.code;
-      case Environment.stg:
-        return Icons.science;
       case Environment.prod:
         return Icons.public;
     }

--- a/lib/main_stg.dart
+++ b/lib/main_stg.dart
@@ -1,7 +1,0 @@
-import 'package:play_with_me/core/config/environment_config.dart';
-import 'package:play_with_me/main_common.dart';
-
-Future<void> main() async {
-  EnvironmentConfig.setEnvironment(Environment.stg);
-  await mainCommon();
-}

--- a/test/ci_only/environment_indicator_test.dart
+++ b/test/ci_only/environment_indicator_test.dart
@@ -51,24 +51,6 @@ void main() {
       expect(find.byIcon(Icons.cloud_off), findsOneWidget);
     });
 
-    testWidgets('renders staging environment indicator', (tester) async {
-      // Arrange
-      EnvironmentConfig.setEnvironment(Environment.stg);
-
-      // Act
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: EnvironmentIndicator(),
-          ),
-        ),
-      );
-
-      // Assert
-      expect(find.text('Staging Environment'), findsOneWidget);
-      expect(find.byIcon(Icons.science), findsOneWidget);
-    });
-
     testWidgets('renders detailed view when showDetails is true', (tester) async {
       // Arrange
       EnvironmentConfig.setEnvironment(Environment.dev);
@@ -84,7 +66,7 @@ void main() {
 
       // Assert
       expect(find.text('Development Environment'), findsOneWidget);
-      expect(find.text('Project: playwithme-dev'), findsOneWidget);
+      expect(find.text('Project: gatherli-dev'), findsOneWidget);
       // Firebase is not initialized in tests, so should show 'Disconnected'
       expect(find.text('Disconnected'), findsOneWidget);
     });
@@ -110,24 +92,6 @@ void main() {
       final devDecoration = devContainer.decoration as BoxDecoration;
       expect(devDecoration.color, equals(Colors.red.shade600));
 
-      // Test staging environment color
-      EnvironmentConfig.setEnvironment(Environment.stg);
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: EnvironmentIndicator(),
-          ),
-        ),
-      );
-
-      final stgContainer = tester.widget<Container>(
-        find.ancestor(
-          of: find.text('Staging Environment'),
-          matching: find.byType(Container),
-        ),
-      );
-      final stgDecoration = stgContainer.decoration as BoxDecoration;
-      expect(stgDecoration.color, equals(Colors.orange.shade600));
     });
   });
 
@@ -138,18 +102,6 @@ void main() {
     });
 
     testWidgets('does not render in non-development environments', (tester) async {
-      // Test staging
-      EnvironmentConfig.setEnvironment(Environment.stg);
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: Stack(children: [FirebaseDebugPanel()]),
-          ),
-        ),
-      );
-      expect(find.byType(FirebaseDebugPanel), findsOneWidget);
-      expect(find.text('Debug'), findsNothing);
-
       // Test production
       EnvironmentConfig.setEnvironment(Environment.prod);
       await tester.pumpWidget(
@@ -255,7 +207,7 @@ void main() {
 
       // Assert
       expect(find.text('Development'), findsOneWidget);
-      expect(find.text('playwithme-dev'), findsOneWidget);
+      expect(find.text('gatherli-dev'), findsOneWidget);
       expect(find.text('false'), findsOneWidget); // isInitialized should be false in tests
     });
   });

--- a/test/ci_only/firebase_config_validator_test.dart
+++ b/test/ci_only/firebase_config_validator_test.dart
@@ -1,3 +1,4 @@
+// Validates FirebaseConfigValidator correctly checks Gatherli bundle IDs and project IDs.
 import 'dart:convert';
 import 'dart:io';
 
@@ -22,16 +23,16 @@ void main() {
         final configFile = File('${tempDir.path}/google-services.json');
         final validConfig = {
           'project_info': {
-            'project_id': 'playwithme-dev',
-            'project_number': '123456789',
-            'storage_bucket': 'playwithme-dev.firebasestorage.app',
+            'project_id': 'gatherli-dev',
+            'project_number': '19710393704',
+            'storage_bucket': 'gatherli-dev.firebasestorage.app',
           },
           'client': [
             {
               'client_info': {
-                'mobilesdk_app_id': '1:123456789:android:abcdef123456',
+                'mobilesdk_app_id': '1:19710393704:android:abcdef123456',
                 'android_client_info': {
-                  'package_name': 'com.playwithme.play_with_me.dev',
+                  'package_name': 'org.gatherli.app.dev',
                 }
               },
               'api_key': [
@@ -65,7 +66,7 @@ void main() {
             {
               'client_info': {
                 'android_client_info': {
-                  'package_name': 'com.playwithme.play_with_me.dev',
+                  'package_name': 'org.gatherli.app.dev',
                 }
               },
               'api_key': [
@@ -90,7 +91,7 @@ void main() {
         final configFile = File('${tempDir.path}/google-services.json');
         final invalidConfig = {
           'project_info': {
-            'project_id': 'playwithme-dev',
+            'project_id': 'gatherli-dev',
           },
           'client': [
             {
@@ -121,13 +122,13 @@ void main() {
         final configFile = File('${tempDir.path}/google-services.json');
         final configWithPlaceholder = {
           'project_info': {
-            'project_id': 'playwithme-dev',
+            'project_id': 'gatherli-dev',
           },
           'client': [
             {
               'client_info': {
                 'android_client_info': {
-                  'package_name': 'com.playwithme.play_with_me.dev',
+                  'package_name': 'org.gatherli.app.dev',
                 }
               },
               'api_key': [
@@ -182,9 +183,9 @@ void main() {
 	<key>API_KEY</key>
 	<string>AIzaSyRealApiKeyWithoutPlaceholder123456</string>
 	<key>PROJECT_ID</key>
-	<string>playwithme-dev</string>
+	<string>gatherli-dev</string>
 	<key>BUNDLE_ID</key>
-	<string>com.playwithme.playWithMe.dev</string>
+	<string>org.gatherli.app.dev</string>
 </dict>
 </plist>''';
 
@@ -208,7 +209,7 @@ void main() {
 	<key>PROJECT_ID</key>
 	<string>wrong-project-id</string>
 	<key>BUNDLE_ID</key>
-	<string>com.playwithme.playWithMe.dev</string>
+	<string>org.gatherli.app.dev</string>
 	<key>API_KEY</key>
 	<string>real-key</string>
 </dict>
@@ -231,7 +232,7 @@ void main() {
 <plist version="1.0">
 <dict>
 	<key>PROJECT_ID</key>
-	<string>playwithme-dev</string>
+	<string>gatherli-dev</string>
 	<key>BUNDLE_ID</key>
 	<string>com.wrong.bundle.id</string>
 	<key>API_KEY</key>
@@ -256,9 +257,9 @@ void main() {
 <plist version="1.0">
 <dict>
 	<key>PROJECT_ID</key>
-	<string>playwithme-dev</string>
+	<string>gatherli-dev</string>
 	<key>BUNDLE_ID</key>
-	<string>com.playwithme.playWithMe.dev</string>
+	<string>org.gatherli.app.dev</string>
 	<key>API_KEY</key>
 	<string>AIzaSyDEV-placeholder-key-for-development-ios</string>
 </dict>
@@ -278,21 +279,21 @@ void main() {
 
     group('Expected Constants', () {
       test('should have correct expected bundle IDs for Android', () {
-        expect(FirebaseConfigValidator.expectedAndroidBundleIds['dev'], 'com.playwithme.play_with_me.dev');
-        expect(FirebaseConfigValidator.expectedAndroidBundleIds['stg'], 'com.playwithme.play_with_me.stg');
-        expect(FirebaseConfigValidator.expectedAndroidBundleIds['prod'], 'com.playwithme.play_with_me');
+        expect(FirebaseConfigValidator.expectedAndroidBundleIds['dev'], 'org.gatherli.app.dev');
+        expect(FirebaseConfigValidator.expectedAndroidBundleIds['prod'], 'org.gatherli.app');
+        expect(FirebaseConfigValidator.expectedAndroidBundleIds.containsKey('stg'), isFalse);
       });
 
       test('should have correct expected bundle IDs for iOS', () {
-        expect(FirebaseConfigValidator.expectediOSBundleIds['dev'], 'com.playwithme.playWithMe.dev');
-        expect(FirebaseConfigValidator.expectediOSBundleIds['stg'], 'com.playwithme.playWithMe.stg');
-        expect(FirebaseConfigValidator.expectediOSBundleIds['prod'], 'com.playwithme.playWithMe');
+        expect(FirebaseConfigValidator.expectediOSBundleIds['dev'], 'org.gatherli.app.dev');
+        expect(FirebaseConfigValidator.expectediOSBundleIds['prod'], 'org.gatherli.app');
+        expect(FirebaseConfigValidator.expectediOSBundleIds.containsKey('stg'), isFalse);
       });
 
       test('should have correct expected project IDs', () {
-        expect(FirebaseConfigValidator.expectedProjectIds['dev'], 'playwithme-dev');
-        expect(FirebaseConfigValidator.expectedProjectIds['stg'], 'playwithme-stg');
-        expect(FirebaseConfigValidator.expectedProjectIds['prod'], 'playwithme-prod');
+        expect(FirebaseConfigValidator.expectedProjectIds['dev'], 'gatherli-dev');
+        expect(FirebaseConfigValidator.expectedProjectIds['prod'], 'gatherli-prod');
+        expect(FirebaseConfigValidator.expectedProjectIds.containsKey('stg'), isFalse);
       });
     });
 

--- a/test/ci_only/firebase_options_provider_test.dart
+++ b/test/ci_only/firebase_options_provider_test.dart
@@ -27,19 +27,6 @@ void main() {
         expect(options.authDomain, equals(CITestHelper.getExpectedAuthDomain(Environment.dev)));
       });
 
-      test('returns staging options when environment is stg', () {
-        // Arrange
-        EnvironmentConfig.setEnvironment(Environment.stg);
-
-        // Act
-        final options = FirebaseOptionsProvider.getFirebaseOptions();
-
-        // Assert
-        expect(options.projectId, equals(CITestHelper.getExpectedProjectId(Environment.stg)));
-        expect(options.storageBucket, equals(CITestHelper.getExpectedStorageBucket(Environment.stg)));
-        expect(options.authDomain, equals(CITestHelper.getExpectedAuthDomain(Environment.stg)));
-      });
-
       test('returns prod options when environment is prod', () {
         // Arrange
         EnvironmentConfig.setEnvironment(Environment.prod);
@@ -95,20 +82,6 @@ void main() {
         expect(summary['storageBucket'], equals(CITestHelper.getExpectedStorageBucket(Environment.dev)));
       });
 
-      test('returns correct summary for staging environment', () {
-        // Arrange
-        EnvironmentConfig.setEnvironment(Environment.stg);
-
-        // Act
-        final summary = FirebaseOptionsProvider.getConfigurationSummary();
-
-        // Assert
-        expect(summary['environment'], equals('Staging'));
-        expect(summary['projectId'], equals(CITestHelper.getExpectedProjectId(Environment.stg)));
-        expect(summary['hasPlaceholders'], equals('false'));
-        expect(summary['storageBucket'], equals(CITestHelper.getExpectedStorageBucket(Environment.stg)));
-      });
-
       test('returns correct summary for production environment', () {
         // Arrange
         EnvironmentConfig.setEnvironment(Environment.prod);
@@ -126,7 +99,7 @@ void main() {
 
     group('Firebase options consistency', () {
       test('all environments have consistent structure', () {
-        final environments = [Environment.dev, Environment.stg, Environment.prod];
+        final environments = [Environment.dev, Environment.prod];
 
         for (final env in environments) {
           EnvironmentConfig.setEnvironment(env);
@@ -146,19 +119,15 @@ void main() {
         EnvironmentConfig.setEnvironment(Environment.dev);
         final devOptions = FirebaseOptionsProvider.getFirebaseOptions();
 
-        EnvironmentConfig.setEnvironment(Environment.stg);
-        final stgOptions = FirebaseOptionsProvider.getFirebaseOptions();
-
         EnvironmentConfig.setEnvironment(Environment.prod);
         final prodOptions = FirebaseOptionsProvider.getFirebaseOptions();
 
         // Assert all project IDs are unique
         final projectIds = [
           devOptions.projectId,
-          stgOptions.projectId,
           prodOptions.projectId,
         ];
-        expect(projectIds.toSet().length, equals(3));
+        expect(projectIds.toSet().length, equals(2));
       });
     });
   });

--- a/test/ci_only/firebase_project_info_test.dart
+++ b/test/ci_only/firebase_project_info_test.dart
@@ -6,12 +6,12 @@ void main() {
     test('should create instance with required fields', () {
       final projectInfo = FirebaseProjectInfo(
         environment: 'dev',
-        expectedProjectId: 'playwithme-dev',
+        expectedProjectId: 'gatherli-dev',
         status: FirebaseProjectStatus.created,
       );
 
       expect(projectInfo.environment, 'dev');
-      expect(projectInfo.expectedProjectId, 'playwithme-dev');
+      expect(projectInfo.expectedProjectId, 'gatherli-dev');
       expect(projectInfo.status, FirebaseProjectStatus.created);
       expect(projectInfo.matchesExpected, false); // default value
       expect(projectInfo.actualProjectId, null);
@@ -22,16 +22,16 @@ void main() {
       final createdAt = DateTime.now();
       final projectInfo = FirebaseProjectInfo(
         environment: 'prod',
-        expectedProjectId: 'playwithme-prod',
-        actualProjectId: 'playwithme-prod',
+        expectedProjectId: 'gatherli-prod',
+        actualProjectId: 'gatherli-prod',
         status: FirebaseProjectStatus.created,
         createdAt: createdAt,
         matchesExpected: true,
       );
 
       expect(projectInfo.environment, 'prod');
-      expect(projectInfo.expectedProjectId, 'playwithme-prod');
-      expect(projectInfo.actualProjectId, 'playwithme-prod');
+      expect(projectInfo.expectedProjectId, 'gatherli-prod');
+      expect(projectInfo.actualProjectId, 'gatherli-prod');
       expect(projectInfo.status, FirebaseProjectStatus.created);
       expect(projectInfo.matchesExpected, true);
       expect(projectInfo.createdAt, createdAt);
@@ -40,18 +40,18 @@ void main() {
     group('JSON serialization', () {
       test('should serialize to JSON correctly', () {
         final projectInfo = FirebaseProjectInfo(
-          environment: 'stg',
-          expectedProjectId: 'playwithme-stg',
-          actualProjectId: 'playwithme-stg-custom',
+          environment: 'dev',
+          expectedProjectId: 'gatherli-dev',
+          actualProjectId: 'gatherli-dev-custom',
           status: FirebaseProjectStatus.created,
           matchesExpected: false,
         );
 
         final json = projectInfo.toJson();
 
-        expect(json['environment'], 'stg');
-        expect(json['expectedProjectId'], 'playwithme-stg');
-        expect(json['actualProjectId'], 'playwithme-stg-custom');
+        expect(json['environment'], 'dev');
+        expect(json['expectedProjectId'], 'gatherli-dev');
+        expect(json['actualProjectId'], 'gatherli-dev-custom');
         expect(json['status'], 'created');
         expect(json['matchesExpected'], false);
       });
@@ -59,8 +59,8 @@ void main() {
       test('should deserialize from JSON correctly', () {
         final json = {
           'environment': 'dev',
-          'expectedProjectId': 'playwithme-dev',
-          'actualProjectId': 'playwithme-dev',
+          'expectedProjectId': 'gatherli-dev',
+          'actualProjectId': 'gatherli-dev',
           'status': 'created',
           'matchesExpected': true,
         };
@@ -68,8 +68,8 @@ void main() {
         final projectInfo = FirebaseProjectInfo.fromJson(json);
 
         expect(projectInfo.environment, 'dev');
-        expect(projectInfo.expectedProjectId, 'playwithme-dev');
-        expect(projectInfo.actualProjectId, 'playwithme-dev');
+        expect(projectInfo.expectedProjectId, 'gatherli-dev');
+        expect(projectInfo.actualProjectId, 'gatherli-dev');
         expect(projectInfo.status, FirebaseProjectStatus.created);
         expect(projectInfo.matchesExpected, true);
       });
@@ -82,12 +82,12 @@ void main() {
       final projects = [
         FirebaseProjectInfo(
           environment: 'dev',
-          expectedProjectId: 'playwithme-dev',
+          expectedProjectId: 'gatherli-dev',
           status: FirebaseProjectStatus.created,
         ),
         FirebaseProjectInfo(
-          environment: 'stg',
-          expectedProjectId: 'playwithme-stg',
+          environment: 'prod',
+          expectedProjectId: 'gatherli-prod',
           status: FirebaseProjectStatus.pending,
         ),
       ];
@@ -110,7 +110,7 @@ void main() {
         final projects = [
           FirebaseProjectInfo(
             environment: 'dev',
-            expectedProjectId: 'playwithme-dev',
+            expectedProjectId: 'gatherli-dev',
             status: FirebaseProjectStatus.created,
           ),
         ];
@@ -136,7 +136,7 @@ void main() {
           'projects': [
             {
               'environment': 'dev',
-              'expectedProjectId': 'playwithme-dev',
+              'expectedProjectId': 'gatherli-dev',
               'status': 'created',
               'matchesExpected': true,
             }
@@ -176,16 +176,15 @@ void main() {
     });
   });
 
-  group('Story 0.2.1 Requirements', () {
+  group('Gatherli Requirements', () {
     test('should support all required project environments', () {
-      const requiredEnvironments = ['dev', 'stg', 'prod'];
+      const requiredEnvironments = ['dev', 'prod'];
       const expectedProjectIds = [
-        'playwithme-dev',
-        'playwithme-stg',
-        'playwithme-prod',
+        'gatherli-dev',
+        'gatherli-prod',
       ];
 
-      final projects = List.generate(3, (index) {
+      final projects = List.generate(2, (index) {
         return FirebaseProjectInfo(
           environment: requiredEnvironments[index],
           expectedProjectId: expectedProjectIds[index],
@@ -193,7 +192,7 @@ void main() {
         );
       });
 
-      expect(projects.length, 3);
+      expect(projects.length, 2);
       expect(projects.map((p) => p.environment).toList(), requiredEnvironments);
       expect(projects.map((p) => p.expectedProjectId).toList(), expectedProjectIds);
     });
@@ -202,22 +201,15 @@ void main() {
       final allCreated = [
         FirebaseProjectInfo(
           environment: 'dev',
-          expectedProjectId: 'playwithme-dev',
-          actualProjectId: 'playwithme-dev',
-          status: FirebaseProjectStatus.created,
-          matchesExpected: true,
-        ),
-        FirebaseProjectInfo(
-          environment: 'stg',
-          expectedProjectId: 'playwithme-stg',
-          actualProjectId: 'playwithme-stg',
+          expectedProjectId: 'gatherli-dev',
+          actualProjectId: 'gatherli-dev',
           status: FirebaseProjectStatus.created,
           matchesExpected: true,
         ),
         FirebaseProjectInfo(
           environment: 'prod',
-          expectedProjectId: 'playwithme-prod',
-          actualProjectId: 'playwithme-prod',
+          expectedProjectId: 'gatherli-prod',
+          actualProjectId: 'gatherli-prod',
           status: FirebaseProjectStatus.created,
           matchesExpected: true,
         ),
@@ -231,7 +223,6 @@ void main() {
       final allMatch = allCreated.every((p) => p.matchesExpected);
       expect(allMatch, true);
 
-      // Story 0.2.1 Definition of Done criteria met
       expect(allComplete && allMatch, true);
     });
   });

--- a/test/ci_only/firebase_service_test.dart
+++ b/test/ci_only/firebase_service_test.dart
@@ -59,20 +59,8 @@ void main() {
         // Assert
         expect(info['isInitialized'], isFalse);
         expect(info['environment'], equals('Development'));
-        expect(info['projectId'], equals('playwithme-dev'));
+        expect(info['projectId'], equals('gatherli-dev'));
         expect(info['appName'], isNull);
-      });
-
-      test('returns correct environment information for staging', () {
-        // Arrange
-        EnvironmentConfig.setEnvironment(Environment.stg);
-
-        // Act
-        final info = FirebaseService.getConnectionInfo();
-
-        // Assert
-        expect(info['environment'], equals('Staging'));
-        expect(info['projectId'], equals('playwithme-stg'));
       });
 
       test('returns correct environment information for production', () {
@@ -84,7 +72,7 @@ void main() {
 
         // Assert
         expect(info['environment'], equals('Production'));
-        expect(info['projectId'], equals('playwithme-prod'));
+        expect(info['projectId'], equals('gatherli-prod'));
       });
     });
 
@@ -144,9 +132,8 @@ void main() {
     group('environment consistency', () {
       test('connection info reflects current environment configuration', () {
         final environments = [
-          (Environment.dev, 'Development', 'playwithme-dev'),
-          (Environment.stg, 'Staging', 'playwithme-stg'),
-          (Environment.prod, 'Production', 'playwithme-prod'),
+          (Environment.dev, 'Development', 'gatherli-dev'),
+          (Environment.prod, 'Production', 'gatherli-prod'),
         ];
 
         for (final (env, expectedName, expectedProjectId) in environments) {

--- a/test/helpers/ci_test_helper.dart
+++ b/test/helpers/ci_test_helper.dart
@@ -25,8 +25,6 @@ class CITestHelper {
     switch (environment) {
       case Environment.dev:
         return 'gatherli-dev';
-      case Environment.stg:
-        return 'playwithme-stg';
       case Environment.prod:
         return 'gatherli-prod';
     }
@@ -48,7 +46,6 @@ class CITestHelper {
   static Map<String, String> getExpectedProjectIds() {
     return {
       'dev': getExpectedProjectId(Environment.dev),
-      'stg': getExpectedProjectId(Environment.stg),
       'prod': getExpectedProjectId(Environment.prod),
     };
   }

--- a/test/integration/firebase_compatibility_test.dart
+++ b/test/integration/firebase_compatibility_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     test('Firebase configuration is valid for all environments with real configs', () {
       // Test all environments have valid configurations
-      final environments = [Environment.dev, Environment.stg, Environment.prod];
+      final environments = [Environment.dev, Environment.prod];
 
       for (final env in environments) {
         // Arrange
@@ -81,7 +81,6 @@ void main() {
       // Test switching between environments with real configurations
       final testCases = [
         (Environment.dev, CITestHelper.getExpectedProjectId(Environment.dev), 'Development'),
-        (Environment.stg, CITestHelper.getExpectedProjectId(Environment.stg), 'Staging'),
         (Environment.prod, CITestHelper.getExpectedProjectId(Environment.prod), 'Production'),
       ];
 
@@ -128,7 +127,6 @@ void main() {
       // Verify that real Firebase configurations contain the expected project IDs
       final expectedProjects = {
         Environment.dev: CITestHelper.getExpectedProjectId(Environment.dev),
-        Environment.stg: CITestHelper.getExpectedProjectId(Environment.stg),
         Environment.prod: CITestHelper.getExpectedProjectId(Environment.prod),
       };
 
@@ -178,19 +176,17 @@ void main() {
       // Verify all configurations are unique
       final projectIds = [
         testData['dev_project'],
-        testData['stg_project'],
         testData['prod_project'],
       ];
 
-      expect(projectIds.toSet().length, equals(3),
+      expect(projectIds.toSet().length, equals(2),
           reason: 'All environments should have unique project IDs');
       expect(projectIds.contains(CITestHelper.getExpectedProjectId(Environment.dev)), isTrue);
-      expect(projectIds.contains(CITestHelper.getExpectedProjectId(Environment.stg)), isTrue);
       expect(projectIds.contains(CITestHelper.getExpectedProjectId(Environment.prod)), isTrue);
     });
 
     test('Firebase configuration accessibility in all environments', () {
-      final environments = [Environment.dev, Environment.stg, Environment.prod];
+      final environments = [Environment.dev, Environment.prod];
 
       for (final env in environments) {
         EnvironmentConfig.setEnvironment(env);
@@ -211,7 +207,6 @@ void main() {
     test('Environment indicators display correct project IDs', () {
       final testCases = [
         (Environment.dev, CITestHelper.getExpectedProjectId(Environment.dev)),
-        (Environment.stg, CITestHelper.getExpectedProjectId(Environment.stg)),
         (Environment.prod, CITestHelper.getExpectedProjectId(Environment.prod)),
       ];
 

--- a/test/unit/app/play_with_me_app_test.dart
+++ b/test/unit/app/play_with_me_app_test.dart
@@ -62,21 +62,6 @@ void main() {
       expect(find.text('Sign in to continue organizing your volleyball games'), findsOneWidget);
     });
 
-    testWidgets('should render correctly in staging environment', (WidgetTester tester) async {
-      EnvironmentConfig.setEnvironment(Environment.stg);
-      await tester.pumpWidget(const PlayWithMeApp());
-
-      // Wait for AuthenticationBloc to process initial auth state and stream subscription
-      await tester.pump(); // Initial build
-      await tester.pump(const Duration(milliseconds: 10)); // Allow bloc to start stream subscription
-      await tester.pump(const Duration(milliseconds: 10)); // Allow stream to emit initial value
-      await tester.pump(); // Rebuild with new state
-
-      // App shows authentication screen regardless of environment
-      expect(find.text('Welcome Back!'), findsOneWidget);
-      expect(find.text('Sign in to continue organizing your volleyball games'), findsOneWidget);
-    });
-
     testWidgets('should have correct theme colors', (WidgetTester tester) async {
       await tester.pumpWidget(const PlayWithMeApp());
 
@@ -112,17 +97,6 @@ void main() {
       await tester.pump(); // Rebuild with new state
       materialApp = tester.widget(find.byType(MaterialApp));
       expect(materialApp.title, 'PlayWithMe (Dev)');
-
-      // Test staging
-      EnvironmentConfig.setEnvironment(Environment.stg);
-      await tester.pumpWidget(const PlayWithMeApp());
-      // Wait for AuthenticationBloc to process initial auth state and stream subscription
-      await tester.pump(); // Initial build
-      await tester.pump(const Duration(milliseconds: 10)); // Allow bloc to start stream subscription
-      await tester.pump(const Duration(milliseconds: 10)); // Allow stream to emit initial value
-      await tester.pump(); // Rebuild with new state
-      materialApp = tester.widget(find.byType(MaterialApp));
-      expect(materialApp.title, 'PlayWithMe (Staging)');
     });
 
     testWidgets('should properly handle authentication state transitions (Unknown → Unauthenticated → UI update)', (WidgetTester tester) async {
@@ -313,54 +287,6 @@ void main() {
       BoxDecoration decoration = envContainer!.decoration as BoxDecoration;
       final border = decoration.border as Border;
       expect(border.top.color, Colors.red);
-
-      // Test staging environment (orange)
-      // Clean up and reinitialize for staging test
-      await tester.pumpWidget(Container()); // Clear the widget tree
-      await tester.pump();
-
-      EnvironmentConfig.setEnvironment(Environment.stg);
-      mockRepo.setCurrentUser(testUser); // Ensure user is still set
-
-      await tester.pumpWidget(BlocProvider<AuthenticationBloc>(
-        create: (context) => sl<AuthenticationBloc>(),
-        child: const MaterialApp(
-          localizationsDelegates: [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: [Locale('en')],
-          home: HomePage(),
-        ),
-      ));
-      await tester.pump();
-
-      // Verify staging environment text
-      expect(find.text('Environment: Staging'), findsOneWidget);
-
-      // Find the environment container for staging
-      final stagingContainers = tester.widgetList<Container>(find.byType(Container));
-      Container? stagingEnvContainer;
-      for (final container in stagingContainers) {
-        if (container.decoration is BoxDecoration) {
-          final decoration = container.decoration as BoxDecoration;
-          if (decoration.border != null && decoration.border is Border) {
-            final border = decoration.border as Border;
-            // Check if it's a uniform border (Border.all) with orange color
-            if (border.top.color == Colors.orange) {
-              stagingEnvContainer = container;
-              break;
-            }
-          }
-        }
-      }
-
-      expect(stagingEnvContainer, isNotNull, reason: 'Should find container with orange border for staging environment');
-      BoxDecoration stagingDecoration = stagingEnvContainer!.decoration as BoxDecoration;
-      final stagingBorder = stagingDecoration.border as Border;
-      expect(stagingBorder.top.color, Colors.orange);
 
       // Test production environment (green)
       // Clean up and reinitialize for production test

--- a/test/unit/core/config/environment_config_test.dart
+++ b/test/unit/core/config/environment_config_test.dart
@@ -14,16 +14,6 @@ void main() {
 
         expect(EnvironmentConfig.environment, Environment.dev);
         expect(EnvironmentConfig.isDevelopment, true);
-        expect(EnvironmentConfig.isStaging, false);
-        expect(EnvironmentConfig.isProduction, false);
-      });
-
-      test('should set and get staging environment', () {
-        EnvironmentConfig.setEnvironment(Environment.stg);
-
-        expect(EnvironmentConfig.environment, Environment.stg);
-        expect(EnvironmentConfig.isDevelopment, false);
-        expect(EnvironmentConfig.isStaging, true);
         expect(EnvironmentConfig.isProduction, false);
       });
 
@@ -32,7 +22,6 @@ void main() {
 
         expect(EnvironmentConfig.environment, Environment.prod);
         expect(EnvironmentConfig.isDevelopment, false);
-        expect(EnvironmentConfig.isStaging, false);
         expect(EnvironmentConfig.isProduction, true);
       });
     });
@@ -41,11 +30,6 @@ void main() {
       test('should return correct environment name for development', () {
         EnvironmentConfig.setEnvironment(Environment.dev);
         expect(EnvironmentConfig.environmentName, 'Development');
-      });
-
-      test('should return correct environment name for staging', () {
-        EnvironmentConfig.setEnvironment(Environment.stg);
-        expect(EnvironmentConfig.environmentName, 'Staging');
       });
 
       test('should return correct environment name for production', () {
@@ -60,11 +44,6 @@ void main() {
         expect(EnvironmentConfig.firebaseProjectId, 'gatherli-dev');
       });
 
-      test('should return correct Firebase project ID for staging', () {
-        EnvironmentConfig.setEnvironment(Environment.stg);
-        expect(EnvironmentConfig.firebaseProjectId, 'playwithme-stg');
-      });
-
       test('should return correct Firebase project ID for production', () {
         EnvironmentConfig.setEnvironment(Environment.prod);
         expect(EnvironmentConfig.firebaseProjectId, 'gatherli-prod');
@@ -75,11 +54,6 @@ void main() {
       test('should return correct app suffix for development', () {
         EnvironmentConfig.setEnvironment(Environment.dev);
         expect(EnvironmentConfig.appSuffix, ' (Dev)');
-      });
-
-      test('should return correct app suffix for staging', () {
-        EnvironmentConfig.setEnvironment(Environment.stg);
-        expect(EnvironmentConfig.appSuffix, ' (Staging)');
       });
 
       test('should return empty app suffix for production', () {


### PR DESCRIPTION
## Summary

- Remove staging (`stg`) environment entirely — project now uses `dev` and `prod` only
- Delete `firebase_config_stg.dart` and `main_stg.dart`
- Update `Environment` enum, `FirebaseConfigBase`, `FirebaseConfigFactory`, `FirebaseOptionsProvider`, and `EnvironmentIndicator` to remove all staging references
- Update `FirebaseConfigValidator` with correct Gatherli project IDs (`gatherli-dev`, `gatherli-prod`) and bundle IDs (`org.gatherli.app.dev`, `org.gatherli.app`)
- Update iOS Firebase copy script (`copy-firebase-config.sh`) to remove `stg` flavor
- Update GitHub Actions `build-verification.yml` to remove staging secrets and build step
- Update all unit, integration, and CI-only tests to reflect two-environment setup

## Test plan

- [x] `flutter analyze` — 0 errors
- [x] `flutter test test/unit/` — 2546 tests pass
- [x] No `Environment.stg` references remain in any `.dart`, `.yml`, or `.sh` files

Authored-by: Babas10 <etienne.dubois91@gmail.com>