### PR TITLE
Story 22.8: Enforce that production tags are pushed from main

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -20,6 +20,17 @@ jobs:
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: 🛡️ Verify tag is on main branch
+        # Prevents accidental beta releases from feature branches reaching
+        # TestFlight and the Play Store internal track.
+        run: |
+          git fetch origin main --depth=50
+          git merge-base --is-ancestor HEAD origin/main \
+            || (echo "❌ ERROR: This tag does not point to a commit on main. Beta deploy aborted." && exit 1)
+          echo "✅ Tag is on main — proceeding with beta deploy"
 
       - name: 🔧 Setup Flutter
         uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -19,6 +19,18 @@ jobs:
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: 🛡️ Verify tag is on main branch
+        # Prevents accidental production releases from feature or hotfix branches.
+        # Play Store production releases go live immediately; App Store submissions
+        # enter Apple review — both are hard to reverse once triggered.
+        run: |
+          git fetch origin main --depth=50
+          git merge-base --is-ancestor HEAD origin/main \
+            || (echo "❌ ERROR: This tag does not point to a commit on main. Production deploy aborted." && exit 1)
+          echo "✅ Tag is on main — proceeding with production deploy"
 
       - name: 🔧 Setup Flutter
         uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0


### PR DESCRIPTION
## Summary

Adds a branch guard as the **first step** in the `test` job of both CD pipelines. If the tagged commit is not reachable from `origin/main`, the pipeline fails immediately with a clear error — before Flutter is set up, before any build runs, before any deploy fires.

- `cd-production.yml`: blocks accidental App Store / Google Play Production releases from non-main commits
- `cd-beta.yml`: same guard for TestFlight / Play Internal Track

## How it works

```bash
git fetch origin main --depth=50
git merge-base --is-ancestor HEAD origin/main \
  || (echo "❌ ERROR: ..." && exit 1)
```

`git merge-base --is-ancestor A B` exits 0 if A is an ancestor of B, 1 otherwise. This correctly handles: direct commits on main, merge commits, and squash-merged PRs — as long as they are within the fetched depth of 50 commits (sufficient for normal release cadence).

`fetch-depth: 0` is added to the checkout step so that `merge-base` has enough history to resolve ancestry.

## Why first step

Placing the guard before Flutter setup and tests means a misfired tag from a feature branch costs only ~5 seconds of runner time instead of 10+ minutes. It also makes the failure reason immediately obvious in the job summary.

## Test plan

- [ ] Tag a commit on `main` → pipeline proceeds normally
- [ ] Tag a commit on a feature branch → pipeline fails at the guard step with the error message
- [ ] `fetch-depth: 0` present on both checkout steps

Closes #594