### PR TITLE
Stories 20.5 & 20.6: Beta and Production CD Pipelines

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -1,0 +1,174 @@
+name: CD — Beta (TestFlight + Play Internal Track)
+
+# Triggered by beta tags: v1.0.0-beta, v1.0.0-beta2, etc.
+# Builds and uploads the prod flavor to:
+#   - Google Play Internal Testing track (Android)
+#   - TestFlight via App Store Connect (iOS)
+on:
+  push:
+    tags:
+      - 'v*-beta'
+      - 'v*-beta[0-9]'
+      - 'v*-beta[0-9][0-9]'
+
+jobs:
+  # ─── Job 1: Tests ────────────────────────────────────────────────────────────
+  test:
+    name: 🧪 Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🔧 Generate Mock Firebase Configs (for tests)
+        run: dart run tools/generate_mock_firebase_configs.dart
+
+      - name: 📊 Run Static Analysis
+        run: flutter analyze
+
+      - name: 🧪 Run Unit & Widget Tests
+        run: flutter test test/unit/ test/widget/
+
+  # ─── Job 2: Deploy Android ───────────────────────────────────────────────────
+  deploy_android:
+    name: 🤖 Build & Upload Android (Play Internal)
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: ☕ Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: 💾 Setup Gradle Build Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🏷️ Extract Version from Tag
+        uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Firebase Prod Config
+        env:
+          FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
+          FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
+          FIREBASE_PROD_ANDROID_APP_ID: ${{ secrets.FIREBASE_PROD_ANDROID_APP_ID }}
+          FIREBASE_PROD_IOS_APP_ID: ${{ secrets.FIREBASE_PROD_IOS_APP_ID }}
+          FIREBASE_PROD_API_KEY: ${{ secrets.FIREBASE_PROD_API_KEY }}
+          FIREBASE_PROD_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_PROD_MESSAGING_SENDER_ID }}
+          FIREBASE_PROD_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_PROD_ANDROID_PACKAGE_NAME }}
+          FIREBASE_PROD_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_PROD_IOS_BUNDLE_ID }}
+        run: dart run tools/generate_firebase_config_from_secrets.dart prod
+
+      - name: 🔑 Decode Android Keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode \
+            > android/app/release.jks
+
+      - name: 🔨 Build Release AAB (prod flavor)
+        env:
+          ANDROID_KEYSTORE_PATH: release.jks
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          flutter build appbundle --release --flavor prod \
+            -t lib/main_prod.dart \
+            --build-name=${{ env.VERSION_NAME }} \
+            --build-number=${{ env.BUILD_NUMBER }}
+
+      - name: 🔑 Decode Google Play Service Account
+        run: |
+          echo "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}" | base64 --decode \
+            > service-account.json
+
+      - name: 🚀 Upload to Google Play Internal Track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: service-account.json
+          packageName: org.gatherli.app
+          releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
+          track: internal
+          status: completed
+          releaseName: ${{ env.VERSION_NAME }}
+
+  # ─── Job 3: Deploy iOS ───────────────────────────────────────────────────────
+  deploy_ios:
+    name: 🍎 Build & Upload iOS (TestFlight)
+    needs: test
+    runs-on: macos-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🏷️ Extract Version from Tag
+        uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Firebase Prod Config
+        env:
+          FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
+          FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
+          FIREBASE_PROD_ANDROID_APP_ID: ${{ secrets.FIREBASE_PROD_ANDROID_APP_ID }}
+          FIREBASE_PROD_IOS_APP_ID: ${{ secrets.FIREBASE_PROD_IOS_APP_ID }}
+          FIREBASE_PROD_API_KEY: ${{ secrets.FIREBASE_PROD_API_KEY }}
+          FIREBASE_PROD_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_PROD_MESSAGING_SENDER_ID }}
+          FIREBASE_PROD_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_PROD_ANDROID_PACKAGE_NAME }}
+          FIREBASE_PROD_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_PROD_IOS_BUNDLE_ID }}
+        run: dart run tools/generate_firebase_config_from_secrets.dart prod
+
+      - name: 🔑 Install App Store Connect API Key
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
+            > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+
+      - name: 🔨 Build & Upload IPA to TestFlight (prod flavor)
+        run: |
+          flutter build ipa --release --flavor prod \
+            -t lib/main_prod.dart \
+            --build-name=${{ env.VERSION_NAME }} \
+            --build-number=${{ env.BUILD_NUMBER }} \
+            --export-options-plist=ios/ExportOptions.plist

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -1,0 +1,173 @@
+name: CD — Production (App Store + Google Play)
+
+# Triggered by production tags only: v1.0.0, v1.2.3, etc.
+# The regex pattern explicitly excludes pre-release suffixes (-beta, -rc, etc.).
+# Builds and uploads the prod flavor to:
+#   - Google Play Production track (Android) — goes live immediately
+#   - App Store Connect (iOS) — enters Apple review (~1-2 days), then goes live
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  # ─── Job 1: Tests ────────────────────────────────────────────────────────────
+  test:
+    name: 🧪 Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🔧 Generate Mock Firebase Configs (for tests)
+        run: dart run tools/generate_mock_firebase_configs.dart
+
+      - name: 📊 Run Static Analysis
+        run: flutter analyze
+
+      - name: 🧪 Run Unit & Widget Tests
+        run: flutter test test/unit/ test/widget/
+
+  # ─── Job 2: Deploy Android ───────────────────────────────────────────────────
+  deploy_android:
+    name: 🤖 Build & Upload Android (Play Production)
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: ☕ Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: 💾 Setup Gradle Build Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🏷️ Extract Version from Tag
+        uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Firebase Prod Config
+        env:
+          FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
+          FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
+          FIREBASE_PROD_ANDROID_APP_ID: ${{ secrets.FIREBASE_PROD_ANDROID_APP_ID }}
+          FIREBASE_PROD_IOS_APP_ID: ${{ secrets.FIREBASE_PROD_IOS_APP_ID }}
+          FIREBASE_PROD_API_KEY: ${{ secrets.FIREBASE_PROD_API_KEY }}
+          FIREBASE_PROD_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_PROD_MESSAGING_SENDER_ID }}
+          FIREBASE_PROD_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_PROD_ANDROID_PACKAGE_NAME }}
+          FIREBASE_PROD_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_PROD_IOS_BUNDLE_ID }}
+        run: dart run tools/generate_firebase_config_from_secrets.dart prod
+
+      - name: 🔑 Decode Android Keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode \
+            > android/app/release.jks
+
+      - name: 🔨 Build Release AAB (prod flavor)
+        env:
+          ANDROID_KEYSTORE_PATH: release.jks
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+        run: |
+          flutter build appbundle --release --flavor prod \
+            -t lib/main_prod.dart \
+            --build-name=${{ env.VERSION_NAME }} \
+            --build-number=${{ env.BUILD_NUMBER }}
+
+      - name: 🔑 Decode Google Play Service Account
+        run: |
+          echo "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}" | base64 --decode \
+            > service-account.json
+
+      - name: 🚀 Upload to Google Play Production
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: service-account.json
+          packageName: org.gatherli.app
+          releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
+          track: production
+          status: completed
+          releaseName: ${{ env.VERSION_NAME }}
+
+  # ─── Job 3: Deploy iOS ───────────────────────────────────────────────────────
+  deploy_ios:
+    name: 🍎 Build & Upload iOS (App Store Connect)
+    needs: test
+    runs-on: macos-latest
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.6'
+          channel: 'stable'
+          cache: true
+
+      - name: 📦 Get Dependencies
+        run: flutter pub get
+
+      - name: 🏷️ Extract Version from Tag
+        uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Firebase Prod Config
+        env:
+          FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
+          FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
+          FIREBASE_PROD_ANDROID_APP_ID: ${{ secrets.FIREBASE_PROD_ANDROID_APP_ID }}
+          FIREBASE_PROD_IOS_APP_ID: ${{ secrets.FIREBASE_PROD_IOS_APP_ID }}
+          FIREBASE_PROD_API_KEY: ${{ secrets.FIREBASE_PROD_API_KEY }}
+          FIREBASE_PROD_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_PROD_MESSAGING_SENDER_ID }}
+          FIREBASE_PROD_ANDROID_PACKAGE_NAME: ${{ secrets.FIREBASE_PROD_ANDROID_PACKAGE_NAME }}
+          FIREBASE_PROD_IOS_BUNDLE_ID: ${{ secrets.FIREBASE_PROD_IOS_BUNDLE_ID }}
+        run: dart run tools/generate_firebase_config_from_secrets.dart prod
+
+      - name: 🔑 Install App Store Connect API Key
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
+            > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+
+      - name: 🔨 Build & Upload IPA to App Store Connect (prod flavor)
+        run: |
+          flutter build ipa --release --flavor prod \
+            -t lib/main_prod.dart \
+            --build-name=${{ env.VERSION_NAME }} \
+            --build-number=${{ env.BUILD_NUMBER }} \
+            --export-options-plist=ios/ExportOptions.plist

