### PR TITLE
Story 19.2: Android — Deferred Token Recovery via Play Install Referrer

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,4 +57,5 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    implementation("com.android.installreferrer:installreferrer:2.2")
 }

--- a/android/app/src/main/kotlin/org/gatherli/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/gatherli/app/MainActivity.kt
@@ -1,5 +1,61 @@
 package org.gatherli.app
 
+import android.os.Handler
+import android.os.Looper
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerStateListener
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    private val channelName = "org.gatherli.app/install_referrer"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getReferrerString" -> fetchReferrerString(result)
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    /**
+     * Reads the Play Install Referrer string asynchronously and delivers it
+     * back to Flutter via [result].
+     *
+     * The referrer string is set by invite.html (Story 19.1) as
+     * `invite_token=<token>` in the Play Store URL. The Play Install Referrer
+     * API makes it available on first launch only.
+     */
+    private fun fetchReferrerString(result: MethodChannel.Result) {
+        val referrerClient = InstallReferrerClient.newBuilder(this).build()
+
+        referrerClient.startConnection(object : InstallReferrerStateListener {
+            override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                val mainHandler = Handler(Looper.getMainLooper())
+                when (responseCode) {
+                    InstallReferrerClient.InstallReferrerResponse.OK -> {
+                        val referrer =
+                            referrerClient.installReferrer?.installReferrer
+                        mainHandler.post { result.success(referrer) }
+                        referrerClient.endConnection()
+                    }
+                    else -> {
+                        // Not installed via Play Store, or referrer unavailable.
+                        mainHandler.post { result.success(null) }
+                        referrerClient.endConnection()
+                    }
+                }
+            }
+
+            override fun onInstallReferrerServiceDisconnected() {
+                Handler(Looper.getMainLooper()).post { result.success(null) }
+            }
+        })
+    }
+}

