### PR TITLE
fix(cd): use --no-fatal-warnings in analyze step

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -35,7 +35,7 @@ jobs:
         run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 📊 Run Static Analysis
-        run: flutter analyze
+        run: flutter analyze --no-fatal-warnings
 
       - name: 🧪 Run Unit & Widget Tests
         run: flutter test test/unit/ test/widget/

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -34,7 +34,7 @@ jobs:
         run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 📊 Run Static Analysis
-        run: flutter analyze
+        run: flutter analyze --no-fatal-warnings
 
       - name: 🧪 Run Unit & Widget Tests
         run: flutter test test/unit/ test/widget/


### PR DESCRIPTION
## Problem
`flutter analyze` exits with code 1 when there are warnings, blocking the CD pipeline.
The warnings are pre-existing and already caught by the main CI on every PR before merge.

## Fix
Use `flutter analyze --no-fatal-warnings` in both `cd-beta.yml` and `cd-production.yml`.
The CD pipeline will now only fail on actual errors, not warnings or infos.