--- a/docs/epic-20/story-20.5/BETA_PIPELINE.md
+++ b/docs/epic-20/story-20.5/BETA_PIPELINE.md
@@ -1,0 +1,85 @@
+# Story 20.5 — Beta CD Pipeline
+
+## Overview
+
+File: `.github/workflows/cd-beta.yml`
+
+Triggers on beta tags (`v*-beta`, `v*-beta2`, etc.) and deploys to:
+- **Google Play Internal Testing track** (Android)
+- **TestFlight** via App Store Connect (iOS)
+
+---
+
+## Trigger
+
+```bash
+git tag v1.0.0-beta
+git push origin v1.0.0-beta
+```
+
+Supported tag patterns:
+- `v1.0.0-beta`
+- `v1.0.0-beta2`
+- `v1.0.0-beta99`
+
+---
+
+## Job Structure
+
+```
+test (ubuntu)
+├── flutter analyze
+└── flutter test test/unit/ test/widget/
+    │
+    ├── deploy_android (ubuntu) — runs in parallel after test passes
+    │   ├── Extract version from tag
+    │   ├── Generate Firebase prod config
+    │   ├── Decode Android keystore
+    │   ├── flutter build appbundle --flavor prod
+    │   ├── Decode Google Play service account
+    │   └── Upload AAB to Play Internal Track
+    │
+    └── deploy_ios (macos-latest) — runs in parallel after test passes
+        ├── Extract version from tag
+        ├── Generate Firebase prod config
+        ├── Install App Store Connect API key
+        └── flutter build ipa --flavor prod (uploads to TestFlight via ExportOptions.plist)
+```
+
+Android and iOS deploy jobs run **in parallel** after tests pass.
+
+---
+
+## Secrets Used
+
+| Secret | Job |
+|--------|-----|
+| `FIREBASE_PROD_*` (8 secrets) | Both |
+| `ANDROID_KEYSTORE_BASE64` | Android |
+| `ANDROID_KEY_ALIAS` | Android |
+| `ANDROID_KEY_PASSWORD` | Android |
+| `ANDROID_STORE_PASSWORD` | Android |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Android |
+| `APP_STORE_CONNECT_API_KEY_BASE64` | iOS |
+| `APP_STORE_CONNECT_API_KEY_ID` | iOS |
+
+---
+
+## What Happens After Upload
+
+**Android:** Build is immediately available in the Google Play Console under
+Internal Testing. Invite testers via the Play Console to get the install link.
+
+**iOS:** Build enters "Processing" in App Store Connect (~5-15 min), then appears
+in TestFlight. Internal testers can install it via the TestFlight app.
+
+---
+
+## If the Beta Has Issues
+
+Fix on main, then tag again with an incremented beta number:
+
+```bash
+git tag v1.0.0-beta2
+git push origin v1.0.0-beta2
+```

