### PR TITLE
fix(cd): generate mock dev firebase config before prod build

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -80,6 +80,9 @@ jobs:
       - name: 🏷️ Extract Version from Tag
         uses: ./.github/actions/extract-version
 
+      - name: 🔧 Generate Mock Firebase Dev Config (required by firebase_options_provider.dart)
+        run: dart run tools/generate_mock_firebase_configs.dart
+
       - name: 🔧 Generate Firebase Prod Config
         env:
           FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
@@ -146,6 +149,9 @@ jobs:
 
       - name: 🏷️ Extract Version from Tag
         uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Mock Firebase Dev Config (required by firebase_options_provider.dart)
+        run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 🔧 Generate Firebase Prod Config
         env:

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -79,6 +79,9 @@ jobs:
       - name: 🏷️ Extract Version from Tag
         uses: ./.github/actions/extract-version
 
+      - name: 🔧 Generate Mock Firebase Dev Config (required by firebase_options_provider.dart)
+        run: dart run tools/generate_mock_firebase_configs.dart
+
       - name: 🔧 Generate Firebase Prod Config
         env:
           FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
@@ -145,6 +148,9 @@ jobs:
 
       - name: 🏷️ Extract Version from Tag
         uses: ./.github/actions/extract-version
+
+      - name: 🔧 Generate Mock Firebase Dev Config (required by firebase_options_provider.dart)
+        run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 🔧 Generate Firebase Prod Config
         env:


### PR DESCRIPTION
## Problem

Android build was failing with:
```
lib/core/services/firebase_options_provider.dart:4:8: Error: Error when reading 'lib/core/config/firebase_config_dev.dart': No such file or directory
```

`firebase_options_provider.dart` imports both `firebase_config_dev.dart` and `firebase_config_prod.dart` unconditionally. The Dart compiler needs both files present even when building with the `prod` flavor. The deploy jobs were only generating the prod config.

## Fix

Added `dart run tools/generate_mock_firebase_configs.dart` before the prod config generation step in all 4 deploy jobs (Android + iOS, in both cd-beta.yml and cd-production.yml). This is the same step the test job already runs.

## iOS signing (separate issue)

The iOS build also failed with `No Accounts / No profiles found`. This is a separate issue — iOS distribution signing requires a `.p12` certificate + provisioning profile stored as GitHub secrets and imported into the macOS Keychain. This will be tracked as Story 20.9.