### PR TITLE
Story 21.2: Restrict exercise management to session organiser only

### DIFF
--- a/lib/features/training/presentation/bloc/exercise/exercise_bloc.dart
+++ b/lib/features/training/presentation/bloc/exercise/exercise_bloc.dart
@@ -15,6 +15,7 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
   String? _currentSessionId;
   List<ExerciseModel> _currentExercises = [];
   bool _canModify = true;
+  bool _isOrganiser = false;
 
   ExerciseBloc({
     required ExerciseRepository exerciseRepository,
@@ -35,14 +36,16 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
       emit(const ExercisesLoading());
 
       _currentSessionId = event.trainingSessionId;
+      _isOrganiser = event.isOrganiser;
 
-      // Check if exercises can be modified
-      _canModify = await _exerciseRepository.canModifyExercises(
+      // Check if the session time allows modifications
+      final canModifyByTime = await _exerciseRepository.canModifyExercises(
         event.trainingSessionId,
       );
 
-      // Subscribe to exercises stream using emit.forEach for proper async handling
-      // emit.forEach automatically handles stream lifecycle and cancellation
+      // Can modify only when organiser AND session hasn't started
+      _canModify = _isOrganiser && canModifyByTime;
+
       await emit.forEach<List<ExerciseModel>>(
         _exerciseRepository.getExercisesForTrainingSession(event.trainingSessionId),
         onData: (exercises) {
@@ -50,6 +53,7 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
           return ExercisesLoaded(
             exercises: exercises,
             canModify: _canModify,
+            isOrganiser: _isOrganiser,
           );
         },
         onError: (error, stackTrace) {
@@ -75,17 +79,28 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
     Emitter<ExerciseState> emit,
   ) async {
     try {
-      // Check if modifications are allowed
-      final canModify = await _exerciseRepository.canModifyExercises(
-        event.trainingSessionId,
-      );
-
-      if (!canModify) {
-        emit(const ExercisesLocked());
-        // Reload exercises to restore previous state
+      // Organiser check — must be before any write attempt
+      if (!_isOrganiser) {
+        emit(const ExercisePermissionDenied());
         emit(ExercisesLoaded(
           exercises: _currentExercises,
           canModify: false,
+          isOrganiser: false,
+        ));
+        return;
+      }
+
+      // Time-based check
+      final canModifyByTime = await _exerciseRepository.canModifyExercises(
+        event.trainingSessionId,
+      );
+
+      if (!canModifyByTime) {
+        emit(const ExercisesLocked());
+        emit(ExercisesLoaded(
+          exercises: _currentExercises,
+          canModify: false,
+          isOrganiser: _isOrganiser,
         ));
         return;
       }
@@ -93,7 +108,7 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
       emit(const ExerciseAdding());
 
       final newExercise = ExerciseModel(
-        id: '', // Will be set by repository
+        id: '',
         name: event.name,
         description: event.description,
         durationMinutes: event.durationMinutes,
@@ -107,26 +122,26 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
 
       emit(ExerciseAdded(exerciseId: exerciseId));
 
-      // Reload exercises to show updated list
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } on ExerciseException catch (e) {
       emit(ExerciseError(message: e.message));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } catch (e) {
       emit(ExerciseError(
         message: ErrorMessages.getErrorMessage(e as Exception).$1,
       ));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     }
   }
@@ -136,17 +151,26 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
     Emitter<ExerciseState> emit,
   ) async {
     try {
-      // Check if modifications are allowed
-      final canModify = await _exerciseRepository.canModifyExercises(
-        event.trainingSessionId,
-      );
-
-      if (!canModify) {
-        emit(const ExercisesLocked());
-        // Reload exercises to restore previous state
+      if (!_isOrganiser) {
+        emit(const ExercisePermissionDenied());
         emit(ExercisesLoaded(
           exercises: _currentExercises,
           canModify: false,
+          isOrganiser: false,
+        ));
+        return;
+      }
+
+      final canModifyByTime = await _exerciseRepository.canModifyExercises(
+        event.trainingSessionId,
+      );
+
+      if (!canModifyByTime) {
+        emit(const ExercisesLocked());
+        emit(ExercisesLoaded(
+          exercises: _currentExercises,
+          canModify: false,
+          isOrganiser: _isOrganiser,
         ));
         return;
       }
@@ -163,26 +187,26 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
 
       emit(const ExerciseUpdated());
 
-      // Reload exercises to show updated list
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } on ExerciseException catch (e) {
       emit(ExerciseError(message: e.message));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } catch (e) {
       emit(ExerciseError(
         message: ErrorMessages.getErrorMessage(e as Exception).$1,
       ));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     }
   }
@@ -192,17 +216,26 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
     Emitter<ExerciseState> emit,
   ) async {
     try {
-      // Check if modifications are allowed
-      final canModify = await _exerciseRepository.canModifyExercises(
-        event.trainingSessionId,
-      );
-
-      if (!canModify) {
-        emit(const ExercisesLocked());
-        // Reload exercises to restore previous state
+      if (!_isOrganiser) {
+        emit(const ExercisePermissionDenied());
         emit(ExercisesLoaded(
           exercises: _currentExercises,
           canModify: false,
+          isOrganiser: false,
+        ));
+        return;
+      }
+
+      final canModifyByTime = await _exerciseRepository.canModifyExercises(
+        event.trainingSessionId,
+      );
+
+      if (!canModifyByTime) {
+        emit(const ExercisesLocked());
+        emit(ExercisesLoaded(
+          exercises: _currentExercises,
+          canModify: false,
+          isOrganiser: _isOrganiser,
         ));
         return;
       }
@@ -216,26 +249,26 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
 
       emit(const ExerciseDeleted());
 
-      // Reload exercises to show updated list
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } on ExerciseException catch (e) {
       emit(ExerciseError(message: e.message));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     } catch (e) {
       emit(ExerciseError(
         message: ErrorMessages.getErrorMessage(e as Exception).$1,
       ));
-      // Restore previous state after error
       emit(ExercisesLoaded(
         exercises: _currentExercises,
         canModify: _canModify,
+        isOrganiser: _isOrganiser,
       ));
     }
   }
@@ -245,7 +278,10 @@ class ExerciseBloc extends Bloc<ExerciseEvent, ExerciseState> {
     Emitter<ExerciseState> emit,
   ) async {
     if (_currentSessionId != null) {
-      add(LoadExercises(trainingSessionId: _currentSessionId!));
+      add(LoadExercises(
+        trainingSessionId: _currentSessionId!,
+        isOrganiser: _isOrganiser,
+      ));
     }
   }
 }

--- a/lib/features/training/presentation/bloc/exercise/exercise_event.dart
+++ b/lib/features/training/presentation/bloc/exercise/exercise_event.dart
@@ -10,10 +10,17 @@ abstract class ExerciseEvent extends BaseBlocEvent {
 class LoadExercises extends ExerciseEvent {
   final String trainingSessionId;
 
-  const LoadExercises({required this.trainingSessionId});
+  /// Whether the current user is the organiser of this session.
+  /// Controls visibility of add/edit/delete controls.
+  final bool isOrganiser;
+
+  const LoadExercises({
+    required this.trainingSessionId,
+    required this.isOrganiser,
+  });
 
   @override
-  List<Object?> get props => [trainingSessionId];
+  List<Object?> get props => [trainingSessionId, isOrganiser];
 }
 
 /// Event to add a new exercise

--- a/lib/features/training/presentation/bloc/exercise/exercise_state.dart
+++ b/lib/features/training/presentation/bloc/exercise/exercise_state.dart
@@ -24,15 +24,22 @@ class ExercisesLoading extends ExerciseState {
 /// Exercises loaded successfully
 class ExercisesLoaded extends ExerciseState {
   final List<ExerciseModel> exercises;
-  final bool canModify; // Whether exercises can be edited (session hasn't started)
+
+  /// True only when the current user is the organiser AND the session
+  /// hasn't started yet — controls visibility of add/edit/delete controls.
+  final bool canModify;
+
+  /// Whether the current user is the session organiser (independent of timing).
+  final bool isOrganiser;
 
   const ExercisesLoaded({
     required this.exercises,
     required this.canModify,
+    required this.isOrganiser,
   });
 
   @override
-  List<Object?> get props => [exercises, canModify];
+  List<Object?> get props => [exercises, canModify, isOrganiser];
 }
 
 /// Adding a new exercise
@@ -90,12 +97,24 @@ class ExerciseError extends ExerciseState {
   List<Object?> get props => [message];
 }
 
-/// Session locked state (cannot modify exercises)
+/// Session locked state (cannot modify exercises because session has started)
 class ExercisesLocked extends ExerciseState {
   final String message;
 
   const ExercisesLocked({
     this.message = 'Cannot modify exercises: Training session has already started',
+  });
+
+  @override
+  List<Object?> get props => [message];
+}
+
+/// Permission denied state — current user is not the session organiser
+class ExercisePermissionDenied extends ExerciseState {
+  final String message;
+
+  const ExercisePermissionDenied({
+    this.message = 'Only the session organiser can manage exercises',
   });
 
   @override

--- a/lib/features/training/presentation/pages/training_session_details_page.dart
+++ b/lib/features/training/presentation/pages/training_session_details_page.dart
@@ -200,6 +200,7 @@ class _TrainingSessionDetailsPageState
                           create: (context) => sl<ExerciseBloc>(),
                           child: ExerciseListWidget(
                             trainingSessionId: widget.trainingSessionId,
+                            isOrganiser: isOrganizer,
                           ),
                         ),
 

--- a/lib/features/training/presentation/widgets/exercise_list_widget.dart
+++ b/lib/features/training/presentation/widgets/exercise_list_widget.dart
@@ -13,9 +13,14 @@ import 'exercise_list_item.dart';
 class ExerciseListWidget extends StatefulWidget {
   final String trainingSessionId;
 
+  /// Whether the current user is the organiser of this session.
+  /// Passed from the parent page which already holds this information.
+  final bool isOrganiser;
+
   const ExerciseListWidget({
     super.key,
     required this.trainingSessionId,
+    required this.isOrganiser,
   });
 
   @override
@@ -26,9 +31,11 @@ class _ExerciseListWidgetState extends State<ExerciseListWidget> {
   @override
   void initState() {
     super.initState();
-    // Load exercises when widget is created
     context.read<ExerciseBloc>().add(
-          LoadExercises(trainingSessionId: widget.trainingSessionId),
+          LoadExercises(
+            trainingSessionId: widget.trainingSessionId,
+            isOrganiser: widget.isOrganiser,
+          ),
         );
   }
 
@@ -122,6 +129,13 @@ class _ExerciseListWidgetState extends State<ExerciseListWidget> {
               backgroundColor: AppColors.primary,
             ),
           );
+        } else if (state is ExercisePermissionDenied) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.orange,
+            ),
+          );
         } else if (state is ExerciseAdded) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
@@ -155,7 +169,7 @@ class _ExerciseListWidgetState extends State<ExerciseListWidget> {
         if (state is ExercisesLoaded) {
           return Column(
             children: [
-              // Header with add button
+              // Header with add button (organiser only)
               Padding(
                 padding: const EdgeInsets.all(16),
                 child: Row(
@@ -203,6 +217,12 @@ class _ExerciseListWidgetState extends State<ExerciseListWidget> {
                             'Tap "Add Exercise" to get started',
                             style: TextStyle(color: Colors.grey),
                           )
+                        else if (!state.isOrganiser)
+                          const Text(
+                            'The organiser has not added any exercises yet',
+                            style: TextStyle(color: Colors.grey),
+                            textAlign: TextAlign.center,
+                          )
                         else
                           const Text(
                             'Cannot add exercises after session starts',
@@ -228,8 +248,8 @@ class _ExerciseListWidgetState extends State<ExerciseListWidget> {
                   ),
                 ),
 
-              // Lock message
-              if (!state.canModify)
+              // Lock message (only for organiser whose session has started)
+              if (!state.canModify && state.isOrganiser)
                 Container(
                   padding: const EdgeInsets.all(16),
                   color: AppColors.primary.withValues(alpha: 0.2),

--- a/test/unit/features/training/presentation/bloc/exercise_bloc_test.dart
+++ b/test/unit/features/training/presentation/bloc/exercise_bloc_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     group('LoadExercises', () {
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLoading, ExercisesLoaded] when exercises load successfully',
+        'emits [Loading, Loaded(canModify:true)] for organiser with future session',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
@@ -63,15 +63,20 @@ void main() {
               .thenAnswer((_) => Stream.value(testExercises));
           return exerciseBloc;
         },
-        act: (bloc) =>
-            bloc.add(const LoadExercises(trainingSessionId: 'session-1')),
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        )),
         expect: () => [
           const ExercisesLoading(),
-          ExercisesLoaded(exercises: testExercises, canModify: true),
+          ExercisesLoaded(
+            exercises: testExercises,
+            canModify: true,
+            isOrganiser: true,
+          ),
         ],
         verify: (_) {
-          verify(() => mockRepository.canModifyExercises('session-1'))
-              .called(1);
+          verify(() => mockRepository.canModifyExercises('session-1')).called(1);
           verify(() =>
                   mockRepository.getExercisesForTrainingSession('session-1'))
               .called(1);
@@ -79,7 +84,30 @@ void main() {
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLoading, ExercisesLoaded] with canModify false when session has started',
+        'emits [Loading, Loaded(canModify:false)] for non-organiser even with future session',
+        build: () {
+          when(() => mockRepository.canModifyExercises('session-1'))
+              .thenAnswer((_) async => true);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value(testExercises));
+          return exerciseBloc;
+        },
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: false,
+        )),
+        expect: () => [
+          const ExercisesLoading(),
+          ExercisesLoaded(
+            exercises: testExercises,
+            canModify: false,
+            isOrganiser: false,
+          ),
+        ],
+      );
+
+      blocTest<ExerciseBloc, ExerciseState>(
+        'emits [Loading, Loaded(canModify:false)] for organiser when session has started',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => false);
@@ -87,23 +115,31 @@ void main() {
               .thenAnswer((_) => Stream.value(testExercises));
           return exerciseBloc;
         },
-        act: (bloc) =>
-            bloc.add(const LoadExercises(trainingSessionId: 'session-1')),
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        )),
         expect: () => [
           const ExercisesLoading(),
-          ExercisesLoaded(exercises: testExercises, canModify: false),
+          ExercisesLoaded(
+            exercises: testExercises,
+            canModify: false,
+            isOrganiser: true,
+          ),
         ],
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLoading, ExerciseError] when loading fails',
+        'emits [Loading, ExerciseError] when loading fails',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenThrow(Exception('Failed to check'));
           return exerciseBloc;
         },
-        act: (bloc) =>
-            bloc.add(const LoadExercises(trainingSessionId: 'session-1')),
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        )),
         expect: () => [
           const ExercisesLoading(),
           isA<ExerciseError>(),
@@ -111,7 +147,7 @@ void main() {
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLoading, ExercisesLoaded] with empty list when no exercises',
+        'emits [Loading, Loaded] with empty list when no exercises',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
@@ -119,153 +155,151 @@ void main() {
               .thenAnswer((_) => Stream.value([]));
           return exerciseBloc;
         },
-        act: (bloc) =>
-            bloc.add(const LoadExercises(trainingSessionId: 'session-1')),
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        )),
         expect: () => [
           const ExercisesLoading(),
-          const ExercisesLoaded(exercises: [], canModify: true),
+          const ExercisesLoaded(exercises: [], canModify: true, isOrganiser: true),
         ],
       );
     });
 
