### PR TITLE
Story 24.2: Instrument Cloud Function triggers with analytics events

### DIFF
--- a/functions/src/friendships.ts
+++ b/functions/src/friendships.ts
@@ -1,6 +1,7 @@
 // Cloud Functions for managing friendships in the social graph
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
+import { writeAnalyticsEvent } from "./helpers/analytics";
 
 // ============================================================================
 // Type Definitions
@@ -1041,6 +1042,8 @@ export const onFriendRequestAccepted = functions.firestore
         });
 
         await batch.commit();
+
+        await writeAnalyticsEvent("friend_connected", {});
 
         functions.logger.info("Friend caches updated successfully", {
           friendshipId: context.params.friendshipId,

--- a/functions/src/helpers/analytics.ts
+++ b/functions/src/helpers/analytics.ts
@@ -1,0 +1,28 @@
+// Helper for writing product analytics events to Firestore.
+// Non-blocking: errors are logged but never propagate to the caller.
+// Story 24.2: Instrument Cloud Function triggers with analytics events
+
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+
+/**
+ * Write a product analytics event to the `analytics_events` collection.
+ * Wrapped in its own try/catch so a Firestore write failure never blocks
+ * or fails the trigger that called it.
+ *
+ * Privacy: never include UIDs, display names, or email addresses in properties.
+ */
+export async function writeAnalyticsEvent(
+  event: string,
+  properties: Record<string, unknown> = {}
+): Promise<void> {
+  try {
+    await admin.firestore().collection("analytics_events").add({
+      event,
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      properties,
+    });
+  } catch (err) {
+    functions.logger.error("[analytics] Failed to write event", { event, err });
+  }
+}

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -1,5 +1,6 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
+import { writeAnalyticsEvent } from "./helpers/analytics";
 
 /**
  * Helper function to check if current time is within quiet hours
@@ -172,6 +173,7 @@ export const onInvitationCreated = functions.firestore
         }
       }
 
+      await writeAnalyticsEvent("invitation_sent", { groupId: invitation.groupId });
       return null;
     } catch (error) {
       functions.logger.error("Error sending invitation notification", {
@@ -292,6 +294,7 @@ export const onInvitationAccepted = functions.firestore
         invitationId,
         userId,
       });
+      await writeAnalyticsEvent("invitation_accepted", { groupId: after.groupId });
       return null;
     } catch (error) {
       functions.logger.error("Error sending invitation accepted notification", {
@@ -535,6 +538,7 @@ export const onGameCreated = functions.firestore
         }
       }
 
+      await writeAnalyticsEvent("game_created", { groupId, sport: game.sport ?? "unknown" });
       return null;
     } catch (error) {
       functions.logger.error("Error sending game created notification", {
@@ -647,6 +651,7 @@ export const onMemberJoined = functions.firestore
             adminTokenCount: adminTokens.length,
           });
         }
+        await writeAnalyticsEvent("member_joined", { groupId, via: "unknown" });
       }
 
       return null;
@@ -2245,6 +2250,7 @@ export const onWaitlistPromoted = functions.firestore
         }
       }
 
+      await writeAnalyticsEvent("waitlist_promoted", { groupId, gameId });
       return null;
     } catch (error) {
       functions.logger.error("Error sending waitlist promotion notification", {
@@ -2639,6 +2645,7 @@ export const onGameCancelled = functions.firestore
           }
       }
 
+      await writeAnalyticsEvent("game_cancelled", { groupId });
       return null;
     } catch (error) {
       functions.logger.error("Error sending game cancelled notification", {

--- a/functions/test/unit/analytics.test.ts
+++ b/functions/test/unit/analytics.test.ts
@@ -1,0 +1,88 @@
+// Unit tests for the writeAnalyticsEvent helper
+// Story 24.2: Instrument Cloud Function triggers with analytics events
+
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+import { writeAnalyticsEvent } from "../../src/helpers/analytics";
+
+// Mock firebase-admin
+jest.mock("firebase-admin", () => {
+  const actualAdmin = jest.requireActual("firebase-admin");
+  return {
+    ...actualAdmin,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions
+jest.mock("firebase-functions", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("writeAnalyticsEvent", () => {
+  let mockAdd: jest.Mock;
+  let mockDb: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAdd = jest.fn().mockResolvedValue({});
+    mockDb = {
+      collection: jest.fn(() => ({ add: mockAdd })),
+    };
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(mockDb);
+  });
+
+  it("writes the event document with correct shape", async () => {
+    await writeAnalyticsEvent("game_created", { groupId: "g1", sport: "volleyball" });
+
+    expect(mockDb.collection).toHaveBeenCalledWith("analytics_events");
+    expect(mockAdd).toHaveBeenCalledWith({
+      event: "game_created",
+      timestamp: "MOCK_TIMESTAMP",
+      properties: { groupId: "g1", sport: "volleyball" },
+    });
+  });
+
+  it("writes with empty properties when none are provided", async () => {
+    await writeAnalyticsEvent("friend_connected");
+
+    expect(mockAdd).toHaveBeenCalledWith({
+      event: "friend_connected",
+      timestamp: "MOCK_TIMESTAMP",
+      properties: {},
+    });
+  });
+
+  it("does not throw when Firestore write fails", async () => {
+    mockAdd.mockRejectedValue(new Error("Firestore unavailable"));
+
+    await expect(writeAnalyticsEvent("game_created", {})).resolves.toBeUndefined();
+  });
+
+  it("logs an error when Firestore write fails", async () => {
+    const firestoreError = new Error("Firestore unavailable");
+    mockAdd.mockRejectedValue(firestoreError);
+
+    await writeAnalyticsEvent("game_created", {});
+
+    expect((functions.logger.error as jest.Mock)).toHaveBeenCalledWith(
+      "[analytics] Failed to write event",
+      expect.objectContaining({ event: "game_created", err: firestoreError })
+    );
+  });
+});

--- a/functions/test/unit/onGameCreated.test.ts
+++ b/functions/test/unit/onGameCreated.test.ts
@@ -53,6 +53,7 @@ describe("onGameCreated Cloud Function", () => {
   let mockCreatorDoc: any;
   let mockMemberDoc1: any;
   let mockMemberDoc2: any;
+  let mockAnalyticsAdd: jest.Mock;
 
   // Re-import to get fresh mocks
   let onGameCreatedHandler: any;
@@ -112,6 +113,8 @@ describe("onGameCreated Cloud Function", () => {
       exists: true,
     };
 
+    mockAnalyticsAdd = jest.fn().mockResolvedValue({});
+
     // Setup mock Firestore
     mockDb = {
       collection: jest.fn((collectionName: string) => {
@@ -133,6 +136,8 @@ describe("onGameCreated Cloud Function", () => {
               update: jest.fn().mockResolvedValue({}),
             })),
           };
+        } else if (collectionName === "analytics_events") {
+          return { add: mockAnalyticsAdd };
         }
         return {doc: jest.fn()};
       }),
@@ -179,6 +184,14 @@ describe("onGameCreated Cloud Function", () => {
       expect(callArgs.notification.body).toContain("Sunset Beach");
       expect(callArgs.data.type).toBe("game_created");
       expect(callArgs.data.gameId).toBe("game123");
+
+      // Verify analytics event was written
+      expect(mockAnalyticsAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "game_created",
+          properties: expect.objectContaining({ groupId: "group123" }),
+        })
+      );
     });
 
     it("should not notify creator", async () => {

--- a/functions/test/unit/onWaitlistPromoted.test.ts
+++ b/functions/test/unit/onWaitlistPromoted.test.ts
@@ -54,6 +54,7 @@ describe("onWaitlistPromoted Cloud Function", () => {
   let mockExistingPlayer2Doc: any;
 
   let onWaitlistPromotedHandler: any;
+  let mockAnalyticsAdd: jest.Mock;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -105,6 +106,8 @@ describe("onWaitlistPromoted Cloud Function", () => {
       exists: true,
     };
 
+    mockAnalyticsAdd = jest.fn().mockResolvedValue({});
+
     // Setup mock Firestore
     mockDb = {
       collection: jest.fn((collectionName: string) => {
@@ -120,6 +123,8 @@ describe("onWaitlistPromoted Cloud Function", () => {
               update: jest.fn().mockResolvedValue({}),
             })),
           };
+        } else if (collectionName === "analytics_events") {
+          return { add: mockAnalyticsAdd };
         }
         return {doc: jest.fn()};
       }),
@@ -164,6 +169,14 @@ describe("onWaitlistPromoted Cloud Function", () => {
 
       // Should send 2 notifications (1 to promoted user, 1 to existing players)
       expect(mockMessaging.sendEachForMulticast).toHaveBeenCalledTimes(2);
+
+      // Verify analytics event was written
+      expect(mockAnalyticsAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "waitlist_promoted",
+          properties: expect.objectContaining({ groupId: "group123", gameId: "game123" }),
+        })
+      );
     });
 
     it("should not trigger when user joins directly (not from waitlist)", async () => {


### PR DESCRIPTION
## Summary

- Add `functions/src/helpers/analytics.ts` with a `writeAnalyticsEvent()` helper that writes to the `analytics_events` Firestore collection; wraps all errors in its own try/catch so analytics failures never block or fail the trigger
- Instrument 7 Cloud Function triggers: `invitation_sent`, `invitation_accepted`, `game_created`, `member_joined`, `waitlist_promoted`, `game_cancelled`, `friend_connected`
- Privacy: event properties never contain UIDs, display names, or email addresses

## Test plan

- [ ] `functions/test/unit/analytics.test.ts` — 4 tests for the helper (write shape, empty properties, error swallowing, error logging)
- [ ] `onGameCreated.test.ts` — updated mock + analytics assertion on main success path
- [ ] `onWaitlistPromoted.test.ts` — updated mock + analytics assertion on main success path
- [ ] All 400 Cloud Function unit tests pass (`npm test` in `functions/`)
- [ ] TypeScript compiles clean (`npm run build` in `functions/`)

Closes #603