### PR TITLE
fix: group members incorrectly shown as friends after account switch

### DIFF
--- a/lib/core/data/repositories/firestore_friend_repository.dart
+++ b/lib/core/data/repositories/firestore_friend_repository.dart
@@ -22,6 +22,10 @@ class FirestoreFriendRepository implements FriendRepository {
 
   static const Duration _friendshipCacheTtl = Duration(minutes: 5);
 
+  /// Tracks which authenticated user the caches belong to.
+  /// When the user changes (logout/login), caches are invalidated automatically.
+  String? _cacheOwnerId;
+
   FirestoreFriendRepository({
     required FirebaseFunctions functions,
     required FirebaseFirestore firestore,
@@ -410,6 +414,15 @@ class FirestoreFriendRepository implements FriendRepository {
         throw FriendshipException('User not authenticated');
       }
 
+      // Invalidate stale caches when the authenticated user changes (e.g., after
+      // logout/login). Without this guard, a singleton repository would serve
+      // friendship data from the previous user's session.
+      if (_cacheOwnerId != currentUserId) {
+        _friendshipCache.clear();
+        _requestStatusCache.clear();
+        _cacheOwnerId = currentUserId;
+      }
+
       // Handle empty list early
       if (userIds.isEmpty) {
         return {};
@@ -543,6 +556,14 @@ class FirestoreFriendRepository implements FriendRepository {
         throw FriendshipException('User not authenticated');
       }
 
+      // Same user-change guard as batchCheckFriendship: clear stale caches on
+      // user switch so request statuses from a previous session are not served.
+      if (_cacheOwnerId != currentUserId) {
+        _friendshipCache.clear();
+        _requestStatusCache.clear();
+        _cacheOwnerId = currentUserId;
+      }
+
       // Handle empty list early
       if (userIds.isEmpty) {
         return {};
@@ -612,10 +633,11 @@ class FirestoreFriendRepository implements FriendRepository {
     _requestStatusCache.remove(userId);
   }
 
-  /// Clears all friendship status caches.
+  /// Clears all friendship status caches and resets the cache owner.
   void clearFriendshipCache() {
     _friendshipCache.clear();
     _requestStatusCache.clear();
+    _cacheOwnerId = null;
   }
 
   @override


### PR DESCRIPTION
## Root cause

`FirestoreFriendRepository` is registered as a `get_it` **lazy singleton**. Its in-memory caches (`_friendshipCache`, `_requestStatusCache`) were never cleared when the authenticated user changed.

Scenario that triggered the bug:
1. User A (e.g. test1, who is friends with all seeded test users) opens a group details page → caches are populated with `{test2: true, test3: true, …}`
2. User A logs out
3. User B (test12, friends only with test1) logs in and opens the **same** group details page
4. Both `batchCheckFriendship` and `batchCheckFriendRequestStatus` check the cache first. Since the TTL (5 min) hasn't expired, they return stale data from user A's session
5. All group members appear as "friends" even though user B has no relationship with them

## Fix

Added a `_cacheOwnerId` field to `FirestoreFriendRepository` that tracks which authenticated user the caches belong to. At the start of both batch-check methods, if the current user's UID differs from `_cacheOwnerId`, the caches are invalidated and the owner is updated. This ensures cross-session data is never served.

## Tests

All 57 existing `firestore_friend_repository_test.dart` tests pass. No new tests were needed — the fix is a guard clause on existing cache logic.

## Checklist

- [x] Security review: no secrets, no new Firestore access patterns
- [x] `flutter analyze` — 0 warnings
- [x] All unit & widget tests pass