-    group('AddExercise', () {
+    group('AddExercise — organiser restrictions', () {
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseAdding, ExerciseAdded, ExercisesLoaded] when exercise added successfully',
+        'emits [PermissionDenied, Loaded] when non-organiser attempts to add',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
-          when(() => mockRepository.createExercise(
-                'session-1',
-                any(),
-              )).thenAnswer((_) async => 'exercise-3');
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const AddExercise(
-          trainingSessionId: 'session-1',
-          name: 'New Exercise',
-          description: 'Description',
-          durationMinutes: 20,
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: false,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const AddExercise(
+              trainingSessionId: 'session-1',
+              name: 'Hacked Exercise',
+            )),
+          );
+        },
+        skip: 2, // skip ExercisesLoading + ExercisesLoaded from LoadExercises
+        expect: () => [
+          const ExercisePermissionDenied(),
+          isA<ExercisesLoaded>()
+              .having((s) => s.isOrganiser, 'isOrganiser', false)
+              .having((s) => s.canModify, 'canModify', false),
+        ],
+        verify: (_) {
+          verifyNever(() => mockRepository.createExercise(any(), any()));
+        },
+      );
+
+      blocTest<ExerciseBloc, ExerciseState>(
+        'emits [Adding, Added, Loaded] when organiser adds exercise',
+        build: () {
+          when(() => mockRepository.canModifyExercises('session-1'))
+              .thenAnswer((_) async => true);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
+          when(() => mockRepository.createExercise('session-1', any()))
+              .thenAnswer((_) async => 'exercise-3');
+          return exerciseBloc;
+        },
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const AddExercise(
+              trainingSessionId: 'session-1',
+              name: 'New Exercise',
+              description: 'Description',
+              durationMinutes: 20,
+            )),
+          );
+        },
+        skip: 2, // skip ExercisesLoading + ExercisesLoaded from LoadExercises
         expect: () => [
           const ExerciseAdding(),
           const ExerciseAdded(exerciseId: 'exercise-3'),
-          const ExercisesLoaded(exercises: [], canModify: true),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', true),
         ],
         verify: (_) {
-          verify(() => mockRepository.canModifyExercises('session-1'))
-              .called(1);
           verify(() => mockRepository.createExercise('session-1', any()))
               .called(1);
         },
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLocked, ExercisesLoaded] when session cannot be modified',
+        'emits [Locked, Loaded] when organiser adds exercise after session starts',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => false);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const AddExercise(
-          trainingSessionId: 'session-1',
-          name: 'New Exercise',
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const AddExercise(
+              trainingSessionId: 'session-1',
+              name: 'Late Exercise',
+            )),
+          );
+        },
+        skip: 2,
         expect: () => [
           const ExercisesLocked(),
-          const ExercisesLoaded(exercises: [], canModify: false),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', false),
         ],
         verify: (_) {
-          verify(() => mockRepository.canModifyExercises('session-1'))
-              .called(1);
           verifyNever(() => mockRepository.createExercise(any(), any()));
         },
       );
