### PR TITLE
Story 19.3: iOS — Deferred Token Recovery via Clipboard

### DIFF
--- a/docs/epic-19/story-19.3/README.md
+++ b/docs/epic-19/story-19.3/README.md
@@ -1,0 +1,121 @@
+# Story 19.3 — iOS: Deferred Token Recovery via Clipboard
+
+## Overview
+
+On iOS, when the app is launched for the first time after being installed via the App Store (following the clipboard-write redirect in Story 19.1), this story recovers the invite token from the clipboard and makes it available to the existing `DeepLinkBloc` flow.
+
+**Depends on:**
+- Story 19.1 (invite.html writes `gatherli://invite/{token}` to clipboard on iOS tap)
+- Story 19.2 (defines the `DeferredDeepLinkService` interface)
+
+## How It Works
+
+```
+User taps https://gatherli.org/invite/{token} on iOS (app not installed)
+    ↓
+Safari falls back to browser → invite.html loads
+    ↓
+User taps "Download on the App Store" button:
+    1. navigator.clipboard.writeText('gatherli://invite/{token}')
+    2. window.location.href = APP_STORE_URL
+    ↓
+App Store installs app
+    ↓
+First launch → IosDeferredDeepLinkService.retrieveDeferredToken()
+    ↓
+Reads clipboard → finds 'gatherli://invite/{token}'
+    ↓
+Extracts token → clears clipboard → returns token
+    ↓
+Story 19.4 feeds token into DeepLinkBloc via InviteTokenReceived ✅
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/core/services/deferred_deep_link/ios_deferred_deep_link_service.dart` | New — iOS implementation |
+| `lib/core/services/service_locator.dart` | Added iOS branch to DI registration |
+| `test/unit/core/services/deferred_deep_link/ios_deferred_deep_link_service_test.dart` | New — 10 unit tests |
+
+## Architecture
+
+### Why `ClipboardReader` abstraction?
+
+`FlutterClipboardReader` (which calls `Clipboard.getData`) is injected into `IosDeferredDeepLinkService`. Unit tests inject a `MockClipboardReader` instead, making the parsing and clear logic fully testable without platform bindings.
+
+This mirrors the `InstallReferrerClient` pattern from Story 19.2.
+
+### iOS 16+ Consent Prompt
+
+iOS 16 and later shows a system prompt when an app reads the clipboard programmatically:
+> *"Allow Gatherli to paste from Safari?"*
+
+| User action | Result |
+|-------------|--------|
+| Taps **Allow** | Clipboard is read, token recovered ✅ |
+| Taps **Don't Allow** | `Clipboard.getData` returns null, token silently lost ✅ |
+
+This is an Apple platform constraint. The implementation handles denial gracefully — no crash, no retry, the invite flow falls back to manual link-tap.
+
+### Clipboard clear after extraction
+
+The clipboard is cleared immediately after a valid token is extracted:
+
+```dart
+await _clipboard.clear();
+```
+
+This prevents the same token from firing on subsequent cold starts (e.g., if the user force-quits and relaunches without opening a group).
+
+### DI registration
+
+```dart
+// service_locator.dart
+if (!kIsWeb && Platform.isAndroid) {
+  sl.registerLazySingleton<DeferredDeepLinkService>(
+    () => AndroidDeferredDeepLinkService(),
+  );
+} else if (!kIsWeb && Platform.isIOS) {
+  sl.registerLazySingleton<DeferredDeepLinkService>(
+    () => IosDeferredDeepLinkService(),
+  );
+}
+```
+
+The `kIsWeb` guard is required because `dart:io Platform` is not available on Flutter Web.
+
+## Unit Tests
+
+All 10 tests in `test/unit/core/services/deferred_deep_link/ios_deferred_deep_link_service_test.dart`:
+
+| Test | Scenario |
+|------|----------|
+| returns token from valid `gatherli://invite/` content | `gatherli://invite/abc123` → `abc123` |
+| clears clipboard after extracting valid token | `clear()` called exactly once |
+| returns null for wrong scheme (https URL) | `https://gatherli.org/invite/abc123` → null |
+| returns null for unrelated clipboard content | `some random text` → null |
+| returns null when clipboard is empty string | `""` → null |
+| returns null when clipboard read returns null | null → null |
+| returns null for `gatherli://invite/` with empty token | `gatherli://invite/` → null |
+| returns null when clipboard throws (iOS consent denied) | exception → null |
+| does not clear clipboard when no valid token found | `clear()` never called |
+| trims whitespace from extracted token | `gatherli://invite/  token123  ` → `token123` |
+
+## Reliability Note
+
+iOS clipboard-based deferred deep linking has ~65–80% success rate depending on:
+- iOS version (16+ requires user consent)
+- Whether the user grants clipboard permission
+- Whether the clipboard is overwritten before first launch
+
+This is an inherent platform limitation. The fallback (Option 1 — user must tap the invite link again after installing) is seamless since Universal Links will open the app directly if it is installed.
+
+## Testing
+
+| Test | Steps | Expected |
+|------|-------|----------|
+| iOS fresh install | Tap invite link in Safari (app not installed) → tap App Store button → install → open | First launch shows invite join flow |
+| Consent denied | Same as above, tap "Don't Allow" on clipboard prompt | App opens normally, no invite shown |
+| No invite | Install app directly from App Store | `retrieveDeferredToken()` returns null |
+| Token whitespace | Clipboard contains `gatherli://invite/ abc123 ` | Token extracted as `abc123` |

