### PR TITLE
fix(ui): restyle date/time pickers and add Android adaptive icon

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application
         android:label="Gatherli"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
 
         <!-- FCM default notification channel -->
         <meta-data

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adaptive icon foreground: white volleyball centered on transparent background.
+  Viewport 108×108 (standard adaptive icon canvas).
+  Safe zone: content within (18,18)→(90,90).
+  Volleyball (24×24 Material paths) scaled ×2.5 and translated (24,24)
+  → spans (29,29)→(79,79), comfortably within the safe zone.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:translateX="24"
+        android:translateY="24"
+        android:scaleX="2.5"
+        android:scaleY="2.5">
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M6,4.01C3.58,5.84,2,8.73,2,12c0,1.46,0.32,2.85,0.89,4.11L6,14.31V4.01z" />
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M11,11.42V2.05C9.94,2.16,8.93,2.43,8,2.84v10.32L11,11.42z" />
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M12,13.15l-8.11,4.68c0.61,0.84,1.34,1.59,2.18,2.2L15,14.89L12,13.15z" />
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M13,7.96v3.46l8.11,4.68c0.42-0.93,0.7-1.93,0.82-2.98L13,7.96z" />
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M8.07,21.2C9.28,21.71,10.6,22,12,22c3.34,0,6.29-1.65,8.11-4.16L17,16.04L8.07,21.2z" />
+        <path
+            android:fillColor="#004E64"
+            android:pathData="M21.92,10.81c-0.55-4.63-4.26-8.3-8.92-8.76v3.6L21.92,10.81z" />
+    </group>
+
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#FFFFFFFF</color>
+</resources>

--- a/lib/features/games/presentation/pages/game_creation_page.dart
+++ b/lib/features/games/presentation/pages/game_creation_page.dart
@@ -1,6 +1,8 @@
 // Game creation page for creating new games with form validation and group selection.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -62,24 +64,170 @@ class _GameCreationPageState extends State<GameCreationPage> {
   Future<void> _selectDateTime(BuildContext context) async {
     final now = DateTime.now();
     final initialDate = now.add(const Duration(days: 1));
+    const blue = AppColors.secondary;
 
     final l10n = AppLocalizations.of(context)!;
     final bloc = context.read<GameCreationBloc>();
+
     final date = await showDatePicker(
       context: context,
       initialDate: initialDate,
       firstDate: now,
       lastDate: now.add(const Duration(days: 365)),
       helpText: l10n.selectGameDate,
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            datePickerTheme: DatePickerThemeData(
+              backgroundColor: Colors.white,
+              surfaceTintColor: Colors.transparent,
+              headerBackgroundColor: Colors.white,
+              headerForegroundColor: blue,
+              dayForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              dayShape: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) {
+                  return RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50),
+                    side: const BorderSide(color: blue, width: 2),
+                  );
+                }
+                return null;
+              }),
+              todayForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              todayBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              todayBorder: const BorderSide(color: Colors.transparent),
+              yearForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              yearBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              yearShape: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) {
+                  return RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50),
+                    side: const BorderSide(color: blue, width: 2),
+                  );
+                }
+                return null;
+              }),
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(foregroundColor: blue),
+            ),
+          ),
+          child: child!,
+        );
+      },
     );
 
     if (date == null || !context.mounted) return;
 
+    // Cupertino drum-roll time picker (iPhone alarm style) as a centered dialog
+    TimeOfDay? time;
+    final isToday = date.year == now.year &&
+        date.month == now.month &&
+        date.day == now.day;
+    // If today is selected, start at now + 1 hour (minimum selectable time)
+    final minPickerTime = isToday ? now : null;
+    DateTime pickerTime = isToday
+        ? DateTime(date.year, date.month, date.day, now.hour, now.minute)
+            .add(const Duration(hours: 1))
+        : DateTime(date.year, date.month, date.day, 14, 0);
+
     // ignore: use_build_context_synchronously