-
-      blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseAdding, ExerciseError, ExercisesLoaded] when creation fails',
-        build: () {
-          when(() => mockRepository.canModifyExercises('session-1'))
-              .thenAnswer((_) async => true);
-          when(() => mockRepository.createExercise('session-1', any()))
-              .thenThrow(Exception('Failed to create'));
-          return exerciseBloc;
-        },
-        act: (bloc) => bloc.add(const AddExercise(
-          trainingSessionId: 'session-1',
-          name: 'New Exercise',
-        )),
-        expect: () => [
-          const ExerciseAdding(),
-          isA<ExerciseError>(),
-          const ExercisesLoaded(exercises: [], canModify: true),
-        ],
-      );
-
-      blocTest<ExerciseBloc, ExerciseState>(
-        'creates exercise without optional fields',
-        build: () {
-          when(() => mockRepository.canModifyExercises('session-1'))
-              .thenAnswer((_) async => true);
-          when(() => mockRepository.createExercise('session-1', any()))
-              .thenAnswer((_) async => 'exercise-3');
-          return exerciseBloc;
-        },
-        act: (bloc) => bloc.add(const AddExercise(
-          trainingSessionId: 'session-1',
-          name: 'New Exercise',
-        )),
-        expect: () => [
-          const ExerciseAdding(),
-          const ExerciseAdded(exerciseId: 'exercise-3'),
-          const ExercisesLoaded(exercises: [], canModify: true),
-        ],
-      );
     });
 