--- a/lib/core/services/deferred_deep_link/ios_deferred_deep_link_service.dart
+++ b/lib/core/services/deferred_deep_link/ios_deferred_deep_link_service.dart
@@ -1,0 +1,67 @@
+// iOS implementation of DeferredDeepLinkService.
+//
+// Reads the clipboard on first launch to recover the invite token written by
+// invite.html (Story 19.1). The clipboard contains `gatherli://invite/{token}`
+// after the user taps the App Store button on the invite page.
+//
+// iOS 16+ shows a system consent prompt ("Allow Gatherli to paste from…?").
+// If the user denies, Clipboard.getData returns null — handled gracefully.
+import 'package:flutter/services.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/deferred_deep_link_service.dart';
+
+/// Thin abstraction over Flutter's Clipboard API, extracted for unit-test
+/// injection (mirrors the InstallReferrerClient pattern from Story 19.2).
+abstract class ClipboardReader {
+  Future<String?> read();
+  Future<void> clear();
+}
+
+/// Production implementation — delegates to Flutter's Clipboard.
+class FlutterClipboardReader implements ClipboardReader {
+  @override
+  Future<String?> read() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    return data?.text;
+  }
+
+  @override
+  Future<void> clear() async {
+    await Clipboard.setData(const ClipboardData(text: ''));
+  }
+}
+
+/// Reads the clipboard on first launch and extracts the invite token written
+/// by invite.html's iOS tap handler (`gatherli://invite/{token}`).
+///
+/// Clears the clipboard immediately after reading to prevent re-processing
+/// the same token on subsequent launches.
+///
+/// Only registered on iOS via service_locator.dart.
+class IosDeferredDeepLinkService implements DeferredDeepLinkService {
+  static const _inviteSchemePrefix = 'gatherli://invite/';
+
+  final ClipboardReader _clipboard;
+
+  IosDeferredDeepLinkService({ClipboardReader? clipboard})
+      : _clipboard = clipboard ?? FlutterClipboardReader();
+
+  @override
+  Future<String?> retrieveDeferredToken() async {
+    try {
+      final text = await _clipboard.read() ?? '';
+
+      if (!text.startsWith(_inviteSchemePrefix)) return null;
+
+      final token = text.substring(_inviteSchemePrefix.length).trim();
+      if (token.isEmpty) return null;
+
+      // Clear immediately — prevents the same token firing on next cold start.
+      await _clipboard.clear();
+
+      return token;
+    } catch (_) {
+      // Clipboard access denied or unavailable — silent failure, no crash.
+      return null;
+    }
+  }
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -57,6 +57,7 @@ import 'package:play_with_me/core/services/deep_link_service.dart';
 import 'package:play_with_me/core/services/app_links_deep_link_service.dart';
 import 'package:play_with_me/core/services/deferred_deep_link/deferred_deep_link_service.dart';
 import 'package:play_with_me/core/services/deferred_deep_link/android_deferred_deep_link_service.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/ios_deferred_deep_link_service.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io' show Platform;
 import 'package:play_with_me/core/presentation/bloc/account_status/account_status_bloc.dart';
@@ -239,12 +240,18 @@ Future<void> initializeDependencies() async {
     );
   }
 
-  // Deferred deep link service — Android only.
+  // Deferred deep link service — platform-specific.
   // kIsWeb guard is required because dart:io Platform is not available on web.
   if (!kIsWeb && Platform.isAndroid) {
     if (!sl.isRegistered<DeferredDeepLinkService>()) {
       sl.registerLazySingleton<DeferredDeepLinkService>(
         () => AndroidDeferredDeepLinkService(),
+      );
+    }
+  } else if (!kIsWeb && Platform.isIOS) {
+    if (!sl.isRegistered<DeferredDeepLinkService>()) {
+      sl.registerLazySingleton<DeferredDeepLinkService>(
+        () => IosDeferredDeepLinkService(),
       );
     }
   }