--- a/docs/epic-19/story-19.2/README.md
+++ b/docs/epic-19/story-19.2/README.md
@@ -1,0 +1,140 @@
+# Story 19.2 — Android: Deferred Token Recovery via Play Install Referrer
+
+## Overview
+
+On Android, when the app is launched for the first time after being installed via a Gatherli invite link, this story recovers the invite token and makes it available to the existing `DeepLinkBloc` flow.
+
+**Depends on:** Story 19.1 (invite.html embeds the token in the Play Store referrer URL)
+
+## How It Works
+
+```
+User taps https://gatherli.org/invite/{token}
+    ↓
+App not installed → Android falls back to browser → invite.html loads
+    ↓
+JS detects Android → window.location.replace(Play Store URL):
+    https://play.google.com/store/apps/details
+      ?id=org.gatherli.app
+      &referrer=invite_token%3D{token}
+    ↓
+Play Store installs app, preserves referrer string
+    ↓
+First launch → AndroidDeferredDeepLinkService.retrieveDeferredToken()
+    ↓
+Native MethodChannel calls com.android.installreferrer API
+    ↓
+Referrer string "invite_token={token}" parsed → token returned
+    ↓
+Story 19.4 feeds token into DeepLinkBloc via InviteTokenReceived ✅
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/core/services/deferred_deep_link/deferred_deep_link_service.dart` | New — abstract interface |
+| `lib/core/services/deferred_deep_link/android_deferred_deep_link_service.dart` | New — Android implementation |
+| `lib/core/services/service_locator.dart` | DI registration (Android-only) |
+| `android/app/build.gradle.kts` | Added `com.android.installreferrer:installreferrer:2.2` |
+| `android/app/src/main/kotlin/org/gatherli/app/MainActivity.kt` | MethodChannel handler |
+| `test/unit/core/services/deferred_deep_link/android_deferred_deep_link_service_test.dart` | New — 9 unit tests |
+
+## Architecture
+
+### Why a MethodChannel instead of a Flutter package?
+
+The `install_referrer` Flutter package (v1.2.1) detects **which store** installed the app (an enum: Google Play, App Store, etc.) — it does **not** expose the custom referrer string.
+
+The correct Google Play Install Referrer Library (`com.android.installreferrer:installreferrer:2.2`) is a native Android library. It is accessed via a `MethodChannel` named `org.gatherli.app/install_referrer`.
+
+### Why an `InstallReferrerClient` abstraction?
+
+The `PlayInstallReferrerClient` (which calls the MethodChannel) is injected into `AndroidDeferredDeepLinkService`. Unit tests inject a `MockInstallReferrerClient` instead, making the parsing logic fully testable without Android hardware.
+
+### Referrer string format
+
+Story 19.1 sets the Play Store URL as:
+```
+https://play.google.com/store/apps/details
+  ?id=org.gatherli.app
+  &referrer=invite_token%3D{token}
+```
+
+The `%3D` is URL-encoded `=`. The Play Store URL-decodes the `referrer` parameter once before delivery, so `AndroidDeferredDeepLinkService` receives:
+```
+invite_token=abc123
+```
+
+The service also handles the double-encoded form (`invite_token%3Dabc123`) seen on some Play Store versions.
+
+### Platform guard in DI
+
+```dart
+// service_locator.dart
+if (!kIsWeb && Platform.isAndroid) {
+  if (!sl.isRegistered<DeferredDeepLinkService>()) {
+    sl.registerLazySingleton<DeferredDeepLinkService>(
+      () => AndroidDeferredDeepLinkService(),
+    );
+  }
+}
+```
+
+The `kIsWeb` check is required because `dart:io Platform` is not available on Flutter Web and would throw at runtime.
+
+## Native Android Implementation
+
+`MainActivity.kt` implements the `getReferrerString` method by calling the `com.android.installreferrer` library asynchronously:
+
+```kotlin
+val referrerClient = InstallReferrerClient.newBuilder(this).build()
+referrerClient.startConnection(object : InstallReferrerStateListener {
+    override fun onInstallReferrerSetupFinished(responseCode: Int) {
+        when (responseCode) {
+            InstallReferrerClient.InstallReferrerResponse.OK -> {
+                val referrer = referrerClient.installReferrer?.installReferrer
+                // deliver referrer string back to Flutter
+            }
+            else -> // deliver null (not installed via Play Store)
+        }
+    }
+    override fun onInstallReferrerServiceDisconnected() {
+        // deliver null
+    }
+})
+```
+
+The referrer string is only available for a short window after install. Subsequent calls return null or an error, which the service handles gracefully.
+
+## Unit Tests
+
+All 9 tests in `test/unit/core/services/deferred_deep_link/android_deferred_deep_link_service_test.dart`:
+
+| Test | Scenario |
+|------|----------|
+| returns token for valid `invite_token` referrer | `invite_token=abc123` → `abc123` |
+| returns token for referrer with multiple params | `utm_source=email&invite_token=xyz789` → `xyz789` |
+| returns null when referrer has no `invite_token` | `utm_source=other` → null |
+| returns null when referrer is empty string | `""` → null |
+| returns null when client returns null | null → null |
+| returns null when client throws | exception → null (graceful) |
+| handles URL-encoded referrer string | `invite_token%3Dabc123` → `abc123` |
+| returns null for malformed referrer string | `%%%invalid%%%` → null |
+| returns null when `invite_token` value is empty | `invite_token=` → null |
+
+## Error Handling
+
+All error paths return `null` silently. The invite flow degrades gracefully:
+- App opens normally with no pending invite
+- User can still accept the invite manually if they have the link
+
+## Testing
+
+This story contains no UI. Validation beyond unit tests is manual:
+
+| Test | Steps | Expected |
+|------|-------|----------|
+| Android fresh install | Install app via Play Store link with token | First launch recovers token (Story 19.4 feeds it to DeepLinkBloc) |
+| Non-invite install | Install app from Play Store search | `retrieveDeferredToken()` returns null |
+| Error path | Disconnect Play Store services before launch | Returns null, no crash |

