### PR TITLE
Story 22.5: Enable --fatal-warnings in all CD pipelines

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -35,7 +35,7 @@ jobs:
         run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 📊 Run Static Analysis
-        run: flutter analyze --no-fatal-warnings
+        run: flutter analyze
 
       - name: 🧪 Run Unit & Widget Tests
         run: flutter test test/unit/ test/widget/

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -34,7 +34,7 @@ jobs:
         run: dart run tools/generate_mock_firebase_configs.dart
 
       - name: 📊 Run Static Analysis
-        run: flutter analyze --no-fatal-warnings
+        run: flutter analyze
 
       - name: 🧪 Run Unit & Widget Tests
         run: flutter test test/unit/ test/widget/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,16 +41,9 @@ jobs:
       - name: 🔍 Verify Dependencies
         run: flutter pub deps
 
-      # Step 7: Run static code analysis
+      # Step 7: Run static code analysis — fails on any warning or error
       - name: 📊 Run Static Analysis
-        run: |
-          echo "Running Flutter analyze..."
-          flutter analyze > analysis_results.txt 2>&1 || true
-          echo "Analysis completed. Results:"
-          cat analysis_results.txt
-          # For now, we'll warn but not fail on analysis issues to establish CI/CD baseline
-          # TODO: In future iterations, enable --fatal-warnings when code quality improves
-          echo "✅ Static analysis completed (warnings-only mode for CI/CD baseline)"
+        run: flutter analyze
 
       # Step 8: Check code formatting
       - name: 🎨 Check Code Formatting

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,11 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`


### PR DESCRIPTION
## Summary

- `analysis_options.yaml`: exclude `*.freezed.dart` and `*.g.dart` from analysis — these are auto-generated files; excluding them is the standard Dart convention and removes the 3 `duplicate_ignore` warnings that were the only blocker
- `main.yml`: replace the `flutter analyze > ... || true` block (never-failing, with a `TODO` comment) with a plain `flutter analyze` that fails on any warning or error
- `cd-beta.yml` + `cd-production.yml`: remove `--no-fatal-warnings`

## Pre-condition verified

`flutter analyze` exits 0 cleanly with 0 issues before this PR opens. 3449 unit + widget tests pass.

## Why exclude generated files?

`*.freezed.dart` and `*.g.dart` are produced by `build_runner` — they are machine-written and not maintained by developers. They contain codegen-specific patterns (like redundant `// ignore:` annotations for older Dart versions) that produce false positives. The standard Dart/Flutter ecosystem convention is to exclude them from the analyzer; this is explicitly recommended in the [Dart analysis docs](https://dart.dev/tools/analysis).

## Test plan

- [ ] `flutter analyze` exits 0 locally with no flags
- [ ] CI `analyze_and_test` job passes (analysis step now a hard gate)
- [ ] CD beta and production pipelines pass on next tag push

Closes #591