### PR TITLE
feat(web): update manifest.json and index.html branding to Gatherli (Story 18.9)

### DIFF
--- a/test/unit/web/web_branding_test.dart
+++ b/test/unit/web/web_branding_test.dart
@@ -1,0 +1,85 @@
+// Validates that web/manifest.json and web/index.html contain correct Gatherli branding.
+// Story 18.9 — Web: Update manifest.json & Web Firebase Config
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Resolve paths relative to project root regardless of where tests run from
+  final projectRoot = _findProjectRoot();
+
+  group('web/manifest.json branding', () {
+    late Map<String, dynamic> manifest;
+
+    setUp(() {
+      final file = File('$projectRoot/web/manifest.json');
+      manifest = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+    });
+
+    test('name is Gatherli', () {
+      expect(manifest['name'], 'Gatherli');
+    });
+
+    test('short_name is Gatherli', () {
+      expect(manifest['short_name'], 'Gatherli');
+    });
+
+    test('description is meaningful (not default Flutter placeholder)', () {
+      final description = manifest['description'] as String;
+      expect(description, isNot('A new Flutter project.'));
+      expect(description, isNotEmpty);
+      expect(description, 'Organize and join games with your group.');
+    });
+
+    test('does not contain play_with_me references', () {
+      final raw = File('$projectRoot/web/manifest.json').readAsStringSync();
+      expect(raw.contains('play_with_me'), isFalse,
+          reason: 'manifest.json should not contain legacy play_with_me branding');
+    });
+  });
+
+  group('web/index.html branding', () {
+    late String html;
+
+    setUp(() {
+      html = File('$projectRoot/web/index.html').readAsStringSync();
+    });
+
+    test('<title> is Gatherli', () {
+      expect(html, contains('<title>Gatherli</title>'));
+    });
+
+    test('apple-mobile-web-app-title is Gatherli', () {
+      expect(
+        html,
+        contains('content="Gatherli"'),
+        reason: 'apple-mobile-web-app-title meta tag should reference Gatherli',
+      );
+    });
+
+    test('meta description is meaningful (not default Flutter placeholder)', () {
+      expect(html, isNot(contains('content="A new Flutter project."')));
+      expect(html, contains('content="Organize and join games with your group."'));
+    });
+
+    test('does not contain play_with_me references', () {
+      expect(html.contains('play_with_me'), isFalse,
+          reason: 'index.html should not contain legacy play_with_me branding');
+    });
+  });
+}
+
+/// Walks up from the current directory to find the Flutter project root
+/// (the directory containing pubspec.yaml).
+String _findProjectRoot() {
+  var dir = Directory.current;
+  while (!File('${dir.path}/pubspec.yaml').existsSync()) {
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      throw StateError('Could not find project root (pubspec.yaml not found)');
+    }
+    dir = parent;
+  }
+  return dir.path;
+}

--- a/test/unit/widget_test.dart
+++ b/test/unit/widget_test.dart
@@ -29,7 +29,7 @@ void main() {
     cleanupTestDependencies();
   });
 
-  testWidgets('PlayWithMe app login page shows correct authentication UI elements', (WidgetTester tester) async {
+  testWidgets('Gatherli app login page shows correct authentication UI elements', (WidgetTester tester) async {
     // Create a test app with the real LoginPage and proper BLoC setup
     await tester.pumpWidget(
       MaterialApp(

--- a/web/index.html
+++ b/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Organize and join games with your group.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="play_with_me">
+  <meta name="apple-mobile-web-app-title" content="Gatherli">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>play_with_me</title>
+  <title>Gatherli</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "play_with_me",
-    "short_name": "play_with_me",
+    "name": "Gatherli",
+    "short_name": "Gatherli",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "description": "Organize and join games with your group.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
## Story 18.9 — Web: Update manifest.json & Web Firebase Config

Closes #515

---

## Changes

### `web/manifest.json`
| Field | Before | After |
|-------|--------|-------|
| `name` | `play_with_me` | `Gatherli` |
| `short_name` | `play_with_me` | `Gatherli` |
| `description` | `A new Flutter project.` | `Organize and join games with your group.` |

### `web/index.html`
| Element | Before | After |
|---------|--------|-------|
| `<title>` | `play_with_me` | `Gatherli` |
| `<meta name="description">` | `A new Flutter project.` | `Organize and join games with your group.` |
| `<meta name="apple-mobile-web-app-title">` | `play_with_me` | `Gatherli` |

### Web Firebase Config
No `web/firebase-config.js` file exists in this project — the web Firebase SDK is initialized via Flutter's `firebase_core` package using the existing environment-specific configs. No action needed.

### Tests
- **`test/unit/web/web_branding_test.dart`** *(new — 8 tests)*: regression guard that reads `web/manifest.json` and `web/index.html` directly and asserts all Gatherli values are present with no legacy `play_with_me` references.
- **`test/unit/widget_test.dart`**: renamed test description from "PlayWithMe app..." to "Gatherli app...".

**Test results:** 2554 tests passing, 3 skipped (pre-existing), 0 failures.

---

## Acceptance Criteria

- [x] `web/manifest.json` shows "Gatherli" as name and short_name
- [x] `web/index.html` title updated to "Gatherli"
- [x] Description updated to meaningful text in both files
- [x] `flutter analyze` returns 0 errors
- [x] All tests pass (2554 passing)
- [x] Web Firebase config — N/A (no `web/firebase-config.js` in project)

Authored-by: Babas10 <etienne.dubois91@gmail.com>