--- a/lib/core/services/deferred_deep_link/android_deferred_deep_link_service.dart
+++ b/lib/core/services/deferred_deep_link/android_deferred_deep_link_service.dart
@@ -1,0 +1,79 @@
+// Android implementation of DeferredDeepLinkService.
+//
+// Reads the Play Install Referrer string via a MethodChannel that delegates
+// to the native com.android.installreferrer library (implemented in
+// MainActivity.kt). The referrer string is set by invite.html (Story 19.1)
+// when the user taps the Play Store link.
+import 'package:flutter/services.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/deferred_deep_link_service.dart';
+
+/// Thin abstraction over the MethodChannel, extracted for unit-test injection.
+abstract class InstallReferrerClient {
+  /// Returns the raw referrer string from the Play Store, or null.
+  Future<String?> getReferrerString();
+}
+
+/// Production implementation — delegates to the native channel.
+class PlayInstallReferrerClient implements InstallReferrerClient {
+  static const _channel =
+      MethodChannel('org.gatherli.app/install_referrer');
+
+  @override
+  Future<String?> getReferrerString() async {
+    return _channel.invokeMethod<String>('getReferrerString');
+  }
+}
+
+/// Reads the Play Install Referrer on first launch and extracts the invite
+/// token embedded by the invite.html redirect page (Story 19.1).
+///
+/// Expected referrer format from Play Store: `invite_token=<token>`
+/// (Play Store URL-decodes the referrer parameter once before delivery.)
+///
+/// Only registered on Android via service_locator.dart.
+class AndroidDeferredDeepLinkService implements DeferredDeepLinkService {
+  final InstallReferrerClient _client;
+
+  AndroidDeferredDeepLinkService({InstallReferrerClient? client})
+      : _client = client ?? PlayInstallReferrerClient();
+
+  @override
+  Future<String?> retrieveDeferredToken() async {
+    try {
+      final referrer = await _client.getReferrerString();
+      return _parseToken(referrer);
+    } catch (_) {
+      // Referrer API unavailable, timed out, or not installed via Play Store.
+      // Return null silently — the invite flow degrades gracefully.
+      return null;
+    }
+  }
+
+  /// Parses `invite_token` from the Play Store referrer string.
+  ///
+  /// The referrer delivered via the Play Install Referrer API is already
+  /// URL-decoded once. However, to be safe this method also handles the
+  /// double-encoded form (e.g. `invite_token%3Dabc`) seen on some devices.
+  String? _parseToken(String? referrer) {
+    if (referrer == null || referrer.isEmpty) return null;
+
+    // Standard form: `invite_token=abc123`
+    final params = Uri.splitQueryString(referrer);
+    final token = params['invite_token'];
+    if (token != null && token.isNotEmpty) return token;
+
+    // Fallback: try URL-decoding the referrer and re-parse.
+    // Handles double-encoded referrers on some Play Store versions.
+    try {
+      final decoded = Uri.decodeComponent(referrer);
+      if (decoded == referrer) return null; // Nothing to decode, already tried
+      final decodedParams = Uri.splitQueryString(decoded);
+      final decodedToken = decodedParams['invite_token'];
+      if (decodedToken != null && decodedToken.isNotEmpty) return decodedToken;
+    } catch (_) {
+      // Malformed referrer — return null
+    }
+
+    return null;
+  }
+}

