### PR TITLE
docs(epic-20): custom domain email verification setup and branded action page

### DIFF
--- a/docs/epic-20/story-20.11/EMAIL_VERIFICATION_CUSTOM_DOMAIN.md
+++ b/docs/epic-20/story-20.11/EMAIL_VERIFICATION_CUSTOM_DOMAIN.md
@@ -1,0 +1,193 @@
+# Email Verification — Custom Domain Setup
+
+**Epic:** 20 — Production Release
+**Story:** 20.11 — Custom Domain Email Verification
+**Status:** Complete
+
+---
+
+## Overview
+
+This document covers the full configuration required to send Firebase Auth emails
+(email verification, password reset) from `noreply@gatherli.org` with a branded
+verification page, good deliverability, and correct app name display.
+
+---
+
+## 1. DNS Records (GoDaddy)
+
+The following DNS records must be present on `gatherli.org`:
+
+### MX — Receive email via ImprovMX (email forwarding)
+
+| Type | Name | Value | Priority |
+|------|------|-------|----------|
+| MX | @ | mx1.improvmx.com. | 10 |
+| MX | @ | mx2.improvmx.com. | 20 |
+
+ImprovMX forwards emails received at `@gatherli.org` to a personal inbox.
+Configure forwarding rules at [improvmx.com](https://improvmx.com).
+
+### SPF — Authorise Firebase and ImprovMX to send on behalf of the domain
+
+> **Critical:** only ONE SPF TXT record is allowed at `@`. Having two separate
+> SPF records breaks SPF validation. Merge both senders into a single record.
+
+| Type | Name | Value |
+|------|------|-------|
+| TXT | @ | `v=spf1 include:spf.improvmx.com include:_spf.firebasemail.com ~all` |
+
+### DMARC — Policy for handling unauthenticated mail
+
+| Type | Name | Value |
+|------|------|-------|
+| TXT | _dmarc | `v=DMARC1; p=quarantine; adkim=r; aspf=r; rua=mailto:dmarc_rua@onsecureserver.net;` |
+
+`p=quarantine` sends suspicious emails to spam rather than rejecting them outright,
+which is a safe starting policy.
+
+### Firebase ownership verification
+
+| Type | Name | Value |
+|------|------|-------|
+| TXT | @ | `firebase=gatherli-prod` |
+| TXT | @ | `hosting-site=gatherli-prod` |
+
+---
+
+## 2. Firebase Auth — Custom Email Sender
+
+**Path:** Firebase Console → Authentication → Templates → Edit any template → Sender
+
+| Field | Value |
+|-------|-------|
+| Sender name | Gatherli |
+| Sender email | noreply@gatherli.org |
+
+This configures all Firebase Auth emails (verification, password reset, email change)
+to appear as coming from `noreply@gatherli.org` rather than Firebase's default domain.
+
+---
+
+## 3. Firebase Auth — Custom Action URL
+
+**Path:** Firebase Console → Authentication → Templates → Email address verification
+→ Customize action URL
+
+| Field | Value |
+|-------|-------|
+| Custom action URL | `https://gatherli.org/auth/action` |
+
+This points the link inside every verification email to Gatherli's branded
+verification page (see Section 5) instead of Firebase's default unstyled handler.
+
+Apply the same custom action URL to the Password Reset and Email Address Change
+templates.
+
+---
+
+## 4. Firebase Auth — Authorised Domains
+
+**Path:** Firebase Console → Authentication → Settings → Authorised domains
+
+Ensure `gatherli.org` is listed. If missing, add it. This allows Firebase to
+issue action links and tokens for the custom domain.
+
+---
+
+## 5. Custom Email Action Handler Page
+
+A branded HTML page is served at `https://gatherli.org/auth/action`.
+
+**File:** `public/auth/action.html`
+
+The page uses the Firebase JS SDK (loaded from CDN) and the Firebase Hosting
+auto-config endpoint (`/__/firebase/init.json`) to avoid hardcoding API keys.
+
+**Flow:**
+1. User clicks the verification link in the email
+2. Browser opens `https://gatherli.org/auth/action?mode=verifyEmail&oobCode=XXX`
+3. The page reads `mode` and `oobCode` from the URL
+4. Calls `applyActionCode(auth, oobCode)` to verify the email server-side
+5. Shows a branded success screen with App Store / Google Play download links
+6. On error (expired or already-used code) shows a friendly error message
+
+**Supported modes:**
+- `verifyEmail` — email address verification (primary use case)
+- Others — shows a graceful fallback message
+
+**Firebase Hosting rewrite** (`firebase.json`):
+```json
+{
+  "source": "/auth/action",
+  "destination": "/auth/action.html"
+}
+```
+
+The `cleanUrls: true` setting in `firebase.json` means `auth/action.html` is
+also accessible as `/auth/action` without the `.html` extension.
+
+---
+
+## 6. App Name in Email Templates (`%APP_NAME%`)
+
+Firebase Auth email templates use `%APP_NAME%` which is populated from the
+**OAuth consent screen app name**, not the Firebase project name.
+
+### Steps to configure
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com) →
+   select project `gatherli-prod`
+2. Navigate to **APIs & Services → OAuth consent screen**
+3. Set **Audience** to **External** (required for public apps)
+4. Set **App name** to `Gatherli`
+5. Set a support email (can use a Google account created with `admin@gatherli.org`)
+6. Save
+
+`%APP_NAME%` in all Firebase Auth email templates will now display `Gatherli`.
+
+> **Note:** The Firebase project name (Project Settings → General) does NOT
+> control `%APP_NAME%`. The OAuth consent screen app name is the authoritative
+> source.
+
+---
+
+## 7. ImprovMX — Email Forwarding
+
+ImprovMX is used to receive emails at `@gatherli.org` and forward them to a
+personal inbox. This is separate from Firebase Auth email sending.
+
+Configure forwarding aliases at [improvmx.com](https://improvmx.com):
+
+| Alias | Forwards to |
+|-------|------------|
+| admin@gatherli.org | personal inbox |
+| noreply@gatherli.org | personal inbox (optional, for bounce monitoring) |
+
+---
+
+## 8. Verification Checklist
+
+Before considering this setup complete, verify:
+
+- [ ] Verification email arrives in inbox (not spam)
+- [ ] Sender shows `noreply@gatherli.org`
+- [ ] Sign-off shows `The Gatherli team` (not `gatherli-prod`)
+- [ ] Link points to `https://gatherli.org/auth/action`
+- [ ] Clicking the link shows the branded verification page
+- [ ] Verified successfully message appears after clicking
+- [ ] SPF record is a single merged TXT record at `@`
+- [ ] DMARC record exists at `_dmarc.gatherli.org`
+- [ ] `gatherli.org` is in Firebase Auth authorised domains
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Email lands in spam | SPF misconfigured (two records) | Merge into one SPF TXT record |
+| `%APP_NAME%` shows `gatherli-prod` | OAuth consent screen not configured | Set app name in Google Cloud Console → APIs & Services → OAuth consent screen |
+| Link shows 404 basketball page | Action URL set to `/__/auth/action` (Firebase default, not custom page) | Set custom action URL to `https://gatherli.org/auth/action` |
+| Verification page shows "already used" | Link clicked twice or expired | Expected behaviour — user must request a new email |
+| Sender shows `noreply@gatherli-prod.firebaseapp.com` | Custom sender not configured in Auth templates | Set sender email in Authentication → Templates → Edit |

--- a/firebase.json
+++ b/firebase.json
@@ -22,6 +22,10 @@
       {
         "source": "/invite/**",
         "destination": "/invite.html"
+      },
+      {
+        "source": "/auth/action",
+        "destination": "/auth/action.html"
       }
     ]
   },