--- a/docs/epic-20/story-20.6/PRODUCTION_PIPELINE.md
+++ b/docs/epic-20/story-20.6/PRODUCTION_PIPELINE.md
@@ -1,0 +1,85 @@
+# Story 20.6 — Production CD Pipeline
+
+## Overview
+
+File: `.github/workflows/cd-production.yml`
+
+Triggers on production tags (`v1.0.0`, `v1.2.3`, etc. — no pre-release suffix) and
+deploys to:
+- **Google Play Production track** (Android) — goes live immediately
+- **App Store Connect** (iOS) — enters Apple review (~1-2 days), then goes live
+
+---
+
+## Trigger
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+The tag pattern `v[0-9]+.[0-9]+.[0-9]+` explicitly matches only clean semantic
+version tags and does **not** match `-beta` or any other pre-release suffix.
+
+---
+
+## Job Structure
+
+Identical structure to cd-beta.yml, with two differences:
+
+| | Beta | Production |
+|--|------|------------|
+| Android track | `internal` | `production` |
+| iOS destination | TestFlight | App Store review |
+| Trigger | `v*-beta*` | `v[0-9]+.[0-9]+.[0-9]+` |
+
+```
+test (ubuntu)
+├── flutter analyze
+└── flutter test test/unit/ test/widget/
+    │
+    ├── deploy_android (ubuntu)
+    │   └── Upload AAB to Play Production track
+    │
+    └── deploy_ios (macos-latest)
+        └── flutter build ipa → uploads to App Store Connect
+```
+
+---
+
+## Secrets Used
+
+Same as the beta pipeline. See `docs/epic-20/story-20.5/BETA_PIPELINE.md`.
+
+---
+
+## What Happens After Upload
+
+**Android:** The release goes live on the Play Store Production track immediately
+after processing (usually within a few minutes).
+
+**iOS:** The build appears in App Store Connect under the app version. You must:
+1. Go to App Store Connect → your app → the version
+2. Select the uploaded build
+3. Click "Submit for Review"
+
+Apple review typically takes 1-2 days. Once approved, the update goes live.
+
+---
+
+## Pre-requisites Before Tagging Production
+
+1. A beta build (`v*-beta`) has been validated on TestFlight and Play Internal
+2. The app version in App Store Connect has been prepared (screenshots, description,
+   release notes) if this is a new version
+3. CI is green on main
+
+---
+
+## Rollback
+
+**Android:** Google Play Console → Release → Production → the release → "Halt rollout"
+Then re-submit the previous AAB or fix and tag a new patch version.
+
+**iOS:** App Store Connect → remove the version from sale, or contact Apple support.
+Then fix on main and tag a new patch version.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/cd-beta.yml` — triggered by `v*-beta*` tags
- Add `.github/workflows/cd-production.yml` — triggered by `v[0-9]+.[0-9]+.[0-9]+` tags (excludes beta)
- Both pipelines share the same structure: tests first, then Android and iOS deploy in parallel
- Documentation added for both pipelines

## Pipeline structure

```
test (ubuntu) — flutter analyze + flutter test
    ├── deploy_android (ubuntu, parallel)
    │   ├── Generate Firebase prod config from secrets
    │   ├── Decode keystore → build signed AAB (prod flavor)
    │   └── Upload to Play Internal Track (beta) / Play Production (prod)
    └── deploy_ios (macos-latest, parallel)
        ├── Generate Firebase prod config from secrets
        ├── Install App Store Connect API key
        └── flutter build ipa (prod flavor) → uploads via ExportOptions.plist
```

## Key differences between beta and production

| | Beta | Production |
|--|------|------------|
| Trigger | `v*-beta*` | `v[0-9]+.[0-9]+.[0-9]+` |
| Android track | Internal Testing | Production |
| iOS | TestFlight | App Store review |

## Test plan

- [ ] `cd-beta.yml` triggers on `v1.0.0-beta` tag, not on `v1.0.0`
- [ ] `cd-production.yml` triggers on `v1.0.0` tag, not on `v1.0.0-beta`
- [ ] Tests job must pass before any deploy job starts
- [ ] Android and iOS jobs run in parallel after tests
- [ ] All secrets correctly referenced (validated in Story 20.7)

Closes #553
Closes #554