### PR TITLE
Story 21.5: Friend request already sent — show green tick instead of red error

### DIFF
--- a/lib/features/friends/presentation/bloc/friend_bloc.dart
+++ b/lib/features/friends/presentation/bloc/friend_bloc.dart
@@ -80,6 +80,13 @@ class FriendBloc extends Bloc<FriendEvent, FriendState> {
       // Reload the data to show updated state
       add(const FriendEvent.loadRequested());
     } on FriendshipException catch (e) {
+      // Story 21.5: show green tick instead of red error when request already exists
+      if (e.code == 'already-exists' || e.code == 'already-friends' || e.code == 'request-exists') {
+        emit(const FriendState.actionSuccess(
+          message: 'Friend request already pending',
+        ));
+        return;
+      }
       emit(FriendState.error(message: e.message));
     } catch (e) {
       final (message, _) = e is Exception

--- a/lib/features/friends/presentation/pages/my_community_page.dart
+++ b/lib/features/friends/presentation/pages/my_community_page.dart
@@ -35,6 +35,7 @@ class _MyCommunityPageContent extends StatefulWidget {
 class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  int _lastRequestCount = 0;
 
   @override
   void initState() {
@@ -63,7 +64,18 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
-    return Scaffold(
+    return BlocListener<FriendRequestCountBloc, FriendRequestCountState>(
+      listener: (context, countState) {
+        if (countState is FriendRequestCountLoaded) {
+          final newCount = countState.count;
+          if (newCount > _lastRequestCount) {
+            // A new request arrived — refresh the list so badge and content stay in sync
+            context.read<FriendBloc>().add(const FriendEvent.loadRequested());
+          }
+          _lastRequestCount = newCount;
+        }
+      },
+      child: Scaffold(
         body: Column(
           children: [
             Container(
@@ -252,7 +264,8 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
           ],
         ),
         floatingActionButton: _buildAddFriendButton(context, l10n),
-      );
+      ),
+    );
   }
 
   Widget _buildAddFriendButton(BuildContext context, AppLocalizations l10n) {

--- a/test/unit/features/friends/presentation/bloc/friend_bloc_test.dart
+++ b/test/unit/features/friends/presentation/bloc/friend_bloc_test.dart
@@ -303,6 +303,43 @@ void main() {
           const FriendState.error(message: 'User not found'),
         ],
       );
+
+      // Story 21.5: already-exists (Cloud Function code) should show green tick
+      blocTest<FriendBloc, FriendState>(
+        'emits [actionSuccess] instead of error when request already exists (already-exists / pending request)',
+        build: () {
+          when(() => mockFriendRepository.sendFriendRequest(any()))
+              .thenThrow(FriendshipException(
+            'A friend request already exists between you and this user',
+            code: 'already-exists',
+          ));
+          return friendBloc;
+        },
+        act: (bloc) => bloc.add(
+          const FriendEvent.requestSent(targetUserId: 'target-user-id'),
+        ),
+        expect: () => [
+          const FriendState.actionSuccess(message: 'Friend request already pending'),
+        ],
+      );
+
+      blocTest<FriendBloc, FriendState>(
+        'emits [actionSuccess] instead of error when already friends (already-exists / accepted)',
+        build: () {
+          when(() => mockFriendRepository.sendFriendRequest(any()))
+              .thenThrow(FriendshipException(
+            'You are already friends with this user',
+            code: 'already-exists',
+          ));
+          return friendBloc;
+        },
+        act: (bloc) => bloc.add(
+          const FriendEvent.requestSent(targetUserId: 'target-user-id'),
+        ),
+        expect: () => [
+          const FriendState.actionSuccess(message: 'Friend request already pending'),
+        ],
+      );
     });
 
     group('FriendRequestAccepted', () {


### PR DESCRIPTION
## Summary

- When sending a friend request that already exists (`already-exists` error from Cloud Function — covers both pending request and already-friends cases), the app now shows a green tick instead of a red error snackbar
- Fixed badge/list desync: when a new request arrives via Firestore real-time stream, the requests list is automatically refreshed so the badge and list content are always in sync

## Changes

- `lib/features/friends/presentation/bloc/friend_bloc.dart`: emit `actionSuccess` instead of `error` for `already-exists` error code in `_onRequestSent`
- `lib/features/friends/presentation/pages/my_community_page.dart`: `BlocListener` on `FriendRequestCountBloc` triggers `FriendBloc.loadRequested()` when count increases
- `test/unit/features/friends/presentation/bloc/friend_bloc_test.dart`: 2 new tests covering both duplicate-request scenarios

## Test plan

- [ ] Send a friend request to a user you already sent one to → green tick, no red error
- [ ] Send a friend request to a user who already sent you one → green tick, no red error
- [ ] Receive a friend request while on MyCommunity page → badge updates AND request appears in list simultaneously
- [ ] Run `flutter test test/unit/features/friends/presentation/bloc/friend_bloc_test.dart` → all 20 tests pass

Closes #576