--- a/test/unit/core/services/deferred_deep_link/ios_deferred_deep_link_service_test.dart
+++ b/test/unit/core/services/deferred_deep_link/ios_deferred_deep_link_service_test.dart
@@ -1,0 +1,110 @@
+// Validates IosDeferredDeepLinkService correctly reads the invite token from
+// the clipboard and clears it after extraction (or returns null gracefully).
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/services/deferred_deep_link/ios_deferred_deep_link_service.dart';
+
+class MockClipboardReader extends Mock implements ClipboardReader {}
+
+void main() {
+  late MockClipboardReader mockClipboard;
+  late IosDeferredDeepLinkService service;
+
+  setUp(() {
+    mockClipboard = MockClipboardReader();
+    service = IosDeferredDeepLinkService(clipboard: mockClipboard);
+  });
+
+  group('IosDeferredDeepLinkService.retrieveDeferredToken', () {
+    test('returns token from valid gatherli://invite/ clipboard content', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'gatherli://invite/abc123');
+      when(() => mockClipboard.clear()).thenAnswer((_) async {});
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, 'abc123');
+    });
+
+    test('clears clipboard after successfully extracting a valid token', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'gatherli://invite/abc123');
+      when(() => mockClipboard.clear()).thenAnswer((_) async {});
+
+      await service.retrieveDeferredToken();
+
+      verify(() => mockClipboard.clear()).called(1);
+    });
+
+    test('returns null for wrong scheme (https URL)', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'https://gatherli.org/invite/abc123');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null for unrelated clipboard content', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'some random text copied by user');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when clipboard is empty string', () async {
+      when(() => mockClipboard.read()).thenAnswer((_) async => '');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when clipboard read returns null', () async {
+      when(() => mockClipboard.read()).thenAnswer((_) async => null);
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null for gatherli://invite/ with empty token segment', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'gatherli://invite/');
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when clipboard read throws (iOS consent denied)', () async {
+      when(() => mockClipboard.read())
+          .thenThrow(Exception('Clipboard access denied'));
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, isNull);
+    });
+
+    test('does not clear clipboard when no valid token found', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'https://other.com/link');
+
+      await service.retrieveDeferredToken();
+
+      verifyNever(() => mockClipboard.clear());
+    });
+
+    test('trims whitespace from extracted token', () async {
+      when(() => mockClipboard.read())
+          .thenAnswer((_) async => 'gatherli://invite/  token123  ');
+      when(() => mockClipboard.clear()).thenAnswer((_) async {});
+
+      final token = await service.retrieveDeferredToken();
+
+      expect(token, 'token123');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements iOS deferred deep linking so invite tokens written to the clipboard by invite.html survive the App Store install flow (Story 19.3, closes #536).

- **`IosDeferredDeepLinkService`**: reads clipboard on first launch, matches `gatherli://invite/{token}` prefix, extracts token, clears clipboard immediately to prevent re-processing on subsequent launches, handles all error paths (iOS 16+ consent denial returns null, exceptions return null — no crash)
- **`ClipboardReader` abstraction**: thin wrapper over `Clipboard.getData` / `Clipboard.setData`, injected for unit-test mock (same pattern as `InstallReferrerClient` in Story 19.2)
- **DI registration**: `IosDeferredDeepLinkService` registered in `get_it` on iOS only (`!kIsWeb && Platform.isIOS`), completing the platform-switch block alongside Android
- **10 unit tests**: valid token, clipboard cleared after extraction, wrong scheme, unrelated content, empty string, null read, empty token segment, throws (consent denied), no-clear on miss, whitespace trim

> **Why no native Swift code?**
> Unlike Android (which required a custom `MethodChannel` + Kotlin for the Play Install Referrer Library), Flutter's built-in `Clipboard.getData()` already works natively on iOS. No `AppDelegate.swift` changes or new dependencies needed.

> **iOS 16+ consent prompt** (`"Allow Gatherli to paste from Safari?"`) is an Apple platform constraint that cannot be bypassed. Denial is handled gracefully — the invite flow falls back to the user re-tapping the link after install (which Universal Links handle directly).

## Test plan

- [x] `flutter test test/unit/core/services/deferred_deep_link/ios_deferred_deep_link_service_test.dart` — 10/10 pass
- [x] `flutter test test/unit/` — 2589 pass, 3 skipped (pre-existing), 0 failures
- [x] Rebased cleanly on top of merged Story 19.2 (main)
- [ ] Manual: install app on iOS via App Store after invite link → first launch shows invite join flow (requires Story 19.4 to wire into DeepLinkBloc)