-    final time = await showTimePicker(
+    await showDialog<void>(
       context: context,
-      initialTime: const TimeOfDay(hour: 14, minute: 0),
-      helpText: l10n.selectGameTime,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          surfaceTintColor: Colors.transparent,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(dialogContext),
+                      child: Text(
+                        l10n.cancel,
+                        style: const TextStyle(color: blue, fontSize: 16),
+                      ),
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          l10n.selectGameTime,
+                          style: const TextStyle(
+                            color: blue,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (isToday)
+                          Text(
+                            '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')} ${l10n.orLater}',
+                            style: const TextStyle(
+                              color: Colors.grey,
+                              fontSize: 12,
+                            ),
+                          ),
+                      ],
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        time = TimeOfDay(
+                          hour: pickerTime.hour,
+                          minute: pickerTime.minute,
+                        );
+                        Navigator.pop(dialogContext);
+                      },
+                      child: Text(
+                        l10n.ok,
+                        style: const TextStyle(
+                          color: blue,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 200,
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  initialDateTime: pickerTime,
+                  minimumDate: minPickerTime,
+                  use24hFormat: true,
+                  onDateTimeChanged: (dt) => pickerTime = dt,
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        );
+      },
     );
 
     if (time == null || !mounted) return;
@@ -88,8 +236,8 @@ class _GameCreationPageState extends State<GameCreationPage> {
       date.year,
       date.month,
       date.day,
-      time.hour,
-      time.minute,
+      time!.hour,
+      time!.minute,
     );
 
     setState(() {

--- a/lib/features/training/presentation/pages/training_session_creation_page.dart
+++ b/lib/features/training/presentation/pages/training_session_creation_page.dart
@@ -1,5 +1,7 @@
 // Training session creation page - simplified version for Story 15.4
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
@@ -58,23 +60,167 @@ class _TrainingSessionCreationPageState
   Future<void> _selectStartTime(BuildContext context) async {
     final now = DateTime.now();
     final initialDate = now.add(const Duration(days: 1));
+    const blue = AppColors.secondary;
 
     final l10n = AppLocalizations.of(context)!;
+
     final date = await showDatePicker(
       context: context,
       initialDate: initialDate,
       firstDate: now,
       lastDate: now.add(const Duration(days: 365)),
       helpText: l10n.selectStartDate,
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            datePickerTheme: DatePickerThemeData(
+              backgroundColor: Colors.white,
+              surfaceTintColor: Colors.transparent,
+              headerBackgroundColor: Colors.white,
+              headerForegroundColor: blue,
+              dayForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              dayShape: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) {
+                  return RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50),
+                    side: const BorderSide(color: blue, width: 2),
+                  );
+                }
+                return null;
+              }),
+              todayForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              todayBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              todayBorder: const BorderSide(color: Colors.transparent),
+              yearForegroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return blue;
+                return null;
+              }),
+              yearBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) return Colors.white;
+                return null;
+              }),
+              yearShape: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.selected)) {
+                  return RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(50),
+                    side: const BorderSide(color: blue, width: 2),
+                  );
+                }
+                return null;
+              }),
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(foregroundColor: blue),
+            ),
+          ),
+          child: child!,
+        );
+      },
     );
 
     if (date == null || !context.mounted) return;
 
+    final isToday = date.year == now.year &&
+        date.month == now.month &&
+        date.day == now.day;
+    final minPickerTime = isToday ? now : null;
+    DateTime pickerTime = isToday
+        ? DateTime(date.year, date.month, date.day, now.hour, now.minute)
+            .add(const Duration(hours: 1))
+        : DateTime(date.year, date.month, date.day, 14, 0);
+
+    TimeOfDay? time;
+
     // ignore: use_build_context_synchronously
-    final time = await showTimePicker(
+    await showDialog<void>(
       context: context,
-      initialTime: const TimeOfDay(hour: 14, minute: 0),
-      helpText: l10n.selectStartTime,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          surfaceTintColor: Colors.transparent,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(dialogContext),
+                      child: Text(l10n.cancel,
+                          style:
+                              const TextStyle(color: blue, fontSize: 16)),
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          l10n.selectStartTime,
+                          style: const TextStyle(
+                            color: blue,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (isToday)
+                          Text(
+                            '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')} ${l10n.orLater}',
+                            style: const TextStyle(
+                                color: Colors.grey, fontSize: 12),
+                          ),
+                      ],
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        time = TimeOfDay(
+                          hour: pickerTime.hour,
+                          minute: pickerTime.minute,
+                        );
+                        Navigator.pop(dialogContext);
+                      },
+                      child: Text(
+                        l10n.ok,
+                        style: const TextStyle(
+                          color: blue,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 200,
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  initialDateTime: pickerTime,
+                  minimumDate: minPickerTime,
+                  use24hFormat: true,
+                  onDateTimeChanged: (dt) => pickerTime = dt,
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        );
+      },
     );
 
     if (time == null || !mounted) return;
