### PR TITLE
Story 24.3: Enable Firebase → BigQuery export and define event schema

### DIFF
--- a/docs/epic-24/story-24.3/EVENT_SCHEMA.md
+++ b/docs/epic-24/story-24.3/EVENT_SCHEMA.md
@@ -1,0 +1,213 @@
+# Gatherli — Analytics Event Schema
+
+**Epic 24 / Story 24.3**
+**Last updated:** 2026-03-24
+
+---
+
+## Overview: Two Data Sources
+
+Gatherli's analytics pipeline has **two independent data sources** that land in different places.
+Understanding which one to query is the first step before writing any SQL.
+
+| Source | What it captures | Where it lands | How to query |
+|--------|-----------------|----------------|--------------|
+| **Firebase Analytics SDK** (client-side) | Screen views, session starts, first opens, app exceptions, any `logEvent()` call from the Flutter app | BigQuery — `analytics_<PROPERTY_ID>.events_YYYYMMDD` tables | Standard SQL via BigQuery console or Looker Studio |
+| **Firestore `analytics_events` collection** (backend) | Business events emitted by Cloud Function triggers (game created, invitation sent, etc.) | Firestore only — not in BigQuery | Firestore console, or export via Firestore → BigQuery extension |
+
+> **Note:** The Firebase Analytics → BigQuery export (enabled in Story 24.3) covers **source 1 only**.
+> To query source 2 events in BigQuery, either set up the
+> [Firestore → BigQuery extension](https://extensions.dev/extensions/firebase/firestore-bigquery-export)
+> or migrate the backend events to use `FirebaseAnalytics.instance.logEvent()` calls from a Cloud
+> Function HTTP endpoint. This is tracked as a future improvement.
+
+---
+
+## Source 1: Firebase Analytics BigQuery Export
+
+### Table location
+
+```
+Project:  gatherli-prod
+Dataset:  analytics_<PROPERTY_ID>          -- replace with your GA property ID
+Tables:   events_YYYYMMDD                  -- one table per day (partitioned)
+          events_intraday_YYYYMMDD         -- today's partial data (refreshes hourly)
+```
+
+Find your property ID in: Firebase Console → Project Settings → Integrations → BigQuery → View in BigQuery.
+
+### Core table schema
+
+The `events_*` tables have the same schema. Key columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `event_date` | STRING | Date as `YYYYMMDD` |
+| `event_timestamp` | INT64 | Microseconds since Unix epoch |
+| `event_name` | STRING | Name of the event (e.g. `session_start`, `screen_view`) |
+| `event_params` | ARRAY\<STRUCT\<key STRING, value STRUCT\<…\>\>\> | Event parameters as key-value pairs |
+| `user_pseudo_id` | STRING | Anonymous user identifier (not a UID) |
+| `user_id` | STRING | Firebase Auth UID — only populated if `setUserId()` is called |
+| `device.operating_system` | STRING | `IOS` or `ANDROID` |
+| `device.language` | STRING | Device locale |
+| `geo.country` | STRING | Country |
+| `app_info.version` | STRING | App version (e.g. `1.0.0`) |
+| `platform` | STRING | `IOS`, `ANDROID`, or `WEB` |
+
+### Reading event parameters
+
+Event parameters are stored as a repeated struct, not flat columns. Use a helper macro:
+
+```sql
+-- Extract a string parameter value from event_params
+CREATE TEMP FUNCTION get_string_param(params ANY TYPE, key STRING) AS (
+  (SELECT value.string_value FROM UNNEST(params) WHERE key = key LIMIT 1)
+);
+
+-- Extract an integer parameter value from event_params
+CREATE TEMP FUNCTION get_int_param(params ANY TYPE, key STRING) AS (
+  (SELECT value.int_value FROM UNNEST(params) WHERE key = key LIMIT 1)
+);
+```
+
+---
+
+## Source 1: Automatic Firebase Analytics Events
+
+These are emitted by the Firebase Analytics SDK without any custom code.
+
+| Event name | When it fires | Key params |
+|-----------|---------------|------------|
+| `first_open` | First time user opens the app after install | — |
+| `session_start` | Start of a new session (30 min inactivity threshold) | — |
+| `user_engagement` | User spends time in the foreground | `engagement_time_msec` |
+| `screen_view` | Every screen navigation (requires `reportFullyDrawn` or navigation observer) | `firebase_screen`, `firebase_previous_screen` |
+| `app_exception` | Crash or non-fatal exception (from Crashlytics integration) | `fatal` (1=crash, 0=non-fatal), `timestamp` |
+| `os_update` | User updated their OS | `previous_os_version` |
+| `app_update` | User updated the app | `previous_app_version` |
+
+---
+
+## Source 1: Custom Firebase Analytics Events (Planned)
+
+These events should be added in a future story via `FirebaseAnalytics.instance.logEvent()` calls in the Flutter app. They complement the backend events below by capturing the user's journey through the UI.
+
+| Event name | Where to fire | Proposed params |
+|-----------|---------------|----------------|
+| `join_group_tapped` | Group invite acceptance screen | `source: 'link' \| 'notification'` |
+| `game_rsvp` | RSVP action | `response: 'join' \| 'decline' \| 'waitlist'` |
+| `profile_photo_uploaded` | Photo upload complete | — |
+| `deep_link_opened` | Deferred deep link resolved | `type: 'group_invite'` |
+
+---
+
+## Source 2: Firestore `analytics_events` Collection
+
+These events are written by Cloud Function triggers (Story 24.2). Each document has the following shape:
+
+```
+analytics_events/{auto-id}
+├── event: string        -- event name (see catalog below)
+├── timestamp: Timestamp -- server timestamp of the write
+└── properties: map      -- event-specific properties (no UIDs, names, or emails)
+```
+
+### Event catalog
+
+#### `game_created`
+Fires when a new game document is created.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group the game belongs to |
+| `sport` | string | Sport type (e.g. `volleyball`, `basketball`), or `unknown` if not set |
+
+---
+
+#### `game_cancelled`
+Fires when a game's status transitions to `cancelled`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group |
+
+---
+
+#### `invitation_sent`
+Fires when a new invitation document is created for a user.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group the invitation is for |
+
+---
+
+#### `invitation_accepted`
+Fires when an invitation's status transitions from `pending` to `accepted`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group |
+
+---
+
+#### `member_joined`
+Fires once per new member detected in a group's `memberIds` array. Emitted inside the loop, so one event per member even if multiple join simultaneously.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group |
+| `via` | string | Join path — currently always `unknown`; will be refined when invite-link vs direct invite is distinguishable |
+
+---
+
+#### `waitlist_promoted`
+Fires when one or more users are promoted from the waitlist to the player list on a game.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `groupId` | string | Firestore ID of the group |
+| `gameId` | string | Firestore ID of the game |
+
+---
+
+#### `friend_connected`
+Fires when a friendship document's status transitions to `accepted`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| *(none)* | — | Only the count matters; no properties to avoid linking two parties |
+
+---
+
+## Privacy Rules
+
+These rules are enforced at write time in `functions/src/helpers/analytics.ts` by convention:
+
+- ❌ Never store Firebase Auth UIDs in event properties
+- ❌ Never store display names or email addresses
+- ❌ Never store Firestore document IDs that can be reverse-mapped to a user identity
+- ✅ Group IDs and game IDs are acceptable (they identify content, not people)
+- ✅ Aggregate counts and boolean flags are acceptable
+
+---
+
+## Adding New Events
+
+**Backend (Cloud Function):**
+```typescript
+import { writeAnalyticsEvent } from "./helpers/analytics";
+
+// Inside a trigger handler, after all business logic:
+await writeAnalyticsEvent("event_name", { groupId, someProperty: "value" });
+```
+
+**Flutter (client-side):**
+```dart
+await FirebaseAnalytics.instance.logEvent(
+  name: 'event_name',
+  parameters: {'screen': 'game_detail'},
+);
+```
+
+Add the new event to this document before merging.

--- a/functions/bigquery/gatherli_queries.sql
+++ b/functions/bigquery/gatherli_queries.sql
@@ -1,0 +1,211 @@
+-- Gatherli — BigQuery Analytics Queries
+-- Story 24.3: Firebase → BigQuery export
+--
+-- Usage:
+--   Replace PROJECT_ID and PROPERTY_ID with your actual values before running.
+--   Find PROPERTY_ID in: Firebase Console → Project Settings → Integrations → BigQuery → View in BigQuery.
+--
+--   Default dataset name: analytics_<PROPERTY_ID>
+--   Default table pattern: `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+--
+-- All queries target the Firebase Analytics BigQuery export (Source 1).
+-- See docs/epic-24/story-24.3/EVENT_SCHEMA.md for the full event catalog.
+-- ============================================================================
+
+
+-- ============================================================================
+-- HELPER: shared date range macro
+-- Adjust the WHERE clause in each query to narrow the date range.
+-- ============================================================================
+
+-- Standard 30-day lookback filter (add to any query):
+--   WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+--                             AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+
+
+-- ============================================================================
+-- 1. DAILY ACTIVE USERS (DAU)
+--    One row per day: distinct users who had at least one session.
+-- ============================================================================
+
+SELECT
+  PARSE_DATE('%Y%m%d', event_date) AS date,
+  COUNT(DISTINCT user_pseudo_id)   AS dau
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name = 'session_start'
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY date
+ORDER BY date;
+
+
+-- ============================================================================
+-- 2. WEEKLY ACTIVE USERS (WAU) + MONTHLY ACTIVE USERS (MAU)
+-- ============================================================================
+
+SELECT
+  DATE_TRUNC(PARSE_DATE('%Y%m%d', event_date), WEEK(MONDAY)) AS week_start,
+  COUNT(DISTINCT user_pseudo_id)                              AS wau
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name = 'session_start'
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY week_start
+ORDER BY week_start;
+
+
+-- ============================================================================
+-- 3. NEW USERS VS RETURNING USERS per day
+--    first_open = new install; session_start without first_open = returning.
+-- ============================================================================
+
+SELECT
+  PARSE_DATE('%Y%m%d', event_date)                                AS date,
+  COUNT(DISTINCT IF(event_name = 'first_open', user_pseudo_id, NULL)) AS new_users,
+  COUNT(DISTINCT IF(event_name = 'session_start', user_pseudo_id, NULL))
+    - COUNT(DISTINCT IF(event_name = 'first_open', user_pseudo_id, NULL)) AS returning_users
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name IN ('first_open', 'session_start')
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY date
+ORDER BY date;
+
+
+-- ============================================================================
+-- 4. PLATFORM SPLIT
+--    Android vs iOS share over the last 30 days.
+-- ============================================================================
+
+SELECT
+  platform,
+  COUNT(DISTINCT user_pseudo_id) AS users,
+  ROUND(COUNT(DISTINCT user_pseudo_id) * 100.0
+    / SUM(COUNT(DISTINCT user_pseudo_id)) OVER (), 1) AS pct
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name = 'first_open'
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY platform;
+
+
+-- ============================================================================
+-- 5. SCREEN VIEWS — top 10 most visited screens
+--    Requires screen_view events (Flutter navigation observer).
+-- ============================================================================
+
+SELECT
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'firebase_screen' LIMIT 1)
+    AS screen_name,
+  COUNT(*)                         AS views,
+  COUNT(DISTINCT user_pseudo_id)   AS unique_users
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name = 'screen_view'
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY screen_name
+ORDER BY views DESC
+LIMIT 10;
+
+
+-- ============================================================================
+-- 6. CRASH RATE — crashes per 1 000 sessions per day
+--    Uses app_exception events (fatal=1) from Crashlytics → BigQuery export.
+-- ============================================================================
+
+WITH sessions AS (
+  SELECT
+    event_date,
+    COUNT(DISTINCT user_pseudo_id) AS sessions
+  FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+  WHERE
+    event_name = 'session_start'
+    AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                          AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+  GROUP BY event_date
+),
+crashes AS (
+  SELECT
+    event_date,
+    COUNT(*) AS crash_count
+  FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+  WHERE
+    event_name = 'app_exception'
+    AND (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'fatal' LIMIT 1) = 1
+    AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY))
+                          AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+  GROUP BY event_date
+)
+SELECT
+  PARSE_DATE('%Y%m%d', s.event_date) AS date,
+  s.sessions,
+  COALESCE(c.crash_count, 0)         AS crashes,
+  ROUND(COALESCE(c.crash_count, 0) * 1000.0 / NULLIF(s.sessions, 0), 2) AS crashes_per_1k_sessions
+FROM sessions s
+LEFT JOIN crashes c USING (event_date)
+ORDER BY date;
+
+
+-- ============================================================================
+-- 7. APP VERSION ADOPTION
+--    How quickly users migrate to new builds.
+-- ============================================================================
+
+SELECT
+  app_info.version                 AS app_version,
+  COUNT(DISTINCT user_pseudo_id)   AS users,
+  MIN(PARSE_DATE('%Y%m%d', event_date)) AS first_seen
+FROM `PROJECT_ID.analytics_PROPERTY_ID.events_*`
+WHERE
+  event_name = 'session_start'
+  AND _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 60 DAY))
+                        AND FORMAT_DATE('%Y%m%d', CURRENT_DATE())
+GROUP BY app_version
+ORDER BY users DESC;
+
+
+-- ============================================================================
+-- NOTES ON SOURCE 2 (Firestore analytics_events collection)
+-- ============================================================================
+-- The events below (game_created, invitation_sent, etc.) are written to the
+-- Firestore `analytics_events` collection by Cloud Function triggers (Story 24.2).
+-- They are NOT in the Firebase Analytics BigQuery dataset above.
+--
+-- To query them in BigQuery, set up the official Firestore → BigQuery extension:
+--   https://extensions.dev/extensions/firebase/firestore-bigquery-export
+-- Configure it to mirror the `analytics_events` collection.
+-- The extension creates a `firestore_export` dataset with a `analytics_events_raw_*`
+-- table that can be queried with standard SQL.
+--
+-- Example query once the extension is set up:
+--
+-- SELECT
+--   JSON_VALUE(data, '$.event')                        AS event_name,
+--   TIMESTAMP_MICROS(CAST(timestamp AS INT64))         AS occurred_at,
+--   JSON_VALUE(data, '$.properties.groupId')           AS group_id,
+--   JSON_VALUE(data, '$.properties.sport')             AS sport
+-- FROM `PROJECT_ID.firestore_export.analytics_events_raw_latest`
+-- WHERE JSON_VALUE(data, '$.event') = 'game_created'
+-- ORDER BY occurred_at DESC;
+--
+-- Invitation conversion rate (backend events):
+--
+-- SELECT
+--   DATE(TIMESTAMP_MICROS(CAST(timestamp AS INT64))) AS date,
+--   COUNTIF(JSON_VALUE(data, '$.event') = 'invitation_sent')     AS sent,
+--   COUNTIF(JSON_VALUE(data, '$.event') = 'invitation_accepted') AS accepted,
+--   ROUND(
+--     SAFE_DIVIDE(
+--       COUNTIF(JSON_VALUE(data, '$.event') = 'invitation_accepted'),
+--       COUNTIF(JSON_VALUE(data, '$.event') = 'invitation_sent')
+--     ) * 100, 1
+--   ) AS conversion_pct
+-- FROM `PROJECT_ID.firestore_export.analytics_events_raw_latest`
+-- WHERE JSON_VALUE(data, '$.event') IN ('invitation_sent', 'invitation_accepted')
+-- GROUP BY date
+-- ORDER BY date;


### PR DESCRIPTION
## Summary

- Add `docs/epic-24/story-24.3/EVENT_SCHEMA.md` — complete event catalog documenting both analytics data sources, BigQuery table schema, event properties, and privacy rules
- Add `functions/bigquery/gatherli_queries.sql` — 7 ready-to-run BigQuery SQL queries for key business metrics

## Data sources clarified

The schema doc explicitly distinguishes the two sources to avoid confusion:

| Source | Transport | How to query |
|--------|-----------|--------------|
| Firebase Analytics SDK (client-side) | Firebase → BigQuery export (enabled ✅) | `analytics_PROPERTY_ID.events_*` tables |
| Firestore `analytics_events` collection (backend, Story 24.2) | Firestore only for now | Requires Firestore → BigQuery extension (documented as next step) |

## Queries included (`gatherli_queries.sql`)

1. Daily Active Users (DAU)
2. Weekly Active Users (WAU)
3. New vs returning users per day
4. Platform split (Android vs iOS)
5. Top 10 most visited screens
6. Crash rate per 1 000 sessions
7. App version adoption

Commented-out queries for Source 2 (invitation conversion rate, game_created funnel) are included ready to activate once the Firestore → BigQuery extension is set up.

## Test plan

- [ ] SQL queries run without syntax errors in BigQuery console (replace `PROJECT_ID` and `PROPERTY_ID`)
- [ ] Firebase Analytics export is active: verify `events_*` tables appear in BigQuery within 24h of first use
- [ ] Schema doc reviewed for accuracy against Story 24.2 event definitions

Closes #604