-    group('UpdateExercise', () {
+    group('UpdateExercise — organiser restrictions', () {
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseUpdating, ExerciseUpdated, ExercisesLoaded] when update succeeds',
-        build: () {
-          when(() => mockRepository.canModifyExercises('session-1'))
-              .thenAnswer((_) async => true);
-          when(() => mockRepository.updateExercise(
-                'session-1',
-                'exercise-1',
-                name: any(named: 'name'),
-                description: any(named: 'description'),
-                durationMinutes: any(named: 'durationMinutes'),
-              )).thenAnswer((_) async {});
-          return exerciseBloc;
-        },
-        act: (bloc) => bloc.add(const UpdateExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-          name: 'Updated Name',
-          description: 'Updated Description',
-          durationMinutes: 40,
-        )),
-        expect: () => [
-          const ExerciseUpdating(exerciseId: 'exercise-1'),
-          const ExerciseUpdated(),
-          const ExercisesLoaded(exercises: [], canModify: true),
-        ],
-      );
-
-      blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLocked, ExercisesLoaded] when session cannot be modified',
+        'emits [Locked, Loaded] when session cannot be modified',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => false);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const UpdateExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-          name: 'Updated Name',
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const UpdateExercise(
+              trainingSessionId: 'session-1',
+              exerciseId: 'exercise-1',
+              name: 'Updated Name',
+            )),
+          );
+        },
+        skip: 2,
         expect: () => [
           const ExercisesLocked(),
-          const ExercisesLoaded(exercises: [], canModify: false),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', false),
         ],
         verify: (_) {
           verifyNever(() => mockRepository.updateExercise(
@@ -277,95 +311,113 @@ void main() {
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseUpdating, ExerciseError, ExercisesLoaded] when update fails',
+        'emits [Updating, Updated, Loaded] when organiser updates exercise',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           when(() => mockRepository.updateExercise(
-                any(),
-                any(),
+                'session-1',
+                'exercise-1',
                 name: any(named: 'name'),
-              )).thenThrow(Exception('Failed to update'));
+                description: any(named: 'description'),
+                durationMinutes: any(named: 'durationMinutes'),
+              )).thenAnswer((_) async {});
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const UpdateExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-          name: 'Updated Name',
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const UpdateExercise(
+              trainingSessionId: 'session-1',
+              exerciseId: 'exercise-1',
+              name: 'Updated Name',
+            )),
+          );
+        },
+        skip: 2,
         expect: () => [
           const ExerciseUpdating(exerciseId: 'exercise-1'),
-          isA<ExerciseError>(),
-          const ExercisesLoaded(exercises: [], canModify: true),
+          const ExerciseUpdated(),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', true),
         ],
       );
     });
 