@@ -83,8 +229,8 @@ class _TrainingSessionCreationPageState
       date.year,
       date.month,
       date.day,
-      time.hour,
-      time.minute,
+      time!.hour,
+      time!.minute,
     );
 
     setState(() {
@@ -95,7 +241,9 @@ class _TrainingSessionCreationPageState
   }
 
   Future<void> _selectEndTime(BuildContext context) async {
+    const blue = AppColors.secondary;
     final l10n = AppLocalizations.of(context)!;
+
     if (_selectedStartTime == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.pleaseSelectStartTimeFirst)),
@@ -103,13 +251,87 @@ class _TrainingSessionCreationPageState
       return;
     }
 
-    final time = await showTimePicker(
+    // End time must be after start time
+    DateTime pickerTime = _selectedEndTime ??
+        _selectedStartTime!.add(const Duration(hours: 2));
+
+    TimeOfDay? time;
+
+    await showDialog<void>(
       context: context,
-      initialTime: TimeOfDay(
-        hour: _selectedEndTime?.hour ?? 16,
-        minute: _selectedEndTime?.minute ?? 0,
-      ),
-      helpText: l10n.selectEndTime,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          surfaceTintColor: Colors.transparent,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(dialogContext),
+                      child: Text(l10n.cancel,
+                          style:
+                              const TextStyle(color: blue, fontSize: 16)),
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          l10n.selectEndTime,
+                          style: const TextStyle(
+                            color: blue,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        Text(
+                          '${_selectedStartTime!.hour.toString().padLeft(2, '0')}:${_selectedStartTime!.minute.toString().padLeft(2, '0')} ${l10n.orLater}',
+                          style: const TextStyle(
+                              color: Colors.grey, fontSize: 12),
+                        ),
+                      ],
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        time = TimeOfDay(
+                          hour: pickerTime.hour,
+                          minute: pickerTime.minute,
+                        );
+                        Navigator.pop(dialogContext);
+                      },
+                      child: Text(
+                        l10n.ok,
+                        style: const TextStyle(
+                          color: blue,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 200,
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  initialDateTime: pickerTime,
+                  minimumDate: _selectedStartTime,
+                  use24hFormat: true,
+                  onDateTimeChanged: (dt) => pickerTime = dt,
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        );
+      },
     );
 
     if (time == null || !context.mounted) return;
@@ -118,8 +340,8 @@ class _TrainingSessionCreationPageState
       _selectedStartTime!.year,
       _selectedStartTime!.month,
       _selectedStartTime!.day,
