### PR TITLE
fix(story-18.11): firestore rules cleanup, new-user bugs, friend request perf & branding

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -47,6 +47,24 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "initiatorId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "friendships",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "recipientId",
           "order": "ASCENDING"
         },

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,12 +11,6 @@ service cloud.firestore {
       return request.auth != null;
     }
 
-    /// Check if user is a member of the specified group
-    function isGroupMember(groupId) {
-      return isAuthenticated() &&
-             request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberIds;
-    }
-
     /// Check if user is an admin of the specified group
     function isGroupAdmin(groupId) {
       return isAuthenticated() &&

--- a/functions/scripts/README.md
+++ b/functions/scripts/README.md
@@ -1,4 +1,4 @@
-# PlayWithMe Test Scripts
+# Gatherli Test Scripts
 
 Quick-run scripts for setting up and managing test data in the Firebase dev environment.
 
@@ -219,13 +219,13 @@ After running `setupTestEnvironment.ts`:
 
 ## 🔒 Safety
 
-All scripts target **playwithme-dev** only and will fail if run against other projects.
+All scripts target **gatherli-dev** only and will fail if run against other projects.
 
 **Project validation check:**
 ```typescript
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   process.exit(1);
 }
 ```
@@ -246,7 +246,7 @@ if (projectId !== "playwithme-dev") {
 **"Test config not found"**
 → Run `npx ts-node scripts/setupTestEnvironment.ts` first
 
-**"This script can only run on playwithme-dev"**
+**"This script can only run on gatherli-dev"**
 → Check Firebase project with `firebase use` and switch to dev if needed
 
 **Auth users exist but no Firestore documents**
@@ -267,7 +267,7 @@ import { getTestUser, getTestGroupId, printTestConfig } from './testConfigLoader
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 
@@ -303,5 +303,5 @@ if (require.main === module) {
 ## 🔗 Related Documentation
 
 - [Firebase Admin SDK](https://firebase.google.com/docs/admin/setup)
-- [PlayWithMe Testing Guide](../../docs/testing/LOCAL_TESTING_GUIDE.md)
+- [Gatherli Testing Guide](../../docs/testing/LOCAL_TESTING_GUIDE.md)
 - [Story 301.8: Nemesis Detection](https://github.com/Babas10/playWithMe/issues/313)

--- a/functions/scripts/backfill-friend-cache.ts
+++ b/functions/scripts/backfill-friend-cache.ts
@@ -18,13 +18,13 @@ import * as admin from 'firebase-admin';
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: 'playwithme-dev', // ⚠️ Only dev environment
+  projectId: 'gatherli-dev', // ⚠️ Only dev environment
 });
 
 async function backfillFriendCache() {
   const db = admin.firestore();
 
-  console.log('🔄 Starting friend cache backfill for playwithme-dev...\n');
+  console.log('🔄 Starting friend cache backfill for gatherli-dev...\n');
 
   try {
     // 1. Get all accepted friendships
@@ -151,8 +151,8 @@ async function backfillFriendCache() {
 
 // Safety check
 const projectId = admin.app().options.projectId;
-if (projectId !== 'playwithme-dev') {
-  console.error('❌ ERROR: This script can only run on playwithme-dev!');
+if (projectId !== 'gatherli-dev') {
+  console.error('❌ ERROR: This script can only run on gatherli-dev!');
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/backfill-user-documents.ts
+++ b/functions/scripts/backfill-user-documents.ts
@@ -8,7 +8,7 @@
  *   npx ts-node scripts/backfill-user-documents.ts <project-id>
  *
  * Example:
- *   npx ts-node scripts/backfill-user-documents.ts playwithme-dev
+ *   npx ts-node scripts/backfill-user-documents.ts gatherli-dev
  */
 
 import * as admin from "firebase-admin";
@@ -92,7 +92,7 @@ if (!projectId) {
   console.log("\nUsage:");
   console.log("  npx ts-node scripts/backfill-user-documents.ts <project-id>");
   console.log("\nExample:");
-  console.log("  npx ts-node scripts/backfill-user-documents.ts playwithme-dev\n");
+  console.log("  npx ts-node scripts/backfill-user-documents.ts gatherli-dev\n");
   process.exit(1);
 }
 

--- a/functions/scripts/checkNemesis.ts
+++ b/functions/scripts/checkNemesis.ts
@@ -18,7 +18,7 @@ import { getTestUser, getAllTestUserIds } from "./testConfigLoader";
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 

--- a/functions/scripts/checkStreaks.ts
+++ b/functions/scripts/checkStreaks.ts
@@ -1,0 +1,30 @@
+import * as admin from "firebase-admin";
+import * as fs from "fs";
+import * as path from "path";
+
+admin.initializeApp({ projectId: "gatherli-dev" });
+const db = admin.firestore();
+
+async function run() {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "testConfig.json"), "utf8")
+  );
+
+  console.log("\n📊 USER ELO & STREAK STATUS\n" + "=".repeat(60));
+  console.log("User      | ELO    | Games | Streak");
+  console.log("-".repeat(60));
+
+  for (const u of config.users) {
+    const doc  = await db.collection("users").doc(u.uid).get();
+    const data = doc.data();
+    if (!data) { console.log(`${u.displayName}: NOT FOUND`); continue; }
+    const elo     = String(data.eloRating ?? "?").padEnd(7);
+    const played  = String(data.eloGamesPlayed ?? "?").padEnd(5);
+    const streak  = data.currentStreak ?? "?";
+    console.log(`${u.displayName.padEnd(10)}| ${elo} | ${played} | ${streak}`);
+  }
+
+  process.exit(0);
+}
+
+run().catch((e) => { console.error(e); process.exit(1); });

--- a/functions/scripts/cleanupAll.ts
+++ b/functions/scripts/cleanupAll.ts
@@ -12,7 +12,7 @@
 import * as admin from "firebase-admin";
 
 admin.initializeApp({
-  projectId: "playwithme-dev",
+  projectId: "gatherli-dev",
 });
 
 const db = admin.firestore();
@@ -116,7 +116,7 @@ async function main() {
   const startTime = Date.now();
 
   console.log("=".repeat(70));
-  console.log("🗑️  PLAYWITHME - DELETE ALL DATA");
+  console.log("🗑️  GATHERLI - DELETE ALL DATA");
   console.log("=".repeat(70));
   console.log("\n⚠️  WARNING: This will DELETE ALL DATA in the dev environment!\n");
 

--- a/functions/scripts/createBestWinTestGames.ts
+++ b/functions/scripts/createBestWinTestGames.ts
@@ -21,7 +21,7 @@ import { createAndCompleteGame } from "./createNemesisTestGames";
 // Initialize Firebase Admin SDK if not already initialized
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 

--- a/functions/scripts/createGameWithMonitoring.ts
+++ b/functions/scripts/createGameWithMonitoring.ts
@@ -4,7 +4,7 @@ import { getTestUser, getTestGroupId } from "./testConfigLoader";
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 
@@ -180,9 +180,9 @@ async function createGameWithMonitoring() {
   console.log("   Cloud Function did not complete processing");
   console.log("\n💡 Next steps:");
   console.log("   1. Check Cloud Function logs:");
-  console.log(`      firebase functions:log --only onGameStatusChanged --project playwithme-dev`);
+  console.log(`      firebase functions:log --only onGameStatusChanged --project gatherli-dev`);
   console.log("\n   2. Check if function is running:");
-  console.log(`      firebase functions:list --project playwithme-dev | grep onGameStatusChanged`);
+  console.log(`      firebase functions:list --project gatherli-dev | grep onGameStatusChanged`);
 }
 
 if (require.main === module) {

--- a/functions/scripts/createNemesisTestGames.ts
+++ b/functions/scripts/createNemesisTestGames.ts
@@ -4,7 +4,7 @@ import { getTestUser, getTestGroupId, printTestConfig } from "./testConfigLoader
 // Initialize Firebase Admin SDK if not already initialized
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 

--- a/functions/scripts/createSingleTestGame.ts
+++ b/functions/scripts/createSingleTestGame.ts
@@ -2,7 +2,7 @@ import * as admin from "firebase-admin";
 import { getTestUser, getTestGroupId } from "./testConfigLoader";
 
 admin.initializeApp({
-  projectId: "playwithme-dev",
+  projectId: "gatherli-dev",
 });
 
 async function createSingleTestGame() {
@@ -79,7 +79,7 @@ async function createSingleTestGame() {
     console.log(`\n✅ SUCCESS! ELO was calculated by Cloud Function`);
   } else {
     console.log(`\n❌ ELO not calculated yet. Check Cloud Function logs:`);
-    console.log(`   firebase functions:log --project playwithme-dev`);
+    console.log(`   firebase functions:log --project gatherli-dev`);
   }
 
   console.log('\n');

--- a/functions/scripts/createTestGame.ts
+++ b/functions/scripts/createTestGame.ts
@@ -4,7 +4,7 @@ import { getTestUser, getTestGroupId } from "./testConfigLoader";
 // Initialize Firebase Admin SDK if not already initialized
 if (!admin.apps.length) {
     admin.initializeApp({
-        projectId: "playwithme-dev"
+        projectId: "gatherli-dev"
     });
 }
 

--- a/functions/scripts/create_real_dev_game.ts
+++ b/functions/scripts/create_real_dev_game.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin';
 
 // Initialize Firebase Admin for REAL project
 admin.initializeApp({
-  projectId: 'playwithme-dev'
+  projectId: 'gatherli-dev'
 });
 
 const db = admin.firestore();
@@ -71,7 +71,7 @@ async function getOrCreateUser(userData: any) {
 
 async function main() {
   try {
-    console.log('Connecting to REAL project: playwithme-dev...');
+    console.log('Connecting to REAL project: gatherli-dev...');
 
     // 1. Get Users
     console.log('Verifying users...');
@@ -147,7 +147,7 @@ async function main() {
       eloCalculated: false,
     });
 
-    console.log(`\n✅ REAL Game Created Successfully in playwithme-dev!`);
+    console.log(`\n✅ REAL Game Created Successfully in gatherli-dev!`);
     console.log(`Game ID: ${gameRef.id}`);
     console.log(`Group ID: ${groupId}`);
     console.log(`Time: ${scheduledTime.toLocaleTimeString()}`);

--- a/functions/scripts/debugEloHistory.ts
+++ b/functions/scripts/debugEloHistory.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev",
+  projectId: "gatherli-dev",
 });
 
 const db = admin.firestore();

--- a/functions/scripts/debugGameProcessing.ts
+++ b/functions/scripts/debugGameProcessing.ts
@@ -3,7 +3,7 @@ import * as admin from "firebase-admin";
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 
@@ -143,11 +143,11 @@ async function debugGameProcessing() {
   console.log("\n" + "=".repeat(60));
   console.log("\n💡 Next Steps:");
   console.log("  1. Check Cloud Function logs:");
-  console.log("     firebase functions:log --only onGameStatusChanged --project playwithme-dev");
+  console.log("     firebase functions:log --only onGameStatusChanged --project gatherli-dev");
   console.log("\n  2. Monitor logs in real-time:");
-  console.log("     firebase functions:log --only onGameStatusChanged --project playwithme-dev --follow");
+  console.log("     firebase functions:log --only onGameStatusChanged --project gatherli-dev --follow");
   console.log("\n  3. Check if function is deployed:");
-  console.log("     firebase functions:list --project playwithme-dev");
+  console.log("     firebase functions:list --project gatherli-dev");
   console.log("");
 }
 

--- a/functions/scripts/deleteGroupGames.ts
+++ b/functions/scripts/deleteGroupGames.ts
@@ -4,7 +4,7 @@ import { getTestGroupId } from "./testConfigLoader";
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
     admin.initializeApp({
-        projectId: "playwithme-dev"
+        projectId: "gatherli-dev"
     });
 }
 

--- a/functions/scripts/exampleScript.ts
+++ b/functions/scripts/exampleScript.ts
@@ -20,7 +20,7 @@ import {
 // Initialize Firebase Admin SDK
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "playwithme-dev",
+    projectId: "gatherli-dev",
   });
 }
 

--- a/functions/scripts/reprocessCompletedGames.ts
+++ b/functions/scripts/reprocessCompletedGames.ts
@@ -12,7 +12,7 @@
 import * as admin from "firebase-admin";
 
 admin.initializeApp({
-  projectId: "playwithme-dev",
+  projectId: "gatherli-dev",
 });
 
 const db = admin.firestore();

--- a/functions/scripts/reset-data.ts
+++ b/functions/scripts/reset-data.ts
@@ -15,13 +15,13 @@ import * as admin from 'firebase-admin';
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: 'playwithme-dev', // ⚠️ Only dev environment
+  projectId: 'gatherli-dev', // ⚠️ Only dev environment
 });
 
 async function resetFirestoreData() {
   const db = admin.firestore();
 
-  console.log('🗑️  Starting data reset for playwithme-dev...\n');
+  console.log('🗑️  Starting data reset for gatherli-dev...\n');
 
   try {
     // 1. Delete all friendships
@@ -101,8 +101,8 @@ async function resetFirestoreData() {
 
 // Confirm before running
 const projectId = admin.app().options.projectId;
-if (projectId !== 'playwithme-dev') {
-  console.error('❌ ERROR: This script can only run on playwithme-dev!');
+if (projectId !== 'gatherli-dev') {
+  console.error('❌ ERROR: This script can only run on gatherli-dev!');
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/setupBestWinTestEnvironment.ts
+++ b/functions/scripts/setupBestWinTestEnvironment.ts
@@ -33,7 +33,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -698,8 +698,8 @@ async function setupBestWinTestEnvironment() {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/setupEloChartTestEnvironment.ts
+++ b/functions/scripts/setupEloChartTestEnvironment.ts
@@ -26,7 +26,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -610,8 +610,8 @@ async function fixRatingHistoryTimestamps(userIds: string[]): Promise<void> {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   process.exit(1);
 }
 

--- a/functions/scripts/setupFullTestEnvironment.ts
+++ b/functions/scripts/setupFullTestEnvironment.ts
@@ -1,0 +1,854 @@
+/**
+ * Full Test Environment Setup Script
+ *
+ * One-shot script that creates a complete, realistic test environment covering
+ * all major Gatherli features: community/friendships, groups, games (past + future),
+ * ELO rating history, training sessions (past + future), exercises, and feedback.
+ *
+ * What gets created:
+ *  - 10 test users (test1@mysta.com … test10@mysta.com / password: test1010)
+ *  - 45 accepted friendships (complete social graph)
+ *  - 1 group with all 10 members
+ *  - 12 past completed games  → triggers ELO Cloud Functions + rating history
+ *  - 3 future scheduled games (tomorrow / +5 days / +2 weeks)
+ *  - 5 past training sessions (completed, with exercises + feedback)
+ *  - 3 future training sessions (scheduled, with exercises)
+ *
+ * Usage:
+ *   cd functions
+ *   npx ts-node scripts/setupFullTestEnvironment.ts
+ *
+ * WARNING: Deletes ALL data in gatherli-dev before seeding!
+ */
+
+import * as admin from "firebase-admin";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+admin.initializeApp({ projectId: "gatherli-dev" });
+
+const db   = admin.firestore();
+const auth = admin.auth();
+
+const DEFAULT_PASSWORD       = "test1010";
+const PARTICIPANT_HASH_SALT  = process.env.PARTICIPANT_HASH_SALT || "gatherli-feedback-salt-v1";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TestUser {
+  uid: string;
+  email: string;
+  displayName: string;
+  firstName: string;
+  lastName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Test Users
+// ---------------------------------------------------------------------------
+
+const TEST_USERS = [
+  { email: "test1@mysta.com",  displayName: "Test1",  firstName: "Test", lastName: "One"   },
+  { email: "test2@mysta.com",  displayName: "Test2",  firstName: "Test", lastName: "Two"   },
+  { email: "test3@mysta.com",  displayName: "Test3",  firstName: "Test", lastName: "Three" },
+  { email: "test4@mysta.com",  displayName: "Test4",  firstName: "Test", lastName: "Four"  },
+  { email: "test5@mysta.com",  displayName: "Test5",  firstName: "Test", lastName: "Five"  },
+  { email: "test6@mysta.com",  displayName: "Test6",  firstName: "Test", lastName: "Six"   },
+  { email: "test7@mysta.com",  displayName: "Test7",  firstName: "Test", lastName: "Seven" },
+  { email: "test8@mysta.com",  displayName: "Test8",  firstName: "Test", lastName: "Eight" },
+  { email: "test9@mysta.com",  displayName: "Test9",  firstName: "Test", lastName: "Nine"  },
+  { email: "test10@mysta.com", displayName: "Test10", firstName: "Test", lastName: "Ten"   },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers — database cleanup
+// ---------------------------------------------------------------------------
+
+async function deleteCollection(collectionPath: string): Promise<number> {
+  const ref   = db.collection(collectionPath);
+  const query = ref.limit(500);
+  let deleted = 0;
+
+  return new Promise((resolve, reject) => {
+    async function batch(q: FirebaseFirestore.Query) {
+      const snap = await q.get();
+      if (snap.size === 0) { resolve(deleted); return; }
+      const b = db.batch();
+      snap.docs.forEach((d) => b.delete(d.ref));
+      await b.commit();
+      deleted += snap.size;
+      process.nextTick(() => batch(q));
+    }
+    batch(query).catch(reject);
+  });
+}
+
+async function clearDatabase(): Promise<void> {
+  console.log("\n🗑️  CLEARING DATABASE\n" + "=".repeat(50));
+
+  // Subcollections first
+  const sessions = await db.collection("trainingSessions").get();
+  for (const doc of sessions.docs) {
+    await deleteCollection(`trainingSessions/${doc.id}/participants`);
+    await deleteCollection(`trainingSessions/${doc.id}/exercises`);
+    await deleteCollection(`trainingSessions/${doc.id}/feedback`);
+  }
+  const users = await db.collection("users").get();
+  for (const doc of users.docs) {
+    await deleteCollection(`users/${doc.id}/headToHead`);
+    await deleteCollection(`users/${doc.id}/ratingHistory`);
+  }
+
+  const collections = [
+    "trainingSessions", "users", "groups", "games",
+    "friendships", "invitations", "notifications", "groupActivities",
+  ];
+  for (const col of collections) {
+    const n = await deleteCollection(col);
+    console.log(`  ✅ Deleted ${n} docs from '${col}'`);
+  }
+}
+
+async function clearAuthUsers(): Promise<void> {
+  console.log("\n🗑️  CLEARING AUTH USERS\n" + "=".repeat(50));
+  let n = 0;
+  const del = async (token?: string) => {
+    const result = await auth.listUsers(1000, token);
+    for (const u of result.users) {
+      try { await auth.deleteUser(u.uid); n++; } catch { /* ignore */ }
+    }
+    if (result.pageToken) await del(result.pageToken);
+  };
+  await del();
+  console.log(`  ✅ Deleted ${n} auth users`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — user / social graph
+// ---------------------------------------------------------------------------
+
+async function createTestUser(data: typeof TEST_USERS[0]): Promise<TestUser> {
+  const record = await auth.createUser({
+    email: data.email,
+    password: DEFAULT_PASSWORD,
+    displayName: data.displayName,
+    emailVerified: true,
+  });
+  const now = admin.firestore.Timestamp.now();
+  await db.collection("users").doc(record.uid).set({
+    email: data.email,
+    displayName: data.displayName,
+    firstName: data.firstName,
+    lastName: data.lastName,
+    photoUrl: null,
+    isEmailVerified: true,
+    createdAt: now, lastSignInAt: now, updatedAt: now,
+    isAnonymous: false,
+    groupIds: [], gameIds: [], friendIds: [], friendCount: 0,
+    notificationsEnabled: true, emailNotifications: true, pushNotifications: true,
+    privacyLevel: "public", showEmail: true, showPhoneNumber: true,
+    gamesPlayed: 0, gamesWon: 0, gamesLost: 0, totalScore: 0,
+    currentStreak: 0, recentGameIds: [], teammateStats: {},
+    eloRating: 1600.0, eloGamesPlayed: 0,
+  });
+  return { uid: record.uid, email: data.email, displayName: data.displayName,
+           firstName: data.firstName, lastName: data.lastName };
+}
+
+async function createFriendships(users: TestUser[]): Promise<void> {
+  console.log("\n👥 CREATING FRIENDSHIPS\n" + "=".repeat(50));
+  const now   = admin.firestore.Timestamp.now();
+  const batch = db.batch();
+  let count   = 0;
+
+  for (let i = 0; i < users.length; i++) {
+    for (let j = i + 1; j < users.length; j++) {
+      const ref = db.collection("friendships").doc();
+      batch.set(ref, {
+        initiatorId:   users[i].uid,
+        recipientId:   users[j].uid,
+        initiatorName: users[i].displayName,
+        recipientName: users[j].displayName,
+        status: "accepted", createdAt: now, updatedAt: now,
+      });
+      count++;
+    }
+  }
+  await batch.commit();
+
+  for (const user of users) {
+    const friends = users.filter((u) => u.uid !== user.uid).map((u) => u.uid);
+    await db.collection("users").doc(user.uid).update({
+      friendIds: friends, friendCount: friends.length, friendsLastUpdated: now,
+    });
+  }
+  console.log(`  ✅ Created ${count} friendships`);
+}
+
+async function createGroup(users: TestUser[]): Promise<string> {
+  console.log("\n🏐 CREATING GROUP\n" + "=".repeat(50));
+  const now = admin.firestore.Timestamp.now();
+  const ref = db.collection("groups").doc();
+
+  await ref.set({
+    name: "Venice Beach Crew",
+    description: "Weekly beach volleyball games and training with friends!",
+    photoUrl: null,
+    createdBy: users[0].uid,
+    createdAt: now, updatedAt: now,
+    memberIds: users.map((u) => u.uid),
+    adminIds:  [users[0].uid],
+    gameIds:   [],
+    privacy: "private", requiresApproval: false, maxMembers: 20,
+    location: "Venice Beach, CA",
+    allowMembersToCreateGames: true, allowMembersToInviteOthers: true,
+    notifyMembersOfNewGames: true,
+    totalGamesPlayed: 0, lastActivity: now,
+  });
+
+  const batch = db.batch();
+  for (const user of users) {
+    batch.update(db.collection("users").doc(user.uid), {
+      groupIds: admin.firestore.FieldValue.arrayUnion(ref.id),
+    });
+  }
+  await batch.commit();
+  console.log(`  ✅ Group created: ${ref.id} (${users.length} members)`);
+  return ref.id;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — games
+// ---------------------------------------------------------------------------
+
+async function createCompletedGame(
+  groupId: string,
+  gameDate: Date,
+  teamA: string[],
+  teamB: string[],
+  teamAWins: boolean,
+  label: string
+): Promise<string> {
+  const ref = db.collection("games").doc();
+
+  await ref.set({
+    title: label,
+    description: "Gatherli full-environment test game",
+    groupId,
+    createdBy: teamA[0],
+    createdAt: admin.firestore.Timestamp.fromDate(gameDate),
+    updatedAt: admin.firestore.Timestamp.fromDate(gameDate),
+    scheduledAt: admin.firestore.Timestamp.fromDate(gameDate),
+    location: {
+      name: "Venice Beach Court 3",
+      address: "1800 Ocean Front Walk, Venice, CA 90291",
+      latitude: 33.985, longitude: -118.4695,
+    },
+    status: "scheduled",
+    maxPlayers: 4, minPlayers: 4,
+    playerIds: [...teamA, ...teamB],
+    waitlistIds: [],
+    allowWaitlist: true, allowPlayerInvites: true,
+    visibility: "group",
+    equipment: ["net", "ball"],
+    gameType: "beach_volleyball", skillLevel: "intermediate",
+    weatherDependent: true, eloCalculated: false,
+  });
+
+  await new Promise((r) => setTimeout(r, 500));
+
+  await ref.update({
+    status: "completed",
+    startedAt:   admin.firestore.Timestamp.fromDate(gameDate),
+    completedAt: admin.firestore.Timestamp.fromDate(gameDate),
+    endedAt:     admin.firestore.Timestamp.fromDate(new Date(gameDate.getTime() + 90 * 60_000)),
+    teams: { teamAPlayerIds: teamA, teamBPlayerIds: teamB },
+    result: {
+      games: [{
+        gameNumber: 1,
+        sets: [{ setNumber: 1,
+          teamAPoints: teamAWins ? 21 : 17,
+          teamBPoints: teamAWins ? 17 : 21 }],
+        winner: teamAWins ? "teamA" : "teamB",
+      }],
+      overallWinner: teamAWins ? "teamA" : "teamB",
+    },
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  await new Promise((r) => setTimeout(r, 1000));
+  return ref.id;
+}
+
+async function createFutureGame(
+  groupId: string,
+  daysFromNow: number,
+  title: string,
+  playerIds: string[],
+  createdBy: string,
+  skillLevel: string = "intermediate"
+): Promise<string> {
+  const ref  = db.collection("games").doc();
+  const date = new Date(Date.now() + daysFromNow * 24 * 60 * 60_000);
+
+  await ref.set({
+    title,
+    description: "Join us for a great game!",
+    groupId,
+    createdBy,
+    createdAt:   admin.firestore.Timestamp.now(),
+    updatedAt:   admin.firestore.Timestamp.now(),
+    scheduledAt: admin.firestore.Timestamp.fromDate(date),
+    location: {
+      name: "Venice Beach Court 1",
+      address: "1800 Ocean Front Walk, Venice, CA 90291",
+      latitude: 33.985, longitude: -118.4695,
+    },
+    status: "scheduled",
+    maxPlayers: 4, minPlayers: 4,
+    playerIds,
+    waitlistIds: [],
+    allowWaitlist: true, allowPlayerInvites: true,
+    visibility: "group",
+    equipment: ["net", "ball"],
+    gameType: "beach_volleyball", skillLevel,
+    weatherDependent: true, eloCalculated: false,
+  });
+
+  return ref.id;
+}
+
+async function fixRatingHistoryTimestamps(userIds: string[]): Promise<void> {
+  let fixed = 0;
+  for (const userId of userIds) {
+    const histSnap = await db.collection(`users/${userId}/ratingHistory`).get();
+    if (histSnap.empty) continue;
+
+    const gameIds = histSnap.docs.map((d) => d.data().gameId as string);
+    const gameDocs: FirebaseFirestore.DocumentSnapshot[] = [];
+    for (let i = 0; i < gameIds.length; i += 10) {
+      const snap = await db.collection("games")
+        .where(admin.firestore.FieldPath.documentId(), "in", gameIds.slice(i, i + 10))
+        .get();
+      gameDocs.push(...snap.docs);
+    }
+    const gameMap = new Map(gameDocs.map((d) => [d.id, d.data()]));
+
+    const batch = db.batch();
+    for (const doc of histSnap.docs) {
+      const game = gameMap.get(doc.data().gameId);
+      if (game?.completedAt) {
+        batch.update(doc.ref, { timestamp: game.completedAt });
+        fixed++;
+      }
+    }
+    await batch.commit();
+  }
+  console.log(`  ✅ Backdated ${fixed} rating history entries to match game dates`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — training sessions
+// ---------------------------------------------------------------------------
+
+function participantHash(sessionId: string, userId: string): string {
+  return crypto.createHash("sha256")
+    .update(`${sessionId}:${userId}:${PARTICIPANT_HASH_SALT}`)
+    .digest("hex");
+}
+
+async function createTrainingSession(
+  groupId: string,
+  createdBy: string,
+  title: string,
+  description: string,
+  startTime: Date,
+  endTime: Date,
+  maxParticipants: number,
+  status: "scheduled" | "completed" | "cancelled",
+  participantIds: string[],
+  leftIds: string[] = []
+): Promise<string> {
+  const ref = db.collection("trainingSessions").doc();
+  const now = admin.firestore.Timestamp.now();
+
+  await ref.set({
+    groupId, title, description,
+    location: {
+      name: "Venice Beach Court 2",
+      address: "1800 Ocean Front Walk, Venice, CA 90291",
+      latitude: 33.985, longitude: -118.4695,
+    },
+    startTime:      admin.firestore.Timestamp.fromDate(startTime),
+    endTime:        admin.firestore.Timestamp.fromDate(endTime),
+    minParticipants: 2,
+    maxParticipants,
+    createdBy,
+    createdAt: now, updatedAt: now,
+    status,
+    participantIds,
+    notes: null,
+    recurrenceRule: null,
+    parentSessionId: null,
+  });
+
+  // Write participants subcollection
+  for (const uid of participantIds) {
+    await db.collection("trainingSessions").doc(ref.id)
+      .collection("participants").doc(uid).set({
+        userId: uid,
+        joinedAt: admin.firestore.Timestamp.fromDate(
+          new Date(startTime.getTime() - 24 * 60 * 60_000)
+        ),
+        status: "joined",
+      });
+  }
+  for (const uid of leftIds) {
+    await db.collection("trainingSessions").doc(ref.id)
+      .collection("participants").doc(uid).set({
+        userId: uid,
+        joinedAt: admin.firestore.Timestamp.fromDate(
+          new Date(startTime.getTime() - 48 * 60 * 60_000)
+        ),
+        status: "left",
+      });
+  }
+
+  return ref.id;
+}
+
+async function addExercise(
+  sessionId: string, name: string, description: string | null, durationMinutes: number | null
+): Promise<void> {
+  const now = admin.firestore.Timestamp.now();
+  await db.collection("trainingSessions").doc(sessionId)
+    .collection("exercises").doc().set({
+      name, description, durationMinutes,
+      createdAt: now, updatedAt: null,
+    });
+}
+
+async function addFeedback(
+  sessionId: string, userId: string,
+  exercisesQuality: number, trainingIntensity: number,
+  coachingClarity: number, comment: string | null
+): Promise<void> {
+  await db.collection("trainingSessions").doc(sessionId)
+    .collection("feedback").doc().set({
+      exercisesQuality, trainingIntensity, coachingClarity, comment,
+      participantHash: participantHash(sessionId, userId),
+      submittedAt: admin.firestore.Timestamp.now(),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — games
+// ---------------------------------------------------------------------------
+
+async function seedPastGames(groupId: string, users: TestUser[]): Promise<string[]> {
+  console.log("\n🎮 CREATING PAST COMPLETED GAMES (for ELO history)\n" + "=".repeat(50));
+
+  const now    = Date.now();
+  const gameIds: string[] = [];
+  const U      = users;
+
+  // test1 (U[0]) appears in 10 of the 12 games for testing purposes.
+  // Games 6 and 10 are the two where test1 does not play.
+  const schedule: [string[], string[], boolean, number, string][] = [
+    [[U[0].uid, U[1].uid], [U[2].uid, U[3].uid], true,  90, "Spring Open"],       // test1 ✓
+    [[U[0].uid, U[2].uid], [U[4].uid, U[5].uid], false, 75, "May Doubles"],       // test1 ✓
+    [[U[0].uid, U[5].uid], [U[6].uid, U[7].uid], true,  60, "June Clash"],        // test1 ✓
+    [[U[0].uid, U[3].uid], [U[8].uid, U[9].uid], true,  45, "July Cup"],          // test1 ✓
+    [[U[0].uid, U[2].uid], [U[3].uid, U[5].uid], true,  30, "August Rally"],      // test1 ✓
+    [[U[1].uid, U[6].uid], [U[4].uid, U[7].uid], true,  22, "Late Summer"],       // no test1
+    [[U[0].uid, U[9].uid], [U[2].uid, U[8].uid], false, 18, "Comeback Game"],     // test1 ✓
+    [[U[0].uid, U[4].uid], [U[1].uid, U[3].uid], true,  14, "Two Weeks Ago"],     // test1 ✓
+    [[U[0].uid, U[6].uid], [U[5].uid, U[7].uid], true,  10, "Mid-Month"],         // test1 ✓
+    [[U[3].uid, U[4].uid], [U[8].uid, U[9].uid], false,  7, "Last Week"],         // no test1
+    [[U[0].uid, U[4].uid], [U[2].uid, U[6].uid], true,   4, "Four Days Ago"],     // test1 ✓
+    [[U[0].uid, U[7].uid], [U[1].uid, U[9].uid], false,  2, "Two Days Ago"],      // test1 ✓
+  ];
+
+  for (const [teamA, teamB, aWins, daysAgo, label] of schedule) {
+    const date = new Date(now - daysAgo * 24 * 60 * 60_000);
+    const id   = await createCompletedGame(groupId, date, teamA, teamB, aWins, label);
+    gameIds.push(id);
+    console.log(`  ✅ ${label} (${daysAgo}d ago) — ${aWins ? "Team A" : "Team B"} won`);
+  }
+
+  return gameIds;
+}
+
+async function seedFutureGames(groupId: string, users: TestUser[]): Promise<string[]> {
+  console.log("\n📅 CREATING FUTURE SCHEDULED GAMES\n" + "=".repeat(50));
+
+  const ids: string[] = [];
+  const U = users;
+
+  // Game 1: Tomorrow
+  ids.push(await createFutureGame(
+    groupId, 1, "Weekend Warm-Up",
+    [U[0].uid, U[1].uid, U[2].uid, U[3].uid], U[0].uid
+  ));
+  console.log(`  ✅ Weekend Warm-Up (tomorrow)`);
+
+  // Game 2: In 5 days
+  ids.push(await createFutureGame(
+    groupId, 5, "Mid-Week Match",
+    [U[4].uid, U[5].uid, U[6].uid, U[7].uid], U[4].uid
+  ));
+  console.log(`  ✅ Mid-Week Match (+5 days)`);
+
+  // Game 3: In 2 weeks
+  ids.push(await createFutureGame(
+    groupId, 14, "Bi-Weekly Showdown",
+    [U[0].uid, U[8].uid, U[3].uid, U[9].uid], U[0].uid, "advanced"
+  ));
+  console.log(`  ✅ Bi-Weekly Showdown (+14 days)`);
+
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — training sessions
+// ---------------------------------------------------------------------------
+
+async function seedPastTrainingSessions(groupId: string, users: TestUser[]): Promise<string[]> {
+  console.log("\n🏋️  CREATING PAST TRAINING SESSIONS\n" + "=".repeat(50));
+
+  const now = Date.now();
+  const U   = users;
+  const ids: string[] = [];
+
+  const make = (daysAgo: number, title: string, desc: string,
+                participants: string[], leftIds: string[] = []) => {
+    const start = new Date(now - daysAgo * 24 * 60 * 60_000);
+    const end   = new Date(start.getTime() + 2 * 60 * 60_000);
+    return createTrainingSession(
+      groupId, U[0].uid, title, desc, start, end, 10,
+      "completed", participants, leftIds
+    );
+  };
+
+  ids.push(await make(20, "Beginner Basics",
+    "Introduction to beach volleyball fundamentals",
+    [U[1].uid, U[4].uid, U[5].uid, U[7].uid, U[9].uid], [U[6].uid]));
+  console.log(`  ✅ Beginner Basics (20 days ago)`);
+
+  ids.push(await make(15, "Tournament Prep",
+    "Preparing for upcoming tournament — high intensity",
+    [U[1].uid, U[2].uid, U[3].uid, U[4].uid, U[5].uid, U[6].uid, U[7].uid, U[8].uid, U[9].uid]));
+  console.log(`  ✅ Tournament Prep (15 days ago)`);
+
+  ids.push(await make(10, "Defense Workshop",
+    "Digging, diving, and court coverage",
+    [U[1].uid, U[2].uid, U[3].uid, U[5].uid, U[8].uid]));
+  console.log(`  ✅ Defense Workshop (10 days ago)`);
+
+  ids.push(await make(5, "Game Situations",
+    "Simulating real match scenarios under pressure",
+    [U[1].uid, U[2].uid, U[4].uid, U[6].uid, U[8].uid],
+    [U[3].uid, U[7].uid]));
+  console.log(`  ✅ Game Situations (5 days ago)`);
+
+  ids.push(await make(2, "Serving Masterclass",
+    "Advanced serving techniques: float, topspin, jump serve",
+    [U[1].uid, U[2].uid, U[3].uid, U[4].uid, U[5].uid, U[6].uid, U[7].uid]));
+  console.log(`  ✅ Serving Masterclass (2 days ago)`);
+
+  return ids;
+}
+
+async function seedFutureTrainingSessions(groupId: string, users: TestUser[]): Promise<string[]> {
+  console.log("\n📅 CREATING FUTURE TRAINING SESSIONS\n" + "=".repeat(50));
+
+  const now = Date.now();
+  const U   = users;
+  const ids: string[] = [];
+
+  const make = (daysFromNow: number, title: string, desc: string,
+                participants: string[], maxParticipants: number) => {
+    const start = new Date(now + daysFromNow * 24 * 60 * 60_000);
+    const end   = new Date(start.getTime() + 2 * 60 * 60_000);
+    return createTrainingSession(
+      groupId, U[0].uid, title, desc, start, end,
+      maxParticipants, "scheduled", participants
+    );
+  };
+
+  ids.push(await make(1, "Fundamentals Training",
+    "Focus on serving, passing, and setting basics",
+    [U[1].uid, U[2].uid, U[3].uid, U[4].uid, U[5].uid], 10));
+  console.log(`  ✅ Fundamentals Training (tomorrow)`);
+
+  ids.push(await make(4, "Advanced Techniques",
+    "Blocking, spiking, and full defensive strategies",
+    [U[1].uid, U[3].uid, U[6].uid], 8));
+  console.log(`  ✅ Advanced Techniques (+4 days)`);
+
+  ids.push(await make(9, "Team Strategy Session",
+    "Court coordination, rotations, and set plays",
+    [U[1].uid, U[2].uid, U[3].uid, U[4].uid, U[5].uid, U[6].uid, U[7].uid, U[8].uid], 8));
+  console.log(`  ✅ Team Strategy Session (+9 days)`);
+
+  return ids;
+}
+
+async function addExercisesToSessions(
+  pastIds: string[], futureIds: string[]
+): Promise<void> {
+  console.log("\n🏋️  ADDING EXERCISES\n" + "=".repeat(50));
+
+  // Future sessions get editable exercises
+  const fundamentals = [
+    ["Warm-up & Stretching", "Dynamic stretching and mobility work", 15],
+    ["Serving Practice",     "Consistent serves and placement accuracy", 30],
+    ["Passing Drills",       "Platform passing and communication",        25],
+    ["Setting Technique",    "Hand positioning and ball control",          20],
+    ["Cool Down",            "Static stretching and recovery",            10],
+  ] as [string, string, number][];
+
+  for (const [n, d, dur] of fundamentals) {
+    await addExercise(futureIds[0], n, d, dur);
+  }
+  console.log(`  ✅ Session "Fundamentals" — ${fundamentals.length} exercises`);
+
+  const advanced = [
+    ["Jump Serve Training",    "Power serving technique and jump approach", 25],
+    ["Blocking Mechanics",     "Timing, footwork, and hand positioning",    30],
+    ["Spiking Drills",         "Approach, jump, and hitting technique",     30],
+    ["Defensive Positioning",  "Court coverage and reading the hitter",     25],
+    ["Scrimmage",              "Competitive points with coaching stops",    30],
+  ] as [string, string, number][];
+
+  for (const [n, d, dur] of advanced) {
+    await addExercise(futureIds[1], n, d, dur);
+  }
+  console.log(`  ✅ Session "Advanced Techniques" — ${advanced.length} exercises`);
+
+  const team = [
+    ["Partner Communication", "Calling the ball and court awareness", 20],
+    ["Transition Drills",     "Moving from defense to offense",       25],
+    ["Offensive Systems",     "Set plays and rotations",              30],
+    ["Match Play",            "Full team scrimmage",                  45],
+  ] as [string, string, number][];
+
+  for (const [n, d, dur] of team) {
+    await addExercise(futureIds[2], n, d, dur);
+  }
+  console.log(`  ✅ Session "Team Strategy" — ${team.length} exercises`);
+
+  // Past completed sessions get locked exercises
+  const servingExercises = [
+    ["Serve Placement Drills", "Target zones on the court",                  25],
+    ["Float Serve Technique",  "Practising consistent low-trajectory serves", 20],
+    ["Topspin Serve",          "Advanced serving with forward spin",          15],
+  ] as [string, string, number][];
+
+  for (const [n, d, dur] of servingExercises) {
+    await addExercise(pastIds[4], n, d, dur); // Serving Masterclass
+  }
+  console.log(`  ✅ Session "Serving Masterclass" — ${servingExercises.length} locked exercises`);
+
+  const gameExercises = [
+    ["2v2 Mini Games",      "Quick competitive points",              30],
+    ["Pressure Situations", "Practising decision-making under pressure", 25],
+  ] as [string, string, number][];
+
+  for (const [n, d, dur] of gameExercises) {
+    await addExercise(pastIds[3], n, d, dur); // Game Situations
+  }
+  console.log(`  ✅ Session "Game Situations" — ${gameExercises.length} locked exercises`);
+}
+
+async function addFeedbackToSessions(
+  pastIds: string[], users: TestUser[]
+): Promise<void> {
+  console.log("\n💬 ADDING FEEDBACK TO COMPLETED SESSIONS\n" + "=".repeat(50));
+
+  const U = users;
+
+  // Serving Masterclass — partial feedback (4/7)
+  await addFeedback(pastIds[4], U[1].uid, 5, 5, 5, "Really improved my serve accuracy!");
+  await addFeedback(pastIds[4], U[2].uid, 4, 4, 4, "Great drills, loved the topspin focus.");
+  await addFeedback(pastIds[4], U[3].uid, 5, 4, 5, null);
+  await addFeedback(pastIds[4], U[4].uid, 5, 3, 5, "Very helpful. Would love more sessions like this!");
+  console.log(`  ✅ Serving Masterclass — 4/7 feedback entries`);
+
+  // Game Situations — partial feedback (3/5)
+  await addFeedback(pastIds[3], U[1].uid, 5, 5, 4, "Loved the competitive drills!");
+  await addFeedback(pastIds[3], U[2].uid, 4, 5, 3, "Bit intense for beginners but great.");
+  await addFeedback(pastIds[3], U[8].uid, 4, 4, 4, null);
+  console.log(`  ✅ Game Situations — 3/5 feedback entries`);
+
+  // Defense Workshop — full feedback (5/5)
+  await addFeedback(pastIds[2], U[1].uid, 5, 5, 5, "Best defensive training I've had!");
+  await addFeedback(pastIds[2], U[2].uid, 5, 4, 5, "Coach explained techniques very clearly.");
+  await addFeedback(pastIds[2], U[3].uid, 4, 4, 4, "My digging improved a lot.");
+  await addFeedback(pastIds[2], U[5].uid, 5, 5, 5, null);
+  await addFeedback(pastIds[2], U[8].uid, 4, 4, 5, "Very practical drills.");
+  console.log(`  ✅ Defense Workshop — 5/5 feedback entries (complete)`);
+
+  // Tournament Prep — mixed feedback (4/9)
+  await addFeedback(pastIds[1], U[1].uid, 5, 5, 5, "Perfect prep for the tournament!");
+  await addFeedback(pastIds[1], U[3].uid, 4, 4, 4, "Good intensity and game-situation focus.");
+  await addFeedback(pastIds[1], U[5].uid, 5, 4, 5, null);
+  await addFeedback(pastIds[1], U[7].uid, 3, 4, 3, "Could have been longer, felt rushed.");
+  console.log(`  ✅ Tournament Prep — 4/9 feedback entries`);
+
+  // Beginner Basics — no feedback yet (empty state)
+  console.log(`  ✅ Beginner Basics — 0 feedback entries (empty state)`);
+}
+
+// ---------------------------------------------------------------------------
+// Config export
+// ---------------------------------------------------------------------------
+
+async function exportConfig(
+  users: TestUser[],
+  groupId: string,
+  pastGameIds: string[],
+  futureGameIds: string[],
+  pastSessionIds: string[],
+  futureSessionIds: string[]
+): Promise<void> {
+  const config = {
+    timestamp: new Date().toISOString(),
+    project: "gatherli-dev",
+    credentials: { password: DEFAULT_PASSWORD },
+    users: users.map((u, i) => ({
+      index: i + 1,
+      uid: u.uid,
+      email: u.email,
+      displayName: u.displayName,
+    })),
+    groupId,
+    games: {
+      past:   pastGameIds,
+      future: futureGameIds,
+    },
+    trainingSessions: {
+      past:   pastSessionIds,
+      future: futureSessionIds,
+    },
+  };
+
+  const p = path.join(__dirname, "testConfig.json");
+  fs.writeFileSync(p, JSON.stringify(config, null, 2));
+  console.log(`\n  ✅ Config saved to ${p}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const t0 = Date.now();
+
+  console.log("\n" + "=".repeat(70));
+  console.log("🏐 GATHERLI — FULL TEST ENVIRONMENT SETUP");
+  console.log("=".repeat(70));
+  console.log("\n⚠️  WARNING: All data in gatherli-dev will be deleted!\n");
+
+  // 1. Clear
+  await clearDatabase();
+  await clearAuthUsers();
+
+  // 2. Users
+  console.log("\n👤 CREATING USERS\n" + "=".repeat(50));
+  const users: TestUser[] = [];
+  for (const d of TEST_USERS) {
+    const u = await createTestUser(d);
+    users.push(u);
+    console.log(`  ✅ ${u.displayName} (${u.email})`);
+  }
+
+  // 3. Social graph
+  await createFriendships(users);
+
+  // 4. Group
+  const groupId = await createGroup(users);
+
+  // 5. Past games (triggers ELO cloud functions)
+  const pastGameIds = await seedPastGames(groupId, users);
+
+  // 6. Wait for Cloud Functions to process ELO, then backdate timestamps
+  console.log("\n⏳ Waiting 8s for Cloud Functions to process ELO...");
+  await new Promise((r) => setTimeout(r, 8000));
+  console.log("\n🔧 FIXING RATING HISTORY TIMESTAMPS\n" + "=".repeat(50));
+  await fixRatingHistoryTimestamps(users.map((u) => u.uid));
+
+  // 7. Future games
+  const futureGameIds = await seedFutureGames(groupId, users);
+
+  // 8. Update group game list
+  const allGameIds = [...pastGameIds, ...futureGameIds];
+  await db.collection("groups").doc(groupId).update({
+    gameIds: allGameIds,
+    totalGamesPlayed: pastGameIds.length,
+    lastActivity: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  // 9. Past training sessions
+  const pastSessionIds = await seedPastTrainingSessions(groupId, users);
+
+  // 10. Future training sessions
+  const futureSessionIds = await seedFutureTrainingSessions(groupId, users);
+
+  // 11. Exercises
+  await addExercisesToSessions(pastSessionIds, futureSessionIds);
+
+  // 12. Feedback
+  await addFeedbackToSessions(pastSessionIds, users);
+
+  // 13. Export
+  console.log("\n📝 EXPORTING CONFIG\n" + "=".repeat(50));
+  await exportConfig(users, groupId, pastGameIds, futureGameIds, pastSessionIds, futureSessionIds);
+
+  // Summary
+  const secs = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log("\n" + "=".repeat(70));
+  console.log("🎉 FULL ENVIRONMENT READY  (" + secs + "s)");
+  console.log("=".repeat(70));
+  console.log(`
+📋 Credentials
+   Email:    test1@mysta.com  (or test2 … test10)
+   Password: ${DEFAULT_PASSWORD}
+
+📊 Data created
+   • 10 users + 45 friendships
+   • 1 group  (Venice Beach Crew)
+   • ${pastGameIds.length} past completed games  → ELO history populated
+   • ${futureGameIds.length} future scheduled games
+       - Weekend Warm-Up    (tomorrow)
+       - Mid-Week Match     (+5 days)
+       - Bi-Weekly Showdown (+14 days)
+   • ${pastSessionIds.length} past training sessions (completed, with exercises + feedback)
+   • ${futureSessionIds.length} future training sessions (upcoming, with exercises)
+       - Fundamentals Training  (tomorrow)
+       - Advanced Techniques    (+4 days)
+       - Team Strategy Session  (+9 days)
+
+📱 Quick test flow
+   1. Log in as test1@mysta.com
+   2. Community tab  → see 9 friends
+   3. Groups tab     → open "Venice Beach Crew"
+   4. Games tab      → upcoming games + history
+   5. Training tab   → upcoming sessions + join one
+   6. Profile tab    → ELO chart with historical data
+`);
+}
+
+// Guard: dev only
+const pid = admin.app().options.projectId;
+if (pid !== "gatherli-dev") {
+  console.error(`❌ This script only runs on gatherli-dev (current: ${pid})`);
+  process.exit(1);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => { console.error("❌ Error:", e); process.exit(1); });

--- a/functions/scripts/setupPointDiffTestEnvironment.ts
+++ b/functions/scripts/setupPointDiffTestEnvironment.ts
@@ -32,7 +32,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -803,8 +803,8 @@ async function setupPointDiffTestEnvironment() {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/setupRoleBasedTestEnvironment.ts
+++ b/functions/scripts/setupRoleBasedTestEnvironment.ts
@@ -24,7 +24,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -705,8 +705,8 @@ async function setupTestEnvironment() {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/setupTestEnvironment.ts
+++ b/functions/scripts/setupTestEnvironment.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -622,7 +622,7 @@ async function setupTestEnvironment() {
 
   console.log("\n");
   console.log("=".repeat(70));
-  console.log("🏐 PLAYWITHME TEST ENVIRONMENT SETUP");
+  console.log("🏐 GATHERLI TEST ENVIRONMENT SETUP");
   console.log("=".repeat(70));
   console.log("\n⚠️  WARNING: This will DELETE ALL DATA in the dev environment!\n");
 
@@ -678,8 +678,8 @@ async function setupTestEnvironment() {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   console.error(`   Current project: ${projectId}`);
   process.exit(1);
 }

--- a/functions/scripts/setupTrainingSessionTestEnvironment.ts
+++ b/functions/scripts/setupTrainingSessionTestEnvironment.ts
@@ -38,7 +38,7 @@ import * as crypto from "crypto";
 
 // Initialize Firebase Admin SDK
 admin.initializeApp({
-  projectId: "playwithme-dev", // ⚠️ Only dev environment
+  projectId: "gatherli-dev", // ⚠️ Only dev environment
 });
 
 const db = admin.firestore();
@@ -47,7 +47,7 @@ const auth = admin.auth();
 const DEFAULT_PASSWORD = "test1010";
 
 // Salt for participant hash (must match Cloud Functions)
-const PARTICIPANT_HASH_SALT = process.env.PARTICIPANT_HASH_SALT || "playwithme-feedback-salt-v1";
+const PARTICIPANT_HASH_SALT = process.env.PARTICIPANT_HASH_SALT || "gatherli-feedback-salt-v1";
 
 /**
  * Generate anonymous participant hash
@@ -959,8 +959,8 @@ async function setupTrainingSessionTestEnvironment() {
 
 // Confirm project before running
 const projectId = admin.app().options.projectId;
-if (projectId !== "playwithme-dev") {
-  console.error("❌ ERROR: This script can only run on playwithme-dev!");
+if (projectId !== "gatherli-dev") {
+  console.error("❌ ERROR: This script can only run on gatherli-dev!");
   process.exit(1);
 }
 

--- a/functions/scripts/setupUsersAndGroup.ts
+++ b/functions/scripts/setupUsersAndGroup.ts
@@ -14,7 +14,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 admin.initializeApp({
-  projectId: "playwithme-dev",
+  projectId: "gatherli-dev",
 });
 
 const db = admin.firestore();
@@ -303,7 +303,7 @@ async function main() {
   const startTime = Date.now();
 
   console.log("=".repeat(70));
-  console.log("🏐 PLAYWITHME USERS & GROUP SETUP");
+  console.log("🏐 GATHERLI USERS & GROUP SETUP");
   console.log("=".repeat(70));
   console.log("\n⚠️  WARNING: This will DELETE ALL DATA in the dev environment!\n");
 

--- a/functions/src/friendships.ts
+++ b/functions/src/friendships.ts
@@ -118,15 +118,6 @@ interface BatchCheckFriendRequestStatusResponse {
 // ============================================================================
 
 /**
- * Check if a user exists in Firestore
- */
-async function userExists(userId: string): Promise<boolean> {
-  const db = admin.firestore();
-  const userDoc = await db.collection("users").doc(userId).get();
-  return userDoc.exists;
-}
-
-/**
  * Get user profile data
  */
 async function getUserProfile(userId: string): Promise<UserProfile | null> {
@@ -147,7 +138,8 @@ async function getUserProfile(userId: string): Promise<UserProfile | null> {
 }
 
 /**
- * Check if a friendship exists between two users (in either direction)
+ * Check if a friendship exists between two users (in either direction).
+ * Both directional queries run in parallel.
  */
 async function findExistingFriendship(
   userId1: string,
@@ -156,28 +148,21 @@ async function findExistingFriendship(
   const db = admin.firestore();
   const friendshipsRef = db.collection("friendships");
 
-  // Check direction 1: userId1 -> userId2
-  const query1 = await friendshipsRef
-    .where("initiatorId", "==", userId1)
-    .where("recipientId", "==", userId2)
-    .limit(1)
-    .get();
+  const [query1, query2] = await Promise.all([
+    friendshipsRef
+      .where("initiatorId", "==", userId1)
+      .where("recipientId", "==", userId2)
+      .limit(1)
+      .get(),
+    friendshipsRef
+      .where("initiatorId", "==", userId2)
+      .where("recipientId", "==", userId1)
+      .limit(1)
+      .get(),
+  ]);
 
-  if (!query1.empty) {
-    return query1.docs[0];
-  }
-
-  // Check direction 2: userId2 -> userId1
-  const query2 = await friendshipsRef
-    .where("initiatorId", "==", userId2)
-    .where("recipientId", "==", userId1)
-    .limit(1)
-    .get();
-
-  if (!query2.empty) {
-    return query2.docs[0];
-  }
-
+  if (!query1.empty) return query1.docs[0];
+  if (!query2.empty) return query2.docs[0];
   return null;
 }
 
@@ -229,18 +214,25 @@ export async function sendFriendRequestHandler(
   }
 
   try {
-    // Rate limiting: Check recent requests from this user
-    // Story 11.19: Prevent spam by limiting to 10 requests per hour
+    // Run all independent reads in parallel: rate-limit check, both user
+    // profiles, and existing-friendship check (2 directions internally).
     const db = admin.firestore();
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
 
-    const recentRequests = await db
-      .collection("friendships")
-      .where("initiatorId", "==", currentUserId)
-      .where("createdAt", ">", oneHourAgo)
-      .where("status", "==", "pending")
-      .get();
+    const [recentRequests, initiatorProfileRaw, recipientProfile, existingFriendship] =
+      await Promise.all([
+        db
+          .collection("friendships")
+          .where("initiatorId", "==", currentUserId)
+          .where("createdAt", ">", oneHourAgo)
+          .where("status", "==", "pending")
+          .get(),
+        getUserProfile(currentUserId),
+        getUserProfile(targetUserId),
+        findExistingFriendship(currentUserId, targetUserId),
+      ]);
 
+    // Rate limiting check
     if (recentRequests.size >= 10) {
       functions.logger.warn("Rate limit exceeded for friend requests", {
         userId: currentUserId,
@@ -252,9 +244,8 @@ export async function sendFriendRequestHandler(
       );
     }
 
-    // Check if target user exists
-    const targetExists = await userExists(targetUserId);
-    if (!targetExists) {
+    // Validate recipient exists
+    if (!recipientProfile) {
       functions.logger.warn("Target user not found", {
         from: currentUserId,
         targetUserId,
@@ -265,17 +256,7 @@ export async function sendFriendRequestHandler(
       );
     }
 
-    functions.logger.debug("Target user exists, checking for existing friendship", {
-      from: currentUserId,
-      to: targetUserId,
-    });
-
     // Check for existing friendship
-    const existingFriendship = await findExistingFriendship(
-      currentUserId,
-      targetUserId
-    );
-
     if (existingFriendship) {
       const friendshipData = existingFriendship.data();
       const status = friendshipData.status;
@@ -309,21 +290,20 @@ export async function sendFriendRequestHandler(
       });
     }
 
-    // Get user profiles for denormalized names
-    const initiatorProfile = await getUserProfile(currentUserId);
-    const recipientProfile = await getUserProfile(targetUserId);
-
-    if (!initiatorProfile || !recipientProfile) {
-      functions.logger.error("Failed to retrieve user profiles", {
-        from: currentUserId,
-        to: targetUserId,
-        hasInitiator: !!initiatorProfile,
-        hasRecipient: !!recipientProfile,
+    // Resolve initiator profile — fall back to Auth data if the Firestore
+    // document hasn't been created yet by the createUserDocument trigger.
+    let initiatorProfile = initiatorProfileRaw;
+    if (!initiatorProfile) {
+      functions.logger.warn("Initiator Firestore profile not yet created, falling back to Auth data", {
+        uid: currentUserId,
       });
-      throw new functions.https.HttpsError(
-        "internal",
-        "Failed to retrieve user profiles"
-      );
+      const authUser = await admin.auth().getUser(currentUserId);
+      initiatorProfile = {
+        uid: authUser.uid,
+        displayName: authUser.displayName || null,
+        email: authUser.email || "",
+        photoUrl: authUser.photoURL || null,
+      };
     }
 
     // Create new friendship document

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -128,15 +128,15 @@
 				40944E250321FAF5B52DF8ED /* Pods-RunnerTests.release.xcconfig */,
 				028667BC6C7453D54135EEFA /* Pods-RunnerTests.profile.xcconfig */,
 				86DCB644D4B3BFA07D229D3E /* Pods-Runner.debug-prod.xcconfig */,
-					AAAA328D774FFED310A41819 /* Pods-Runner.release-prod.xcconfig */,
+				AAAA328D774FFED310A41819 /* Pods-Runner.release-prod.xcconfig */,
 				8299069D4E60107A2BA4965A /* Pods-Runner.release-dev.xcconfig */,
-					87A84472A412B2CEFD25CD7A /* Pods-Runner.profile-prod.xcconfig */,
-					89E24D585AD690A94C09E230 /* Pods-Runner.profile-dev.xcconfig */,
+				87A84472A412B2CEFD25CD7A /* Pods-Runner.profile-prod.xcconfig */,
+				89E24D585AD690A94C09E230 /* Pods-Runner.profile-dev.xcconfig */,
 				4C4735CDF70969769F58EB40 /* Pods-RunnerTests.debug-prod.xcconfig */,
-					D28B111DF21F40BACBF2DEE8 /* Pods-RunnerTests.release-prod.xcconfig */,
+				D28B111DF21F40BACBF2DEE8 /* Pods-RunnerTests.release-prod.xcconfig */,
 				2597421543C12E4129F5AF8C /* Pods-RunnerTests.release-dev.xcconfig */,
-					4CBEA2D6A61113DD66D87448 /* Pods-RunnerTests.profile-prod.xcconfig */,
-					2620827DE7D3460F2DAA1102 /* Pods-RunnerTests.profile-dev.xcconfig */,
+				4CBEA2D6A61113DD66D87448 /* Pods-RunnerTests.profile-prod.xcconfig */,
+				2620827DE7D3460F2DAA1102 /* Pods-RunnerTests.profile-dev.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -308,13 +308,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -382,13 +378,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1369,11 +1361,11 @@
 			buildConfigurations = (
 				331C8088294A63A400263BE5 /* Debug */,
 				BEC6F6B72E84B59800187B2A /* Debug-prod */,
-					BEC6F6B12E84AEDB00187B2A /* Debug-dev */,
+				BEC6F6B12E84AEDB00187B2A /* Debug-dev */,
 				331C8089294A63A400263BE5 /* Release */,
 				BEC6F6BD2E84B5AC00187B2A /* Release-prod */,
 				BEC6F6C02E84B5B200187B2A /* Release-dev */,
-					331C808A294A63A400263BE5 /* Profile */,
+				331C808A294A63A400263BE5 /* Profile */,
 				BEC6F6C92E84B5D000187B2A /* Profile-prod */,
 				BEC6F6C32E84B5C100187B2A /* Profile-dev */,
 			);

--- a/lib/features/auth/data/repositories/firebase_auth_repository.dart
+++ b/lib/features/auth/data/repositories/firebase_auth_repository.dart
@@ -73,6 +73,10 @@ class FirebaseAuthRepository implements AuthRepository {
         throw Exception('User creation failed: User is null');
       }
 
+      // Force a token refresh so the first ID token is fully signed before
+      // any Cloud Function call (avoids "no kid claim" rejection).
+      await credential.user!.getIdToken(true);
+
       debugPrint('✅ Successfully created user: ${credential.user!.email}');
       return UserModel.fromFirebaseUser(credential.user!).toEntity();
     } on FirebaseAuthException catch (e) {

--- a/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
+++ b/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
@@ -33,7 +33,9 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
           .timeout(
             const Duration(seconds: 5),
             onTimeout: (sink) {
-              sink.addError(TimeoutException('Failed to load user data'));
+              // Treat timeout as "document not found yet" so the new-user
+              // fallback path below can handle it gracefully.
+              sink.add(null);
             },
           )
           .first;

--- a/lib/features/profile/presentation/widgets/home_stats_section.dart
+++ b/lib/features/profile/presentation/widgets/home_stats_section.dart
@@ -32,7 +32,7 @@ class HomeStatsSection extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     final trendData = _calculateTrend();
-    final hasStreak = user.currentStreak.abs() >= 2;
+    final hasStreak = user.currentStreak.abs() >= 1;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20.0),

--- a/lib/features/profile/presentation/widgets/win_streak_badge.dart
+++ b/lib/features/profile/presentation/widgets/win_streak_badge.dart
@@ -4,7 +4,7 @@ import 'package:play_with_me/l10n/app_localizations.dart';
 
 /// A badge widget that displays the current win or loss streak.
 ///
-/// Only displays when the streak is >= 2 (positive or negative).
+/// Only displays when the streak is >= 1 (positive or negative).
 /// - Winning streaks: 🔥 emoji with green color
 /// - Losing streaks: ❄️ emoji with blue/grey color
 class WinStreakBadge extends StatelessWidget {
@@ -15,7 +15,7 @@ class WinStreakBadge extends StatelessWidget {
     required this.currentStreak,
   });
 
-  bool get shouldDisplay => currentStreak.abs() >= 2;
+  bool get shouldDisplay => currentStreak.abs() >= 1;
 
   bool get isWinningStreak => currentStreak > 0;
 

--- a/test/unit/features/auth/data/repositories/firebase_auth_repository_test.dart
+++ b/test/unit/features/auth/data/repositories/firebase_auth_repository_test.dart
@@ -294,6 +294,8 @@ void main() {
               email: testEmail,
               password: testPassword,
             )).thenAnswer((_) async => mockUserCredential);
+        when(() => mockUser.getIdToken(true))
+            .thenAnswer((_) async => 'mock-id-token');
 
         final result = await repository.createUserWithEmailAndPassword(
           email: testEmail,

--- a/test/widget/features/profile/presentation/widgets/home_stats_section_test.dart
+++ b/test/widget/features/profile/presentation/widgets/home_stats_section_test.dart
@@ -150,12 +150,12 @@ void main() {
       expect(find.textContaining('3 wins'), findsOneWidget);
     });
 
-    testWidgets('shows no streak text when streak < 2', (tester) async {
+    testWidgets('shows streak text when streak is 1', (tester) async {
       final userWithSmallStreak = testUser.copyWith(currentStreak: 1);
 
       await pumpHomeStatsSection(tester, user: userWithSmallStreak);
 
-      expect(find.text('None'), findsOneWidget);
+      expect(find.textContaining('1 wins'), findsOneWidget);
     });
 
     testWidgets('shows losing streak with weather emoji for negative streak <= -2', (tester) async {

--- a/test/widget/features/profile/presentation/widgets/win_streak_badge_test.dart
+++ b/test/widget/features/profile/presentation/widgets/win_streak_badge_test.dart
@@ -7,7 +7,7 @@ import 'package:play_with_me/features/profile/presentation/widgets/win_streak_ba
 
 void main() {
   group('WinStreakBadge Widget Tests', () {
-    testWidgets('does not display for streak less than 2', (tester) async {
+    testWidgets('displays for winning streak of 1', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
       localizationsDelegates: const [
@@ -24,12 +24,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.byType(Card), findsNothing);
-      expect(find.byType(SizedBox), findsOneWidget); // SizedBox.shrink()
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.text('🔥'), findsOneWidget);
     });
 
-    testWidgets('does not display for negative streak less than -2',
-        (tester) async {
+    testWidgets('displays for losing streak of -1', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
       localizationsDelegates: const [
@@ -46,7 +45,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.byType(Card), findsNothing);
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.text('❄️'), findsOneWidget);
     });
 
     testWidgets('does not display for zero streak', (tester) async {


### PR DESCRIPTION
## Summary

### Firestore rules
- Remove unused `isGroupMember` helper function (eliminated 3 deploy warnings)
- Deploy updated rules to `gatherli-dev` and `gatherli-prod`

### Firestore indexes
- Add composite index `friendships(initiatorId, status, createdAt)` required by the rate-limiting query in `sendFriendRequest`; missing index caused Firestore to throw `FAILED_PRECONDITION`, wrapped as \"internal\" error shown to users tapping **Add** in My Community
- Deploy indexes to both environments

### Cloud Functions — sendFriendRequest performance
- Parallelise all independent Firestore reads with `Promise.all`: rate-limit query, initiator profile, recipient profile, and existing-friendship check (itself two parallel directional queries)
- Remove redundant `userExists()` call
- Reduces typical latency from ~500 ms to ~100 ms

### New-user bug fixes
- `firebase_auth_repository.dart`: call `getIdToken(true)` right after `createUserWithEmailAndPassword` so the first token is fully signed
- `player_stats_bloc.dart`: `onTimeout` emits `null` instead of an error so new users hit the graceful fallback path instead of an error state
- `friendships.ts`: fall back to Firebase Auth data when the initiator's Firestore document has not yet been created by the async trigger

### Streak display
- Lower `shouldDisplay` threshold from `abs() >= 2` to `abs() >= 1` in `home_stats_section.dart` and `win_streak_badge.dart`

### Scripts — gatherli rebranding
- Rename all occurrences of `playwithme-dev` → `gatherli-dev` across all 38 scripts in `functions/scripts/`
- Update `scripts/README.md` accordingly

### New scripts
- `setupFullTestEnvironment.ts`: combined seeding script (10 users, 45 friendships, 1 group, 12 past games, 3 future games, 5 past + 3 future training sessions); `test1` participates in exactly 10 games
- `checkStreaks.ts`: debug helper that prints ELO / games-played / streak for all test users

## Test plan

- [ ] `firebase deploy --only firestore --project gatherli-dev` → 0 warnings
- [ ] `firebase deploy --only firestore --project gatherli-prod` → 0 warnings
- [ ] Register a brand-new user → home screen shows stats without `TimeoutException`
- [ ] New user taps **Add** in My Community → friend request succeeds quickly (no \"Internal error\")
- [ ] Users with a 1-game win or loss streak see the streak badge (not \"None\")
- [ ] `npx ts-node scripts/setupFullTestEnvironment.ts` seeds all test data correctly