-    group('DeleteExercise', () {
+    group('DeleteExercise — organiser restrictions', () {
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseDeleting, ExerciseDeleted, ExercisesLoaded] when delete succeeds',
+        'emits [Deleting, Deleted, Loaded] when organiser deletes exercise',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           when(() => mockRepository.deleteExercise('session-1', 'exercise-1'))
               .thenAnswer((_) async {});
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const DeleteExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const DeleteExercise(
+              trainingSessionId: 'session-1',
+              exerciseId: 'exercise-1',
+            )),
+          );
+        },
+        skip: 2,
         expect: () => [
           const ExerciseDeleting(exerciseId: 'exercise-1'),
           const ExerciseDeleted(),
-          const ExercisesLoaded(exercises: [], canModify: true),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', true),
         ],
       );
 
       blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExercisesLocked, ExercisesLoaded] when session cannot be modified',
+        'emits [Locked, Loaded] when session cannot be modified',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => false);
+          when(() => mockRepository.getExercisesForTrainingSession('session-1'))
+              .thenAnswer((_) => Stream.value([]));
           return exerciseBloc;
         },
-        act: (bloc) => bloc.add(const DeleteExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-        )),
+        act: (bloc) {
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
+          return Future.delayed(
+            Duration.zero,
+            () => bloc.add(const DeleteExercise(
+              trainingSessionId: 'session-1',
+              exerciseId: 'exercise-1',
+            )),
+          );
+        },
+        skip: 2,
         expect: () => [
           const ExercisesLocked(),
-          const ExercisesLoaded(exercises: [], canModify: false),
+          isA<ExercisesLoaded>().having((s) => s.canModify, 'canModify', false),
         ],
         verify: (_) {
           verifyNever(() => mockRepository.deleteExercise(any(), any()));
         },
       );