-      time.hour,
-      time.minute,
+      time!.hour,
+      time!.minute,
     );
 
     setState(() {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -575,5 +575,9 @@
   "featureRestricted": "Diese Funktion erfordert eine E-Mail-Bestätigung.",
   "verifyToUnlock": "Bestätigen Sie Ihre E-Mail, um diese Funktion zu nutzen.",
   "featureRestrictedTitle": "Funktion eingeschränkt",
-  "verifyEmail": "E-Mail bestätigen"
+  "verifyEmail": "E-Mail bestätigen",
+  "orLater": "oder später",
+  "@orLater": {
+    "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2744,5 +2744,9 @@
   "verifyEmail": "Verify Email",
   "@verifyEmail": {
     "description": "Button label to verify email in restriction dialog"
+  },
+  "orLater": "or later",
+  "@orLater": {
+    "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -575,5 +575,9 @@
   "featureRestricted": "Esta función requiere verificación de email.",
   "verifyToUnlock": "Verifica tu email para usar esta función.",
   "featureRestrictedTitle": "Función restringida",
-  "verifyEmail": "Verificar email"
+  "verifyEmail": "Verificar email",
+  "orLater": "o más tarde",
+  "@orLater": {
+    "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -575,5 +575,9 @@
   "featureRestricted": "Cette fonctionnalité nécessite la vérification de l'email.",
   "verifyToUnlock": "Vérifiez votre email pour utiliser cette fonctionnalité.",
   "featureRestrictedTitle": "Fonctionnalité restreinte",
-  "verifyEmail": "Vérifier l'email"
+  "verifyEmail": "Vérifier l'email",
+  "orLater": "ou plus tard",
+  "@orLater": {
+    "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -575,5 +575,9 @@
   "featureRestricted": "Questa funzione richiede la verifica dell'email.",
   "verifyToUnlock": "Verifica la tua email per usare questa funzione.",
   "featureRestrictedTitle": "Funzione limitata",
-  "verifyEmail": "Verifica email"
+  "verifyEmail": "Verifica email",
+  "orLater": "o più tardi",
+  "@orLater": {
+    "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3475,6 +3475,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Verify Email'**
   String get verifyEmail;
+
+  /// Suffix shown in time picker when today is selected, indicating the minimum selectable time
+  ///
+  /// In en, this message translates to:
+  /// **'or later'**
+  String get orLater;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1899,4 +1899,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get verifyEmail => 'E-Mail bestätigen';
+
+  @override
+  String get orLater => 'oder später';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1864,4 +1864,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get verifyEmail => 'Verify Email';
+
+  @override
+  String get orLater => 'or later';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1889,4 +1889,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get verifyEmail => 'Verificar email';
+
+  @override
+  String get orLater => 'o más tarde';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1902,4 +1902,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get verifyEmail => 'Vérifier l\'email';
+
+  @override
+  String get orLater => 'ou plus tard';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1885,4 +1885,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get verifyEmail => 'Verifica email';
+
+  @override
+  String get orLater => 'o più tardi';
 }

--- a/test/widget/features/games/presentation/pages/game_creation_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_creation_page_test.dart
@@ -327,6 +327,121 @@ void main() {
           findsNWidgets(2),
         );
       });
+
+      testWidgets('shows time picker as centered Dialog after date confirmed',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Open date picker
+        final dateTimeTile = find.ancestor(
+          of: find.byIcon(Icons.calendar_today),
+          matching: find.byType(ListTile),
+        );
+        await tester.tap(dateTimeTile);
+        await tester.pumpAndSettle();
+        expect(find.byType(DatePickerDialog), findsOneWidget);
+
+        // Confirm the date (OK button on date picker)
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Time picker must appear as a centered Dialog, not a bottom sheet
+        expect(find.byType(Dialog), findsOneWidget);
+        expect(find.byType(BottomSheet), findsNothing);
+      });
+
+      testWidgets('time picker dialog shows title, cancel and ok buttons',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Open and confirm date picker
+        final dateTimeTile = find.ancestor(
+          of: find.byIcon(Icons.calendar_today),
+          matching: find.byType(ListTile),
+        );
+        await tester.tap(dateTimeTile);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Time dialog should have a title, Cancel and OK
+        expect(find.text('Select Game Time'), findsOneWidget);
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('OK'), findsOneWidget);
+      });
+
+      testWidgets('canceling time picker does not update date time',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Open and confirm date picker
+        final dateTimeTile = find.ancestor(
+          of: find.byIcon(Icons.calendar_today),
+          matching: find.byType(ListTile),
+        );
+        await tester.tap(dateTimeTile);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Cancel the time picker
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        // SetDateTime must not have been called
+        verifyNever(
+          () => mockGameCreationBloc.add(any(that: isA<SetDateTime>())),
+        );
+
+        // Date time tile still shows 'Tap to select'
+        expect(find.text('Tap to select'), findsNWidgets(2));
+      });
+
+      testWidgets('confirming time picker dispatches SetDateTime with future datetime',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Open and confirm date picker (default is tomorrow)
+        final dateTimeTile = find.ancestor(
+          of: find.byIcon(Icons.calendar_today),
+          matching: find.byType(ListTile),
+        );
+        await tester.tap(dateTimeTile);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Confirm the time picker
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // SetDateTime should have been called once with a future datetime
+        final captured = verify(
+          () => mockGameCreationBloc.add(captureAny(that: isA<SetDateTime>())),
+        ).captured;
+        expect(captured, hasLength(1));
+        final event = captured.first as SetDateTime;
+        expect(event.dateTime.isAfter(DateTime.now()), isTrue);
+      });
+
+      testWidgets('canceling date picker does not show time picker',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Open date picker and cancel
+        final dateTimeTile = find.ancestor(
+          of: find.byIcon(Icons.calendar_today),
+          matching: find.byType(ListTile),
+        );
+        await tester.tap(dateTimeTile);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        // No Dialog (time picker) should appear
+        expect(find.byType(Dialog), findsNothing);
+        expect(find.text('Tap to select'), findsNWidgets(2));
+      });
     });
 
     group('Loading State', () {

--- a/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
+++ b/test/widget/features/training/presentation/pages/training_session_creation_page_test.dart
@@ -288,6 +288,127 @@ void main() {
         // Date picker dialog should appear
         expect(find.byType(DatePickerDialog), findsOneWidget);
       });
+
+      testWidgets('time picker opens as centered Dialog after date confirmed',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Tap start time tile
+        await tester.tap(find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+
+        // Confirm the date in the date picker
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Time picker should be a Dialog, not a BottomSheet
+        expect(find.byType(Dialog), findsOneWidget);
+        expect(find.byType(BottomSheet), findsNothing);
+      });
+
+      testWidgets('time picker dialog has Cancel and OK buttons',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(Dialog), findsOneWidget);
+        expect(find.text('Cancel'), findsOneWidget);
+        // Two OK buttons exist: one from date picker (dismissed) and one in time dialog
+        expect(find.text('OK'), findsOneWidget);
+      });
+
+      testWidgets('canceling date picker does not open time picker',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        // No dialog or bottom sheet should remain open
+        expect(find.byType(Dialog), findsNothing);
+        expect(find.byType(DatePickerDialog), findsNothing);
+      });
+
+      testWidgets('canceling time picker does not update start time',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+
+        // Confirm date
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Cancel the time picker
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        // Start time subtitle should still show 'Not selected'
+        expect(find.text('Not selected'), findsWidgets);
+      });
+
+      testWidgets('tapping end time without start time shows snackbar',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.ancestor(
+          of: find.text('End Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(find.text('Please select start time first'), findsOneWidget);
+        // No Dialog should have opened
+        expect(find.byType(Dialog), findsNothing);
+      });
+
+      testWidgets('end time picker opens as Dialog after start time set',
+          (tester) async {
+        await tester.pumpWidget(createTestWidget());
+
+        // Set start time first
+        await tester.tap(find.ancestor(
+          of: find.text('Start Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK')); // Confirm date
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK')); // Confirm time
+        await tester.pumpAndSettle();
+
+        // Now tap end time
+        await tester.tap(find.ancestor(
+          of: find.text('End Time'),
+          matching: find.byType(ListTile),
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(Dialog), findsOneWidget);
+        expect(find.byType(BottomSheet), findsNothing);
+      });
     });
 
     group('Participant Sliders', () {


### PR DESCRIPTION
## Summary

- **Cupertino drum-roll time picker** replaces the Material time picker on both game creation and training session creation, displayed as a centered Dialog (consistent position with the date picker)
- **Themed date picker**: white background, blue header/title/buttons, selected day shows a white fill with blue border circle; today's date has no highlight circle
- **Past-time prevention**: when today is selected, the time picker minimum is set to now + 1h; a hint shows the earliest selectable time
- **Training end-time enforcement**: end time picker enforces end ≥ start via `minimumDate`; tapping end time before setting start time shows a snackbar
- **`orLater` localization key** added to all 5 languages (EN, FR, DE, ES, IT)
- **Android adaptive icon**: vector foreground (blue volleyball on 108dp safe-zone canvas) + white background via `mipmap-anydpi-v26` adaptive icon definitions, fixing the pixelated blue border on Android 8+ launchers; legacy PNGs retained as fallback for Android < 8

## Test plan

- [x] Widget tests: 5 new tests on `GameCreationPage` — centered Dialog, Cancel/OK buttons, cancel date picker skips time picker, cancel time picker leaves field unchanged, confirm dispatches future `SetDateTime`
- [x] Widget tests: 6 new tests on `TrainingSessionCreationPage` — centered Dialog after date confirm, Cancel/OK, cancel date picker, cancel time picker, snackbar when end time tapped without start, end time Dialog after start set
- [x] All 61 widget tests for both pages pass (`flutter test test/widget/features/games/... test/widget/features/training/...`)
- [x] Full unit + widget suite passes (`flutter test test/unit/ test/widget/`)
- [x] `flutter analyze` — no errors (pre-existing warnings in generated freezed files only)
- [x] Android debug APK builds successfully with adaptive icon resources