### PR TITLE
Story 22.1: Pin all GitHub Action versions to commit SHAs

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -61,7 +61,7 @@ jobs:
           echo "✅ Firebase configurations generated securely from secrets"
 
       - name: 📤 Upload Firebase Configs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: firebase-configs
           path: |
@@ -83,23 +83,23 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
           cache: true
 
       - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: 💾 Setup Gradle Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
         with:
           path: |
             ~/.gradle/caches
@@ -113,7 +113,7 @@ jobs:
         run: flutter pub get
 
       - name: 📥 Download Firebase Configs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: firebase-configs
 
@@ -123,7 +123,7 @@ jobs:
           flutter build apk --flavor ${{ matrix.flavor }} -t lib/main_${{ matrix.flavor }}.dart --release
 
       - name: 📤 Upload Android APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: android-apk-${{ matrix.flavor }}
           path: build/app/outputs/flutter-apk/*.apk
@@ -142,10 +142,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -155,7 +155,7 @@ jobs:
         run: flutter pub get
 
       - name: 📥 Download Firebase Configs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: firebase-configs
 
@@ -165,7 +165,7 @@ jobs:
           flutter build web -t lib/main_${{ matrix.flavor }}.dart --release
 
       - name: 📤 Upload Web Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: web-build-${{ matrix.flavor }}
           path: build/web/

--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -80,23 +80,23 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
           cache: true
 
       - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: 💾 Setup Gradle Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
         with:
           path: |
             ~/.gradle/caches
@@ -177,7 +177,7 @@ jobs:
             > service-account.json
 
       - name: 🚀 Upload to Google Play Internal Track
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb  # v1.1.3
         with:
           serviceAccountJson: service-account.json
           packageName: org.gatherli.app
@@ -194,10 +194,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -47,23 +47,23 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
           cache: true
 
       - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: 💾 Setup Gradle Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
         with:
           path: |
             ~/.gradle/caches
@@ -144,7 +144,7 @@ jobs:
             > service-account.json
 
       - name: 🚀 Upload to Google Play Production
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb  # v1.1.3
         with:
           serviceAccountJson: service-account.json
           packageName: org.gatherli.app
@@ -161,10 +161,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       # Step 2: Setup Flutter
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -35,7 +35,7 @@ jobs:
 
       # Step 3: Setup Node.js (required for Firebase CLI)
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
 
       # Step 6: Setup Java (required for Firestore Emulator)
       - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -173,7 +173,7 @@ jobs:
       # Step 13: Upload Firebase Emulator logs (on failure)
       - name: 📤 Upload Firebase Emulator Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: firebase-emulator-logs
           path: |
@@ -186,7 +186,7 @@ jobs:
       # Step 13.5: Upload Integration Test Logs (always run)
       - name: 📦 Upload Integration Test Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: integration-test-logs
           path: |
@@ -200,7 +200,7 @@ jobs:
       # Step 14: Comment on PR with results (optional)
       - name: 💬 Comment Test Results on PR
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const issue_number = context.payload.pull_request.number;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository code
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       # Step 2: Setup Flutter environment
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'
@@ -68,7 +68,7 @@ jobs:
 
       # Step 10: Upload coverage reports
       - name: 📈 Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457  # v3.1.6
         if: success()
         with:
           file: coverage/lcov.info
@@ -84,11 +84,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository code
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       # Step 2: Setup Node.js environment
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a  # v4.2.0
         with:
           node-version: '22'
 
@@ -121,7 +121,7 @@ jobs:
     steps:
       # Step 1: Checkout the repository code
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -140,7 +140,7 @@ jobs:
       # Step 3: Setup Python environment
       - name: 🔧 Setup Python
         if: steps.python_changes.outputs.changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -164,7 +164,7 @@ jobs:
       # Step 6: Upload Python coverage to Codecov
       - name: 📈 Upload Python Coverage to Codecov
         if: steps.python_changes.outputs.changed == 'true' && success()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457  # v3.1.6
         with:
           file: functions/python/coverage.xml
           flags: python-functions
@@ -185,11 +185,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository code
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       # Step 2: Setup Flutter environment
       - name: 🔧 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0
         with:
           flutter-version: '3.32.6'
           channel: 'stable'

--- a/.github/workflows/validate-version-tag.yml
+++ b/.github/workflows/validate-version-tag.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout Repository (full history for tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 

--- a/docs/epic-22/story-22.1/PINNED_ACTION_SHAS.md
+++ b/docs/epic-22/story-22.1/PINNED_ACTION_SHAS.md
@@ -1,0 +1,64 @@
+# Story 22.1: Pinned GitHub Action SHAs
+
+All third-party GitHub Actions across every workflow file are now pinned to an
+immutable commit SHA instead of a mutable version tag.
+
+## Why
+
+Version tags (`@v4`, `@v2`) are Git pointers that can be silently moved to any
+commit by the action's maintainer — or by an attacker who compromises a maintainer
+account. If a tag is moved to a malicious commit, the next pipeline run would
+silently execute that malicious code with full access to all GitHub Secrets
+(signing keys, App Store credentials, Firebase service account).
+
+This attack vector was exploited in the wild in 2025 (tj-actions/changed-files,
+reviewdog). Pinning to a SHA makes this impossible — a SHA is immutable and
+permanently tied to a specific commit.
+
+## Pinned versions
+
+| Action | SHA | Version |
+|--------|-----|---------|
+| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
+| `actions/cache` | `d4323d4df104b026a6aa633fdb11d772146be0bf` | v4.2.2 |
+| `actions/setup-node` | `1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a` | v4.2.0 |
+| `actions/setup-java` | `3a4f6e1af504cf6a31855fa899c6aa5355ba6c12` | v4.7.0 |
+| `actions/setup-python` | `42375524e23c412d93fb67b49958b491fce71c38` | v5.4.0 |
+| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
+| `actions/download-artifact` | `95815c38cf2ff2164869cbab79da8d1f422bc89e` | v4.2.1 |
+| `actions/github-script` | `60a0d83039c74a4aee543508d2ffcb1c3799cdea` | v7.0.1 |
+| `subosito/flutter-action` | `f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff` | v2.18.0 |
+| `codecov/codecov-action` | `ab904c41d6ece82784817410c45d8b8c02684457` | v3.1.6 |
+| `r0adkll/upload-google-play` | `935ef9c68bb393a8e6116b1575626a7f5be3a7fb` | v1.1.3 |
+
+## Files updated
+
+- `.github/workflows/main.yml`
+- `.github/workflows/cd-beta.yml`
+- `.github/workflows/cd-production.yml`
+- `.github/workflows/build-verification.yml`
+- `.github/workflows/validate-version-tag.yml`
+- `.github/workflows/integration-tests.yml`
+
+Total: 51 action references pinned across 6 workflow files.
+
+## How to upgrade an action in the future
+
+When you want to upgrade to a new version of an action:
+
+```bash
+# 1. Look up the SHA for the new version tag
+gh api repos/actions/checkout/git/ref/tags/v4.3.0 --jq '.object.sha'
+
+# If the result type is "tag" (annotated tag), dereference it:
+gh api repos/actions/checkout/git/tags/<sha-from-above> --jq '.object.sha'
+
+# 2. Update the SHA and version comment in the relevant workflow file(s)
+# uses: actions/checkout@<new-sha>  # v4.3.0
+
+# 3. Open a PR — the upgrade is now reviewed and intentional
+```
+
+The version comment on each line (`# v4.2.2`) makes it easy to see which version
+is running at a glance, while the SHA ensures it cannot be changed without a
+deliberate code change.


### PR DESCRIPTION
## Story 22.1: Pin all GitHub Action versions to commit SHAs

Closes #587 | Epic #586

---

## What changed

All third-party GitHub Actions across every workflow file are now pinned to an immutable commit SHA instead of a mutable version tag.

**6 files updated — 51 action references pinned:**

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
| `actions/cache` | `d4323d4df104b026a6aa633fdb11d772146be0bf` | v4.2.2 |
| `actions/setup-node` | `1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a` | v4.2.0 |
| `actions/setup-java` | `3a4f6e1af504cf6a31855fa899c6aa5355ba6c12` | v4.7.0 |
| `actions/setup-python` | `42375524e23c412d93fb67b49958b491fce71c38` | v5.4.0 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/download-artifact` | `95815c38cf2ff2164869cbab79da8d1f422bc89e` | v4.2.1 |
| `actions/github-script` | `60a0d83039c74a4aee543508d2ffcb1c3799cdea` | v7.0.1 |
| `subosito/flutter-action` | `f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff` | v2.18.0 |
| `codecov/codecov-action` | `ab904c41d6ece82784817410c45d8b8c02684457` | v3.1.6 |
| `r0adkll/upload-google-play` | `935ef9c68bb393a8e6116b1575626a7f5be3a7fb` | v1.1.3 |

## Why

Version tags like `@v4` are mutable Git pointers. Any maintainer (or attacker who compromises a maintainer account) can silently move the tag to a different commit. The next pipeline run would then execute that new code with full access to all GitHub Secrets — signing keys, App Store credentials, Firebase service account.

This attack was exploited in the wild in 2025 (tj-actions/changed-files, reviewdog). SHAs are immutable — they cannot be moved.

## How to upgrade an action in future

```bash
# Get the SHA for the new version tag
gh api repos/actions/checkout/git/ref/tags/v4.3.0 --jq '.object.sha'

# Update the SHA + version comment in the workflow file, open a PR
```

The version comment on each line (`# v4.2.2`) keeps it human-readable while the SHA enforces immutability.

## Checklist

- [x] All `uses:` directives reference a full 40-character commit SHA
- [x] Each SHA has an inline comment with the corresponding version tag
- [x] No mutable `@vX` references remain in any workflow file
- [x] Documentation added at `docs/epic-22/story-22.1/PINNED_ACTION_SHAS.md`
- [x] Single squashed commit

Authored-by: Babas10 <etienne.dubois91@gmail.com>