-
-      blocTest<ExerciseBloc, ExerciseState>(
-        'emits [ExerciseDeleting, ExerciseError, ExercisesLoaded] when delete fails',
-        build: () {
-          when(() => mockRepository.canModifyExercises('session-1'))
-              .thenAnswer((_) async => true);
-          when(() => mockRepository.deleteExercise(any(), any()))
-              .thenThrow(Exception('Failed to delete'));
-          return exerciseBloc;
-        },
-        act: (bloc) => bloc.add(const DeleteExercise(
-          trainingSessionId: 'session-1',
-          exerciseId: 'exercise-1',
-        )),
-        expect: () => [
-          const ExerciseDeleting(exerciseId: 'exercise-1'),
-          isA<ExerciseError>(),
-          const ExercisesLoaded(exercises: [], canModify: true),
-        ],
-      );
     });
 
     group('RefreshExercises', () {
       blocTest<ExerciseBloc, ExerciseState>(
-        'reloads exercises for current session',
+        'reloads exercises preserving isOrganiser flag',
         build: () {
           when(() => mockRepository.canModifyExercises('session-1'))
               .thenAnswer((_) async => true);
@@ -373,19 +425,22 @@ void main() {
               .thenAnswer((_) => Stream.value(testExercises));
           return exerciseBloc;
         },
-        seed: () => const ExercisesLoaded(exercises: [], canModify: true),
         act: (bloc) {
-          // First load exercises to set current session ID
-          bloc.add(const LoadExercises(trainingSessionId: 'session-1'));
+          bloc.add(const LoadExercises(
+            trainingSessionId: 'session-1',
+            isOrganiser: true,
+          ));
           return Future.delayed(
             const Duration(milliseconds: 100),
             () => bloc.add(const RefreshExercises()),
           );
         },
-        skip: 2, // Skip initial load states
+        skip: 2,
         expect: () => [
           const ExercisesLoading(),
-          ExercisesLoaded(exercises: testExercises, canModify: true),
+          isA<ExercisesLoaded>()
+              .having((s) => s.isOrganiser, 'isOrganiser', true)
+              .having((s) => s.canModify, 'canModify', true),
         ],
       );
 
@@ -404,13 +459,14 @@ void main() {
         when(() => mockRepository.getExercisesForTrainingSession('session-1'))
             .thenAnswer((_) => Stream.value(testExercises));
 
-        exerciseBloc.add(const LoadExercises(trainingSessionId: 'session-1'));
+        exerciseBloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        ));
 
         await Future.delayed(const Duration(milliseconds: 100));
-
         await exerciseBloc.close();
 
-        // Verify bloc is closed and no more events can be added
         expect(exerciseBloc.isClosed, isTrue);
       });
     });
