### PR TITLE
Story 22.6: Decouple mobile builds from Cloud Function deployment

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -75,7 +75,7 @@ jobs:
   # ─── Job 3: Deploy Android ───────────────────────────────────────────────────
   deploy_android:
     name: 🤖 Build & Upload Android (Play Internal)
-    needs: [test, deploy_functions]
+    needs: test
     runs-on: ubuntu-latest
 
     steps:
@@ -189,7 +189,7 @@ jobs:
   # ─── Job 3: Deploy iOS ───────────────────────────────────────────────────────
   deploy_ios:
     name: 🍎 Build & Upload iOS (TestFlight)
-    needs: [test, deploy_functions]
+    needs: test
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
## Summary

- `cd-beta.yml`: removes `deploy_functions` from `needs` in both `deploy_android` and `deploy_ios` — they now depend only on `test`
- `cd-production.yml`: no change needed — it was already correctly structured

## Why

Mobile builds (Android AAB, iOS IPA) contain only Flutter/Dart code. They have zero dependency on `functions/`. The coupling was purely accidental and caused a real outage in v0.5.0-beta: a Cloud Scheduler IAM error in `deploy_functions` blocked both mobile uploads from running entirely.

## Effect on pipeline

Before: `test` → `deploy_functions` → `deploy_android` + `deploy_ios` (sequential)

After: `test` → `deploy_functions`, `deploy_android`, `deploy_ios` (all three concurrent)

- ~10 minutes saved on wall-clock time
- A functions failure no longer blocks TestFlight or Play Store uploads
- Failures are isolated to the job that actually failed

## Test plan

- [ ] `deploy_android` and `deploy_ios` in `cd-beta.yml` show `needs: test` only
- [ ] Pipeline passes on next beta tag push
- [ ] If `deploy_functions` were to fail, mobile build jobs still run

Closes #592