--- a/lib/core/services/deferred_deep_link/deferred_deep_link_service.dart
+++ b/lib/core/services/deferred_deep_link/deferred_deep_link_service.dart
@@ -1,0 +1,9 @@
+// Abstract service for recovering a deferred invite token on first app launch.
+abstract class DeferredDeepLinkService {
+  /// Returns the invite token preserved through the app install process, or
+  /// null if no deferred token is available.
+  ///
+  /// Must be called only once on first launch. Subsequent calls may return
+  /// null because the underlying referrer data is consumed on first read.
+  Future<String?> retrieveDeferredToken();
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -55,6 +55,10 @@ import 'package:play_with_me/features/groups/presentation/bloc/group_invite_link
 import 'package:play_with_me/core/services/pending_invite_storage.dart';
 import 'package:play_with_me/core/services/deep_link_service.dart';
 import 'package:play_with_me/core/services/app_links_deep_link_service.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/deferred_deep_link_service.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/android_deferred_deep_link_service.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:io' show Platform;
 import 'package:play_with_me/core/presentation/bloc/account_status/account_status_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_bloc.dart';
@@ -233,6 +237,16 @@ Future<void> initializeDependencies() async {
     sl.registerLazySingleton<DeepLinkService>(
       () => AppLinksDeepLinkService(),
     );
+  }
+
+  // Deferred deep link service — Android only.
+  // kIsWeb guard is required because dart:io Platform is not available on web.
+  if (!kIsWeb && Platform.isAndroid) {
+    if (!sl.isRegistered<DeferredDeepLinkService>()) {
+      sl.registerLazySingleton<DeferredDeepLinkService>(
+        () => AndroidDeferredDeepLinkService(),
+      );
+    }
   }
 
   // Register BLoCs only if not already registered

--- a/test/unit/core/services/deferred_deep_link/android_deferred_deep_link_service_test.dart
+++ b/test/unit/core/services/deferred_deep_link/android_deferred_deep_link_service_test.dart
@@ -1,0 +1,102 @@
+// Validates AndroidDeferredDeepLinkService correctly parses the Play Store
+// referrer string and extracts the invite token (or returns null gracefully).
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/android_deferred_deep_link_service.dart';
+
+class MockInstallReferrerClient extends Mock implements InstallReferrerClient {}
+
+void main() {
+  late MockInstallReferrerClient mockClient;
+  late AndroidDeferredDeepLinkService service;
+
+  setUp(() {
+    mockClient = MockInstallReferrerClient();
+    service = AndroidDeferredDeepLinkService(client: mockClient);
+  });
+
+  group('AndroidDeferredDeepLinkService.retrieveDeferredToken', () {
+    test('returns token for valid invite_token referrer', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => 'invite_token=abc123');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, 'abc123');
+    });
+
+    test('returns token for referrer with multiple params', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => 'utm_source=email&invite_token=xyz789&utm_medium=social');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, 'xyz789');
+    });
+
+    test('returns null when referrer has no invite_token param', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => 'utm_source=other&utm_medium=email');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when referrer is empty string', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => '');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when client returns null', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => null);
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when client throws (graceful error handling)', () async {
+      when(() => mockClient.getReferrerString())
+          .thenThrow(Exception('Referrer API unavailable'));
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('handles URL-encoded referrer string (double-encoded form)', () async {
+      // In some Play Store versions the referrer may arrive double-encoded:
+      // invite_token%3Dabc123 instead of invite_token=abc123
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => 'invite_token%3Dabc123');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, 'abc123');
+    });
+
+    test('returns null for malformed referrer string', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => '%%%invalid%%%');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when invite_token value is empty', () async {
+      when(() => mockClient.getReferrerString())
+          .thenAnswer((_) async => 'invite_token=');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements Android deferred deep linking so invite tokens survive the Play Store install flow (Story 19.2, closes #535).

- **Abstract interface** `DeferredDeepLinkService` with `retrieveDeferredToken()` — the contract for both Android (this story) and iOS (Story 19.3)
- **`AndroidDeferredDeepLinkService`**: calls a native MethodChannel (`org.gatherli.app/install_referrer`), parses `invite_token=<token>` from the Play Store referrer string, handles URL-encoded form and all error paths (returns null gracefully, no crash)
- **`InstallReferrerClient` abstraction**: thin wrapper injected into the service — allows full unit-test coverage without Android hardware
- **`MainActivity.kt`**: implements the MethodChannel using `com.android.installreferrer:installreferrer:2.2` (the official Google Play Install Referrer native library)
- **DI registration**: `DeferredDeepLinkService` registered in `get_it` on Android only (`!kIsWeb && Platform.isAndroid`)
- **9 unit tests**: valid token, multiple params, missing param, empty string, null client, client throws, URL-encoded referrer, malformed referrer, empty token value

> **Why MethodChannel instead of a Flutter package?**
> The `install_referrer` Flutter package (v1.x) detects *which store* installed the app (an enum) — it does not expose the custom referrer string. The correct Google Play Install Referrer Library is native-only and accessed via a MethodChannel.

## Test plan

- [x] `flutter test test/unit/core/services/deferred_deep_link/` — 9/9 pass
- [x] `flutter test test/unit/` — 2579 pass, 3 skipped (pre-existing), 0 failures
- [x] `flutter analyze` — no new errors or warnings in changed files
- [ ] Manual: install app on Android via Play Store referrer link → first launch recovers token (requires Story 19.4 to wire into DeepLinkBloc)