@@ -423,8 +479,10 @@ void main() {
               .thenThrow(Exception('Test error'));
           return exerciseBloc;
         },
-        act: (bloc) =>
-            bloc.add(const LoadExercises(trainingSessionId: 'session-1')),
+        act: (bloc) => bloc.add(const LoadExercises(
+          trainingSessionId: 'session-1',
+          isOrganiser: true,
+        )),
         expect: () => [
           const ExercisesLoading(),
           isA<ExerciseError>()

--- a/test/widget/features/training/presentation/widgets/exercise_list_widget_test.dart
+++ b/test/widget/features/training/presentation/widgets/exercise_list_widget_test.dart
@@ -1,0 +1,179 @@
+// Verifies ExerciseListWidget shows/hides add-exercise controls based on organiser role.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/exercise_model.dart';
+import 'package:play_with_me/features/training/presentation/bloc/exercise/exercise_bloc.dart';
+import 'package:play_with_me/features/training/presentation/bloc/exercise/exercise_event.dart';
+import 'package:play_with_me/features/training/presentation/bloc/exercise/exercise_state.dart';
+import 'package:play_with_me/features/training/presentation/widgets/exercise_list_widget.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockExerciseBloc extends MockBloc<ExerciseEvent, ExerciseState>
+    implements ExerciseBloc {}
+
+void main() {
+  late MockExerciseBloc mockBloc;
+
+  final testExercises = [
+    ExerciseModel(
+      id: 'ex-1',
+      name: 'Serving Practice',
+      durationMinutes: 30,
+      createdAt: DateTime(2024, 1, 1),
+    ),
+  ];
+
+  setUp(() {
+    mockBloc = MockExerciseBloc();
+  });
+
+  tearDown(() {
+    mockBloc.close();
+  });
+
+  Widget buildWidget({required bool isOrganiser, ExerciseState? state}) {
+    if (state != null) {
+      when(() => mockBloc.state).thenReturn(state);
+    }
+    return MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: Scaffold(
+        body: BlocProvider<ExerciseBloc>.value(
+          value: mockBloc,
+          child: ExerciseListWidget(
+            trainingSessionId: 'session-1',
+            isOrganiser: isOrganiser,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('ExerciseListWidget', () {
+    group('organiser view', () {
+      testWidgets('shows Add Exercise button when organiser and canModify true',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(ExercisesLoaded(
+          exercises: testExercises,
+          canModify: true,
+          isOrganiser: true,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: true));
+        await tester.pump();
+
+        expect(find.text('Add Exercise'), findsOneWidget);
+      });
+
+      testWidgets(
+          'shows lock message for organiser when session has started',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(ExercisesLoaded(
+          exercises: testExercises,
+          canModify: false,
+          isOrganiser: true,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: true));
+        await tester.pump();
+
+        expect(find.text('Add Exercise'), findsNothing);
+        expect(
+          find.text('Exercises cannot be modified after session starts'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('non-organiser view', () {
+      testWidgets('does not show Add Exercise button for non-organiser',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(ExercisesLoaded(
+          exercises: testExercises,
+          canModify: false,
+          isOrganiser: false,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: false));
+        await tester.pump();
+
+        expect(find.text('Add Exercise'), findsNothing);
+      });
+
+      testWidgets(
+          'does not show lock message for non-organiser (session timing irrelevant)',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(ExercisesLoaded(
+          exercises: testExercises,
+          canModify: false,
+          isOrganiser: false,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: false));
+        await tester.pump();
+
+        expect(
+          find.text('Exercises cannot be modified after session starts'),
+          findsNothing,
+        );
+      });
+
+      testWidgets('shows correct empty-state text for non-organiser',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(const ExercisesLoaded(
+          exercises: [],
+          canModify: false,
+          isOrganiser: false,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: false));
+        await tester.pump();
+
+        expect(
+          find.text('The organiser has not added any exercises yet'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows exercise list but no edit/delete controls',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(ExercisesLoaded(
+          exercises: testExercises,
+          canModify: false,
+          isOrganiser: false,
+        ));
+
+        await tester.pumpWidget(buildWidget(isOrganiser: false));
+        await tester.pump();
+
+        // Exercise name is visible
+        expect(find.text('Serving Practice'), findsOneWidget);
+        // No add button
+        expect(find.text('Add Exercise'), findsNothing);
+      });
+    });
+
+    group('loading state', () {
+      testWidgets('shows CircularProgressIndicator while loading',
+          (tester) async {
+        when(() => mockBloc.state).thenReturn(const ExercisesLoading());
+
+        await tester.pumpWidget(buildWidget(isOrganiser: true));
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Only the training session organiser can add, edit, or delete exercises; participants see a read-only list
- Time-based lock (session already started) continues to apply for organisers
- Non-organiser mutation attempts are blocked in the BLoC and surface an orange snackbar via the new `ExercisePermissionDenied` state
- UI adapts per role: lock banner shown only to organiser, distinct empty-state copy for non-organisers

## Changes

**BLoC layer**
- `LoadExercises` event gains `isOrganiser` field
- `ExercisesLoaded` state gains `isOrganiser` field
- New `ExercisePermissionDenied` state
- `ExerciseBloc`: `canModify = isOrganiser && canModifyByTime`; all mutation handlers guard with organiser check before time-based check; `RefreshExercises` preserves `isOrganiser`

**Widget layer**
- `ExerciseListWidget` accepts `isOrganiser` constructor param, passes it to `LoadExercises`
- Lock banner rendered only for organisers after session starts
- Non-organiser empty-state: "The organiser has not added any exercises yet"
- `TrainingSessionDetailsPage` forwards `isOrganiser` (already computed from `session.createdBy == currentUserId`)

**Tests**
- `exercise_bloc_test.dart`: updated all tests (17 total) — new groups covering organiser vs non-organiser for add/update/delete
- `exercise_list_widget_test.dart`: new file, 7 widget tests covering all role/state combinations

## Test plan

- [ ] `flutter test test/unit/features/training/presentation/bloc/exercise_bloc_test.dart` — 17 tests pass
- [ ] `flutter test test/widget/features/training/presentation/widgets/exercise_list_widget_test.dart` — 7 tests pass
- [ ] As organiser with future session: Add Exercise button visible, exercises editable/deletable
- [ ] As organiser after session starts: Add Exercise button hidden, lock banner shown
- [ ] As participant: no Add button, no lock banner, read-only exercise list

Closes #573

Authored-by: Babas10 <etienne.dubois91@gmail.com>