### PR TITLE
Stories 20.2 & 20.3: Android & iOS Signing and Release Build Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,17 @@ lib/core/config/firebase_config_prod.dart
 **/*_key.json
 **/secrets.json
 
+# Android signing
+*.jks
+*.keystore
+android/app/release.jks
+
+# iOS signing
+*.p8
+*.mobileprovision
+*.cer
+*.p12
+
 # Node modules
 node_modules/
 infrastructure/terraform/.terraform/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,6 +21,21 @@ android {
         jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
+    // Release signing config — credentials injected from environment variables in CI.
+    // Locally, the release build falls back to debug signing if env vars are not set.
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH") ?: "release.jks"
+            val keystoreFile = file(keystorePath)
+            if (keystoreFile.exists()) {
+                storeFile = keystoreFile
+                storePassword = System.getenv("ANDROID_STORE_PASSWORD") ?: ""
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS") ?: ""
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD") ?: ""
+            }
+        }
+    }
+
     defaultConfig {
         applicationId = "org.gatherli.app"
         minSdk = 23  // Firebase requires minimum API 23
@@ -44,9 +59,19 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            val releaseConfig = signingConfigs.getByName("release")
+            // Use release signing if keystore is available (CI), otherwise fall back to debug
+            signingConfig = if (releaseConfig.storeFile?.exists() == true) {
+                releaseConfig
+            } else {
+                signingConfigs.getByName("debug")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,20 @@
+# Flutter wrapper
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.** { *; }
+-keep class io.flutter.util.** { *; }
+-keep class io.flutter.view.** { *; }
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+
+# Firebase
+-keep class com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+
+# Kotlin coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+
+# Keep data classes used with Firestore serialization
+-keepclassmembers class * {
+    @com.google.firebase.firestore.PropertyName <fields>;
+}

--- a/docs/epic-20/story-20.2/ANDROID_BUILD.md
+++ b/docs/epic-20/story-20.2/ANDROID_BUILD.md
@@ -1,0 +1,80 @@
+# Story 20.2 — Android Signing & Release Build Configuration
+
+## Overview
+
+The Android release build is configured to sign the AAB using credentials injected
+from environment variables. Locally (without env vars set), the build falls back to
+debug signing so `flutter run --release` continues to work during development.
+
+---
+
+## Signing Configuration
+
+File: `android/app/build.gradle.kts`
+
+The signing config reads four environment variables at build time:
+
+| Environment Variable | GitHub Secret | Description |
+|---------------------|---------------|-------------|
+| `ANDROID_KEYSTORE_PATH` | — | Path to decoded `.jks` file (set by CI step) |
+| `ANDROID_STORE_PASSWORD` | `ANDROID_STORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | `ANDROID_KEY_ALIAS` | Key alias |
+| `ANDROID_KEY_PASSWORD` | `ANDROID_KEY_PASSWORD` | Key password |
+
+The keystore file itself is stored as `ANDROID_KEYSTORE_BASE64` in GitHub Secrets
+and decoded to `android/app/release.jks` by the CI pipeline before the build runs.
+
+---
+
+## ProGuard
+
+File: `android/app/proguard-rules.pro`
+
+Rules configured to preserve:
+- Flutter engine classes
+- Firebase SDK classes
+- Kotlin coroutines
+- Firestore serialization annotations
+
+`isMinifyEnabled = true` and `isShrinkResources = true` are enabled for release
+builds to reduce APK/AAB size.
+
+---
+
+## Build Command
+
+Used in CI pipeline (Stories 20.5 and 20.6):
+
+```bash
+flutter build appbundle --release --flavor prod \
+  -t lib/main_prod.dart \
+  --build-name=$VERSION_NAME \
+  --build-number=$BUILD_NUMBER
+```
+
+Output: `build/app/outputs/bundle/prodRelease/app-prod-release.aab`
+
+---
+
+## Local Release Build (without CI secrets)
+
+Falls back to debug signing automatically — no configuration needed locally:
+
+```bash
+flutter build appbundle --release --flavor prod -t lib/main_prod.dart
+```
+
+---
+
+## CI Decode Step
+
+The pipeline decodes the base64 keystore before building:
+
+```yaml
+- name: Decode keystore
+  run: |
+    echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode \
+      > android/app/release.jks
+```
+
+`android/app/release.jks` is in `.gitignore` and never committed.

--- a/docs/epic-20/story-20.3/IOS_BUILD.md
+++ b/docs/epic-20/story-20.3/IOS_BUILD.md
@@ -1,0 +1,103 @@
+# Story 20.3 — iOS Signing & Release Build Configuration
+
+## Overview
+
+The iOS release build uses **Automatic Signing** with an **App Store Connect API key**
+for authentication. This avoids managing certificates and provisioning profiles manually
+in CI — Xcode resolves them from Apple's servers at build time using the API key.
+
+---
+
+## Xcode Project Configuration
+
+File: `ios/Runner.xcodeproj/project.pbxproj`
+
+| Setting | Value |
+|---------|-------|
+| `CODE_SIGN_STYLE` | `Automatic` |
+| `DEVELOPMENT_TEAM` | `2FN99DA6RR` |
+| `PRODUCT_BUNDLE_IDENTIFIER` (prod) | `org.gatherli.app` |
+| `PRODUCT_BUNDLE_IDENTIFIER` (dev) | `org.gatherli.app.dev` |
+
+No manual certificate or provisioning profile management is needed.
+
+---
+
+## ExportOptions.plist
+
+File: `ios/ExportOptions.plist`
+
+Configures the IPA export for App Store upload:
+
+- `method`: `app-store` — targets the App Store (not ad-hoc or enterprise)
+- `destination`: `upload` — uploads directly to App Store Connect
+- `signingStyle`: `automatic` — lets Xcode manage signing
+- `uploadSymbols`: `true` — enables crash symbolication in App Store Connect
+- `uploadBitcode`: `false` — bitcode is deprecated as of Xcode 14
+
+---
+
+## Required GitHub Secrets
+
+| Secret Name | Description |
+|-------------|-------------|
+| `APP_STORE_CONNECT_API_KEY_ID` | 10-char Key ID (from `.p8` filename) |
+| `APP_STORE_CONNECT_API_ISSUER_ID` | UUID from App Store Connect API page |
+| `APP_STORE_CONNECT_API_KEY_BASE64` | Base64-encoded `.p8` private key file |
+| `IOS_BUNDLE_ID` | `org.gatherli.app` |
+
+See `docs/epic-20/story-20.1/SECRETS_SETUP.md` for how to generate these.
+
+---
+
+## Build Command
+
+Used in CI pipeline (Stories 20.5 and 20.6):
+
+```bash
+flutter build ipa --release --flavor prod \
+  -t lib/main_prod.dart \
+  --build-name=$VERSION_NAME \
+  --build-number=$BUILD_NUMBER \
+  --export-options-plist=ios/ExportOptions.plist
+```
+
+Output: `build/ios/ipa/Gatherli.ipa`
+
+---
+
+## CI API Key Install Step
+
+The pipeline installs the `.p8` key before building:
+
+```yaml
+- name: Install App Store Connect API key
+  run: |
+    mkdir -p ~/.appstoreconnect/private_keys
+    echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
+      > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+```
+
+The `.p8` file is written to the standard location where `xcodebuild` and `xcrun altool`
+expect to find it automatically.
+
+---
+
+## Upload Command
+
+```bash
+xcrun altool --upload-app \
+  --type ios \
+  --file "build/ios/ipa/Gatherli.ipa" \
+  --apiKey ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
+  --apiIssuer ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+```
+
+---
+
+## Notes
+
+- iOS builds require a **macOS runner** in GitHub Actions (`runs-on: macos-latest`)
+- macOS runners are significantly more expensive than Linux — keep the job lean
+- The `.p8` key file is in `.gitignore` and never committed
+- `flutter build ipa` requires the `prod` flavor and `lib/main_prod.dart` entrypoint

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Configure Android release signing in `build.gradle.kts` from environment variables — falls back to debug signing locally so development is unaffected
- Enable `minifyEnabled` + `shrinkResources` for Android release builds
- Add `proguard-rules.pro` with rules for Flutter, Firebase and Kotlin coroutines
- Add `ios/ExportOptions.plist` for App Store IPA export (automatic signing, upload destination)
- Update `.gitignore` to block `*.jks`, `*.keystore`, `*.p8`, `*.mobileprovision`, `*.cer`, `*.p12`
- Add documentation for Android build (Story 20.2) and iOS build (Story 20.3)

## Test plan

- [ ] `flutter analyze` returns 0 errors
- [ ] Local Android release build still works without env vars set (falls back to debug signing): `flutter build appbundle --release --flavor prod -t lib/main_prod.dart`
- [ ] `ios/ExportOptions.plist` present and valid XML
- [ ] `.gitignore` blocks `*.jks` and `*.p8` files
- [ ] `android/app/proguard-rules.pro` present
- [ ] Docs present at `docs/epic-20/story-20.2/ANDROID_BUILD.md` and `docs/epic-20/story-20.3/IOS_BUILD.md`

Closes #550
Closes #551