### PR TITLE
test: update hardcoded PlayWithMe IDs and branding in test suite (Story 18.10)

### DIFF
--- a/integration_test/helpers/firebase_emulator_helper.dart
+++ b/integration_test/helpers/firebase_emulator_helper.dart
@@ -12,7 +12,7 @@ import 'package:firebase_core/firebase_core.dart';
 /// - Managing test state
 class FirebaseEmulatorHelper {
   static bool _initialized = false;
-  static const String _testProjectId = 'playwithme-dev';
+  static const String _testProjectId = 'gatherli-dev';
 
   // Emulator host configuration
   static const String emulatorHost = 'localhost';

--- a/lib/features/profile/presentation/pages/email_verification_page.dart
+++ b/lib/features/profile/presentation/pages/email_verification_page.dart
@@ -436,7 +436,7 @@ class EmailVerificationPage extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               Text(
-                'Contact support at support@playwithme.com',
+                'Contact support at support@gatherli.org',
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.primary,
                 ),

--- a/test/unit/core/services/app_links_deep_link_service_test.dart
+++ b/test/unit/core/services/app_links_deep_link_service_test.dart
@@ -95,7 +95,7 @@ void main() {
 
       test('returns null for unknown scheme', () async {
         when(() => mockAppLinks.getInitialLink()).thenAnswer(
-          (_) async => Uri.parse('playwithme://invite/abc123'),
+          (_) async => Uri.parse('unknown://invite/abc123'),
         );
         final service = buildService();
         final token = await service.getInitialInviteToken();

--- a/test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart
+++ b/test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart
@@ -34,7 +34,7 @@ void main() {
       const groupId = 'group-123';
       const inviteId = 'invite-456';
       const token = 'abc123token';
-      const deepLinkUrl = 'https://playwithme.app/invite/abc123token';
+      const deepLinkUrl = 'https://gatherli.org/invite/abc123token';
 
       blocTest<GroupInviteLinkBloc, GroupInviteLinkState>(
         'emits [loading, generated] when invite is created successfully',

--- a/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
@@ -233,7 +233,7 @@ void main() {
             findsOneWidget);
         expect(find.text('Check your internet connection'), findsOneWidget);
         expect(find.text('Still having issues?'), findsOneWidget);
-        expect(find.text('Contact support at support@playwithme.com'),
+        expect(find.text('Contact support at support@gatherli.org'),
             findsOneWidget);
       });
     });

--- a/test/widget/features/groups/presentation/widgets/invite_link_section_test.dart
+++ b/test/widget/features/groups/presentation/widgets/invite_link_section_test.dart
@@ -94,7 +94,7 @@ void main() {
     testWidgets('shows generated link with copy and share buttons',
         (tester) async {
       when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
-        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        deepLinkUrl: 'https://gatherli.org/invite/abc123',
         inviteId: 'invite-456',
       ));
 
@@ -102,7 +102,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.text('https://playwithme.app/invite/abc123'),
+        find.text('https://gatherli.org/invite/abc123'),
         findsOneWidget,
       );
       expect(find.text('Copy Link'), findsOneWidget);
@@ -112,7 +112,7 @@ void main() {
 
     testWidgets('copy button copies link to clipboard', (tester) async {
       when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
-        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        deepLinkUrl: 'https://gatherli.org/invite/abc123',
         inviteId: 'invite-456',
       ));
 
@@ -151,7 +151,7 @@ void main() {
     testWidgets('revoke button dispatches RevokeInvite event',
         (tester) async {
       when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
-        deepLinkUrl: 'https://playwithme.app/invite/abc123',
+        deepLinkUrl: 'https://gatherli.org/invite/abc123',
         inviteId: 'invite-456',
       ));
 
@@ -228,7 +228,7 @@ void main() {
 
     testWidgets('shows copy and share icons', (tester) async {
       when(() => mockBloc.state).thenReturn(const GroupInviteLinkGenerated(
-        deepLinkUrl: 'https://playwithme.app/invite/test',
+        deepLinkUrl: 'https://gatherli.org/invite/test',
         inviteId: 'inv-1',
       ));
 


### PR DESCRIPTION
## Story 18.10 — Test Suite: Update Hardcoded Project IDs & Bundle IDs

Closes #516

---

## Changes

| File | Change |
|------|--------|
| `integration_test/helpers/firebase_emulator_helper.dart` | `_testProjectId`: `playwithme-dev` → `gatherli-dev` |
| `test/unit/core/services/app_links_deep_link_service_test.dart` | "unknown scheme" test URI: `playwithme://invite/abc123` → `unknown://invite/abc123` |
| `test/unit/features/groups/presentation/bloc/group_invite_link/group_invite_link_bloc_test.dart` | `deepLinkUrl` constant: `playwithme.app/invite` → `gatherli.org/invite` |
| `test/unit/features/profile/presentation/pages/email_verification_page_test.dart` | Expected support email: `support@playwithme.com` → `support@gatherli.org` |
| `test/widget/features/groups/presentation/widgets/invite_link_section_test.dart` | 5× deep link URLs: `playwithme.app/invite` → `gatherli.org/invite` |
| `lib/features/profile/presentation/pages/email_verification_page.dart` | Hardcoded support email: `support@playwithme.com` → `support@gatherli.org` (kept in sync with test) |

### Notes

- **`test/ci_only/firebase_config_validator_test.dart`** was already fully updated to Gatherli values in Story 18.5 — no change needed.
- **GitHub issue references** (`github.com/Babas10/playWithMe/issues/*`) remain valid and are intentionally left unchanged — the repo URL has not changed.
- The `playwithme://` URI in `app_links_deep_link_service_test.dart` was deliberately changed to `unknown://` to make the test intent clearer (testing that unrecognised schemes return null), while also eliminating the legacy branding reference.

---

## Test Results

- ✅ `flutter analyze` — 0 errors
- ✅ `flutter test test/unit/` — 2554 tests passed, 3 skipped (pre-existing)
- ✅ `flutter test test/widget/` — all widget tests pass
- ✅ No remaining `playwithme` branding references in test or integration_test files (outside of package import paths and GitHub issue URLs)

---

## Acceptance Criteria

- [x] `firebase_emulator_helper.dart` uses `gatherli-dev` project ID
- [x] `firebase_config_validator_test.dart` already asserts against new identifiers (done in Story 18.5)
- [x] All unit tests pass
- [x] All widget tests pass
- [x] 0 analyzer errors
- [x] No new skipped tests

Authored-by: Babas10 <etienne.dubois91@gmail.com>