--- a/public/auth/action.html
+++ b/public/auth/action.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gatherli</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background: #f0f4f8;
+      color: #4a5568;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .card {
+      background: white;
+      border-radius: 20px;
+      padding: 48px 40px;
+      max-width: 420px;
+      width: 100%;
+      text-align: center;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+    }
+    .icon {
+      font-size: 64px;
+      margin-bottom: 24px;
+      display: block;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: #1a202c;
+      margin-bottom: 12px;
+    }
+    p {
+      font-size: 15px;
+      line-height: 1.6;
+      color: #718096;
+      margin-bottom: 32px;
+    }
+    .btn {
+      display: inline-block;
+      background: #004E64;
+      color: white;
+      text-decoration: none;
+      padding: 14px 32px;
+      border-radius: 12px;
+      font-size: 15px;
+      font-weight: 600;
+      margin: 6px;
+      transition: opacity 0.2s;
+    }
+    .btn:hover { opacity: 0.88; }
+    .btn.secondary {
+      background: transparent;
+      color: #004E64;
+      border: 2px solid #004E64;
+    }
+    .store-badges {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+    }
+    .store-badges img {
+      height: 40px;
+      width: auto;
+    }
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid #e2e8f0;
+      border-top-color: #004E64;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto 24px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+  <!-- Loading state -->
+  <div class="card" id="loading">
+    <div class="spinner"></div>
+    <h1>Just a moment…</h1>
+    <p>We're verifying your email address.</p>
+  </div>
+
+  <!-- Success state -->
+  <div class="card hidden" id="success">
+    <span class="icon">✅</span>
+    <h1>Email verified!</h1>
+    <p>Thank you for verifying your email address.<br>You're all set — welcome to Gatherli! 🎉</p>
+    <div class="store-badges">
+      <a href="https://apps.apple.com/app/gatherli/id6738921951">
+        <img src="/badge-app-store.svg" alt="Download on the App Store">
+      </a>
+      <a href="https://play.google.com/store/apps/details?id=org.gatherli.app">
+        <img src="/badge-google-play.png" alt="Get it on Google Play">
+      </a>
+    </div>
+  </div>
+
+  <!-- Error state -->
+  <div class="card hidden" id="error">
+    <span class="icon">❌</span>
+    <h1 id="error-title">Something went wrong</h1>
+    <p id="error-message">This link may have expired or already been used. Please request a new verification email from the app.</p>
+    <a href="https://gatherli.org" class="btn secondary">Back to Gatherli</a>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js';
+    import { getAuth, applyActionCode, verifyPasswordResetCode, confirmPasswordReset, checkActionCode } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js';
+
+    function show(id) {
+      ['loading', 'success', 'error'].forEach(s => {
+        document.getElementById(s).classList.toggle('hidden', s !== id);
+      });
+    }
+
+    function setError(title, message) {
+      document.getElementById('error-title').textContent = title;
+      document.getElementById('error-message').textContent = message;
+      show('error');
+    }
+
+    async function main() {
+      // Load Firebase config automatically from Firebase Hosting
+      const config = await fetch('/__/firebase/init.json').then(r => r.json());
+      const app = initializeApp(config);
+      const auth = getAuth(app);
+
+      const params = new URLSearchParams(window.location.search);
+      const mode = params.get('mode');
+      const oobCode = params.get('oobCode');
+
+      if (!mode || !oobCode) {
+        setError('Invalid link', 'This link is missing required parameters. Please request a new one from the app.');
+        return;
+      }
+
+      try {
+        if (mode === 'verifyEmail') {
+          await applyActionCode(auth, oobCode);
+          show('success');
+
+        } else if (mode === 'resetPassword') {
+          // For password reset, redirect to a dedicated page or show inline form
+          // For now, show a generic message
+          setError('Password Reset', 'Password reset links must be opened directly from the Gatherli app.');
+
+        } else {
+          setError('Unknown action', 'This link type is not supported. Please return to the app.');
+        }
+      } catch (e) {
+        const msg = {
+          'auth/expired-action-code': 'This link has expired. Please request a new verification email from the app.',
+          'auth/invalid-action-code': 'This link has already been used or is invalid. Please request a new one.',
+          'auth/user-disabled': 'This account has been disabled. Please contact support.',
+          'auth/user-not-found': 'No account was found for this link.',
+        }[e.code] || 'Something went wrong. Please try again or contact support.';
+        setError('Verification failed', msg);
+      }
+    }
+
+    main();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add `docs/epic-20/story-20.11/EMAIL_VERIFICATION_CUSTOM_DOMAIN.md` — full reference covering DNS records (SPF, DMARC, MX via ImprovMX), Firebase Auth sender configuration (`noreply@gatherli.org`), custom action URL, OAuth consent screen app name setup, and a troubleshooting table
- Add `public/auth/action.html` — branded email verification page served at `https://gatherli.org/auth/action`, replacing Firebase's default unstyled handler; uses Firebase JS SDK via CDN and auto-config endpoint (no hardcoded API keys), with success/error states and App Store / Google Play links
- Update `firebase.json` — add `/auth/action` rewrite to serve the new handler page

## Test plan

- [ ] Send a test verification email from a new account registration
- [ ] Confirm sender shows `noreply@gatherli.org`
- [ ] Confirm sign-off shows `Gatherli` (not `gatherli-prod`)
- [ ] Confirm link points to `https://gatherli.org/auth/action`
- [ ] Confirm clicking the link shows the branded verification page
- [ ] Confirm email lands in inbox, not spam