### PR TITLE
Story 21.3: Unify RSVP badge to JOINED and add WAITING LIST badge

### DIFF
--- a/lib/features/profile/presentation/widgets/next_game_card.dart
+++ b/lib/features/profile/presentation/widgets/next_game_card.dart
@@ -209,7 +209,7 @@ class NextGameCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
         ),
         child: Text(
-          l10n.youreIn,
+          l10n.joined,
           style: const TextStyle(
             color: Colors.white,
             fontWeight: FontWeight.w600,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -248,7 +248,7 @@
   "dragPlayersToAssign": "Ziehen Sie Spieler, um sie Team A oder B zuzuweisen",
   "pendingVerification": "Überprüfung Ausstehend",
   "youreIn": "Sie sind dabei",
-  "onWaitlist": "Auf Warteliste",
+  "onWaitlist": "WARTELISTE",
   "full": "Voll",
   "joinGame": "Spiel Beitreten",
   "today": "Heute",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1271,7 +1271,7 @@
     "description": "Status badge for confirmed participation"
   },
 
-  "onWaitlist": "On Waitlist",
+  "onWaitlist": "WAITING LIST",
   "@onWaitlist": {
     "description": "Status badge for waitlist"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -248,7 +248,7 @@
   "dragPlayersToAssign": "Arrastra jugadores para asignarlos al Equipo A o B",
   "pendingVerification": "Verificación Pendiente",
   "youreIn": "Estás Inscrito",
-  "onWaitlist": "En Lista de Espera",
+  "onWaitlist": "LISTA DE ESPERA",
   "full": "Lleno",
   "joinGame": "Unirse al Partido",
   "today": "Hoy",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -248,7 +248,7 @@
   "dragPlayersToAssign": "Faites glisser les joueurs pour les assigner à l'Équipe A ou B",
   "pendingVerification": "Vérification en Attente",
   "youreIn": "Vous êtes inscrit",
-  "onWaitlist": "Sur Liste d'Attente",
+  "onWaitlist": "LISTE D'ATTENTE",
   "full": "Complet",
   "joinGame": "Rejoindre le Match",
   "today": "Aujourd'hui",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -248,7 +248,7 @@
   "dragPlayersToAssign": "Trascina i giocatori per assegnarli alla Squadra A o B",
   "pendingVerification": "Verifica in Sospeso",
   "youreIn": "Sei Iscritto",
-  "onWaitlist": "In Lista d'Attesa",
+  "onWaitlist": "LISTA D'ATTESA",
   "full": "Completo",
   "joinGame": "Unisciti alla Partita",
   "today": "Oggi",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1595,7 +1595,7 @@ abstract class AppLocalizations {
   /// Status badge for waitlist
   ///
   /// In en, this message translates to:
-  /// **'On Waitlist'**
+  /// **'WAITING LIST'**
   String get onWaitlist;
 
   /// Status badge when game is full

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -809,7 +809,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get youreIn => 'Sie sind dabei';
 
   @override
-  String get onWaitlist => 'Auf Warteliste';
+  String get onWaitlist => 'WARTELISTE';
 
   @override
   String get full => 'Voll';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -798,7 +798,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get youreIn => 'You\'re In';
 
   @override
-  String get onWaitlist => 'On Waitlist';
+  String get onWaitlist => 'WAITING LIST';
 
   @override
   String get full => 'Full';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -807,7 +807,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get youreIn => 'Estás Inscrito';
 
   @override
-  String get onWaitlist => 'En Lista de Espera';
+  String get onWaitlist => 'LISTA DE ESPERA';
 
   @override
   String get full => 'Lleno';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -813,7 +813,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get youreIn => 'Vous êtes inscrit';
 
   @override
-  String get onWaitlist => 'Sur Liste d\'Attente';
+  String get onWaitlist => 'LISTE D\'ATTENTE';
 
   @override
   String get full => 'Complet';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -806,7 +806,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get youreIn => 'Sei Iscritto';
 
   @override
-  String get onWaitlist => 'In Lista d\'Attesa';
+  String get onWaitlist => 'LISTA D\'ATTESA';
 
   @override
   String get full => 'Completo';

--- a/test/widget/features/profile/presentation/widgets/next_game_card_test.dart
+++ b/test/widget/features/profile/presentation/widgets/next_game_card_test.dart
@@ -1,4 +1,4 @@
-// Widget tests for NextGameCard
+// Verifies NextGameCard RSVP badge shows "JOINED" and "WAITING LIST" per Story 21.3.
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -91,8 +91,32 @@ void main() {
       await pumpNextGameCard(tester, game: game);
 
       // Assert
-      // GameListItem shows "You're In" badge when user is a player
-      expect(find.text("You're In"), findsOneWidget);
+      expect(find.text('JOINED'), findsOneWidget);
+    });
+
+    testWidgets('shows WAITING LIST badge when user is on waitlist', (tester) async {
+      // Arrange
+      final game = GameModel(
+        id: 'game-1',
+        title: 'Test Game',
+        groupId: 'group-1',
+        createdBy: 'creator-1',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        scheduledAt: DateTime.now().add(const Duration(days: 1)),
+        location: const GameLocation(name: 'Court 1'),
+        status: GameStatus.scheduled,
+        playerIds: const ['other-user-1', 'other-user-2'],
+        waitlistIds: const [testUserId],
+        maxPlayers: 2,
+        minPlayers: 2,
+      );
+
+      // Act
+      await pumpNextGameCard(tester, game: game);
+
+      // Assert
+      expect(find.text('WAITING LIST'), findsOneWidget);
+      expect(find.text('JOINED'), findsNothing);
     });
 
     testWidgets('calls onTap callback when game card is tapped', (tester) async {


### PR DESCRIPTION
## Summary

- Both homepage cards (next game and next training session) now show **JOINED** for confirmed RSVP — previously the game card showed "You're In" while the training card showed "JOINED"
- Waitlist badge text updated to all-caps style (**WAITING LIST**) across all 5 languages to match the visual style of the JOINED badge
- No new keys added — reused existing `onWaitlist` key with updated values

## Changes

**Widget**
- `next_game_card.dart`: `l10n.youreIn` → `l10n.joined` for the confirmed RSVP badge (waitlist badge already used `l10n.onWaitlist` with distinct orange styling)

**Localization (all 5 ARB files + regenerated)**
- `onWaitlist`: EN "WAITING LIST", FR "LISTE D'ATTENTE", DE "WARTELISTE", ES "LISTA DE ESPERA", IT "LISTA D'ATTESA"

**Tests**
- `next_game_card_test.dart`: updated existing badge test ("You're In" → "JOINED") + new test for WAITING LIST badge when user is on waitlist

## Test plan

- [ ] `flutter test test/widget/features/profile/presentation/widgets/next_game_card_test.dart` — all tests pass
- [ ] `flutter test test/widget/features/profile/presentation/widgets/next_training_session_card_test.dart` — all tests pass
- [ ] Homepage game card shows "JOINED" for confirmed players
- [ ] Homepage game card shows "WAITING LIST" for waitlisted users
- [ ] Homepage training session card shows "JOINED" for participants
- [ ] No "You're in" text remains anywhere in the app

Closes #574

Authored-by: Babas10 <etienne.dubois91@gmail.com>