### PR TITLE
perf: reduce group details page load time

### DIFF
--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -137,6 +137,70 @@ class FirestoreGameRepository implements GameRepository {
   }
 
   @override
+  Stream<List<GameModel>> getRecentGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) {
+    try {
+      final cutoff = Timestamp.fromDate(
+          DateTime.now().subtract(Duration(days: pastDays)));
+      return _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('scheduledAt', isGreaterThan: cutoff)
+          .orderBy('scheduledAt', descending: false)
+          .snapshots()
+          .map((snapshot) => snapshot.docs
+              .where((doc) => doc.exists)
+              .map((doc) => GameModel.fromFirestore(doc))
+              .toList())
+          .handleError((error) {
+        if (error is FirebaseException) {
+          throw GameException(
+              'Failed to get recent games for group: ${error.message}',
+              code: error.code);
+        }
+        throw GameException('Failed to get recent games for group: $error',
+            code: 'stream-error');
+      });
+    } catch (e) {
+      throw GameException('Failed to get recent games for group: $e',
+          code: 'stream-error');
+    }
+  }
+
+  @override
+  Future<List<GameModel>> getOlderGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async {
+    try {
+      final cutoff = Timestamp.fromDate(
+          DateTime.now().subtract(Duration(days: pastDays)));
+      final query = await _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('scheduledAt', isLessThanOrEqualTo: cutoff)
+          .orderBy('scheduledAt', descending: false)
+          .get();
+
+      final games = query.docs
+          .where((doc) => doc.exists)
+          .map((doc) => GameModel.fromFirestore(doc))
+          .toList();
+      // Sort descending (most recent first) in Dart to avoid a new index
+      games.sort((a, b) => b.scheduledAt.compareTo(a.scheduledAt));
+      return games;
+    } on FirebaseException catch (e) {
+      throw GameException('Failed to get older games for group: ${e.message}',
+          code: e.code);
+    } catch (e) {
+      throw GameException('Failed to get older games for group: $e',
+          code: 'unknown');
+    }
+  }
+
+  @override
   Stream<int> getUpcomingGamesCount(String groupId) {
     try {
       final now = Timestamp.now();

--- a/lib/core/data/repositories/firestore_training_session_repository.dart
+++ b/lib/core/data/repositories/firestore_training_session_repository.dart
@@ -168,6 +168,74 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
   }
 
   @override
+  Stream<List<TrainingSessionModel>> getRecentTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) {
+    try {
+      final cutoff = Timestamp.fromDate(
+          DateTime.now().subtract(Duration(days: pastDays)));
+      return _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('startTime', isGreaterThan: cutoff)
+          .orderBy('startTime', descending: false)
+          .snapshots()
+          .map((snapshot) => snapshot.docs
+              .where((doc) => doc.exists)
+              .map((doc) => TrainingSessionModel.fromFirestore(doc))
+              .toList())
+          .handleError((error) {
+        if (error is FirebaseException) {
+          throw TrainingSessionException(
+              'Failed to get recent training sessions for group: ${error.message}',
+              code: error.code);
+        }
+        throw TrainingSessionException(
+            'Failed to get recent training sessions for group: $error',
+            code: 'stream-error');
+      });
+    } catch (e) {
+      throw TrainingSessionException(
+          'Failed to get recent training sessions for group: $e',
+          code: 'stream-error');
+    }
+  }
+
+  @override
+  Future<List<TrainingSessionModel>> getOlderTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async {
+    try {
+      final cutoff = Timestamp.fromDate(
+          DateTime.now().subtract(Duration(days: pastDays)));
+      final query = await _firestore
+          .collection(_collection)
+          .where('groupId', isEqualTo: groupId)
+          .where('startTime', isLessThanOrEqualTo: cutoff)
+          .orderBy('startTime', descending: false)
+          .get();
+
+      final sessions = query.docs
+          .where((doc) => doc.exists)
+          .map((doc) => TrainingSessionModel.fromFirestore(doc))
+          .toList();
+      // Sort descending (most recent first) in Dart to avoid a new index
+      sessions.sort((a, b) => b.startTime.compareTo(a.startTime));
+      return sessions;
+    } on FirebaseException catch (e) {
+      throw TrainingSessionException(
+          'Failed to get older training sessions for group: ${e.message}',
+          code: e.code);
+    } catch (e) {
+      throw TrainingSessionException(
+          'Failed to get older training sessions for group: $e',
+          code: 'unknown');
+    }
+  }
+
+  @override
   Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(
       String userId) {
     try {

--- a/lib/core/domain/repositories/game_repository.dart
+++ b/lib/core/domain/repositories/game_repository.dart
@@ -18,6 +18,20 @@ abstract class GameRepository {
   /// Get games for a group
   Stream<List<GameModel>> getGamesForGroup(String groupId);
 
+  /// Get recent games for a group (upcoming + past within [pastDays] days).
+  /// Use this for the group details activity feed initial load.
+  Stream<List<GameModel>> getRecentGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  });
+
+  /// One-time fetch of games older than [pastDays] days for a group.
+  /// Used for the "Load older activities" feature.
+  Future<List<GameModel>> getOlderGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  });
+
   /// Get count of upcoming games for a group
   Stream<int> getUpcomingGamesCount(String groupId);
 

--- a/lib/core/domain/repositories/training_session_repository.dart
+++ b/lib/core/domain/repositories/training_session_repository.dart
@@ -30,6 +30,20 @@ abstract class TrainingSessionRepository {
     int limit = 20,
   });
 
+  /// Get recent training sessions for a group (upcoming + past within [pastDays] days).
+  /// Use this for the group details activity feed initial load.
+  Stream<List<TrainingSessionModel>> getRecentTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  });
+
+  /// One-time fetch of training sessions older than [pastDays] days for a group.
+  /// Used for the "Load older activities" feature.
+  Future<List<TrainingSessionModel>> getOlderTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  });
+
   /// Get training sessions for a user (across all groups they're members of)
   Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(String userId);
 

--- a/lib/features/games/presentation/bloc/games_list/games_list_bloc.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_bloc.dart
@@ -2,19 +2,22 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/data/models/training_session_model.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 import 'package:play_with_me/core/domain/repositories/training_session_repository.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/data/models/group_activity_item.dart';
-// ignore: depend_on_referenced_packages
-import 'package:rxdart/rxdart.dart';
 import 'games_list_event.dart';
 import 'games_list_state.dart';
 
 class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
   final GameRepository _gameRepository;
   final TrainingSessionRepository _trainingSessionRepository;
-  StreamSubscription<dynamic>? _activitiesSubscription;
+  StreamSubscription<List<GameModel>>? _gamesSubscription;
+  StreamSubscription<List<TrainingSessionModel>>? _trainingsSubscription;
+  List<GameModel> _currentGames = [];
+  List<TrainingSessionModel> _currentTrainings = [];
   String? _currentGroupId;
   String? _currentUserId;
 
@@ -27,6 +30,7 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
     on<LoadGamesForGroup>(_onLoadGamesForGroup);
     on<ActivityListUpdated>(_onActivityListUpdated);
     on<RefreshGamesList>(_onRefreshGamesList);
+    on<LoadOlderActivities>(_onLoadOlderActivities);
   }
 
   Future<void> _onLoadGamesForGroup(
@@ -38,31 +42,35 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
 
       _currentGroupId = event.groupId;
       _currentUserId = event.userId;
+      _currentGames = [];
+      _currentTrainings = [];
 
-      await _activitiesSubscription?.cancel();
+      await _gamesSubscription?.cancel();
+      await _trainingsSubscription?.cancel();
 
-      // Combine games and training sessions streams
-      final gamesStream = _gameRepository.getGamesForGroup(event.groupId);
-      final trainingsStream = _trainingSessionRepository
-          .getTrainingSessionsForGroup(event.groupId);
-
-      _activitiesSubscription =
-          Rx.combineLatest2(gamesStream, trainingsStream, (games, trainings) {
-        // Convert to GroupActivityItem
-        final gameActivities =
-            games.map((game) => GroupActivityItem.game(game)).toList();
-        final trainingActivities = trainings
-            .map((session) => GroupActivityItem.training(session))
-            .toList();
-
-        return [...gameActivities, ...trainingActivities];
-      }).listen(
-        (activities) {
-          add(ActivityListUpdated(activities: activities));
+      // Subscribe to games — emits independently as soon as data arrives
+      _gamesSubscription = _gameRepository
+          .getRecentGamesForGroup(event.groupId)
+          .listen(
+        (games) {
+          _currentGames = games;
+          _emitMerged();
         },
         onError: (error) {
-          debugPrint('❌ GamesListBloc: Stream error: $error');
-          add(const ActivityListUpdated(activities: []));
+          debugPrint('❌ GamesListBloc: Games stream error: $error');
+        },
+      );
+
+      // Subscribe to trainings — emits independently as soon as data arrives
+      _trainingsSubscription = _trainingSessionRepository
+          .getRecentTrainingSessionsForGroup(event.groupId)
+          .listen(
+        (trainings) {
+          _currentTrainings = trainings;
+          _emitMerged();
+        },
+        onError: (error) {
+          debugPrint('❌ GamesListBloc: Trainings stream error: $error');
         },
       );
     } on GameException catch (e) {
@@ -75,13 +83,22 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
     }
   }
 
+  void _emitMerged() {
+    final gameActivities =
+        _currentGames.map((game) => GroupActivityItem.game(game)).toList();
+    final trainingActivities = _currentTrainings
+        .map((session) => GroupActivityItem.training(session))
+        .toList();
+    add(ActivityListUpdated(
+        activities: [...gameActivities, ...trainingActivities]));
+  }
+
   Future<void> _onActivityListUpdated(
     ActivityListUpdated event,
     Emitter<GamesListState> emit,
   ) async {
     final now = DateTime.now();
 
-    // Separate into upcoming and past activities
     final upcomingActivities = event.activities
         .where((activity) => activity.startTime.isAfter(now))
         .toList()
@@ -92,15 +109,24 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
         .toList()
       ..sort((a, b) => b.startTime.compareTo(a.startTime));
 
-    // Emit empty state only if both lists are empty after filtering
     if (upcomingActivities.isEmpty && pastActivities.isEmpty) {
       emit(GamesListEmpty(userId: _currentUserId ?? ''));
       return;
     }
 
+    // Preserve older activities if already loaded
+    final previousOlder = state is GamesListLoaded
+        ? (state as GamesListLoaded).olderPastActivities
+        : <GroupActivityItem>[];
+    final previousOlderLoaded = state is GamesListLoaded
+        ? (state as GamesListLoaded).olderActivitiesLoaded
+        : false;
+
     emit(GamesListLoaded(
       upcomingActivities: upcomingActivities,
       pastActivities: pastActivities,
+      olderPastActivities: previousOlder,
+      olderActivitiesLoaded: previousOlderLoaded,
       userId: _currentUserId ?? '',
     ));
   }
@@ -117,9 +143,57 @@ class GamesListBloc extends Bloc<GamesListEvent, GamesListState> {
     }
   }
 
+  Future<void> _onLoadOlderActivities(
+    LoadOlderActivities event,
+    Emitter<GamesListState> emit,
+  ) async {
+    if (state is! GamesListLoaded || _currentGroupId == null) return;
+    final current = state as GamesListLoaded;
+    if (current.isLoadingOlderActivities || current.olderActivitiesLoaded) {
+      return;
+    }
+
+    emit(current.copyWith(isLoadingOlderActivities: true));
+
+    try {
+      final results = await Future.wait([
+        _gameRepository.getOlderGamesForGroup(_currentGroupId!),
+        _trainingSessionRepository
+            .getOlderTrainingSessionsForGroup(_currentGroupId!),
+      ]);
+
+      final olderGames = (results[0] as List<GameModel>)
+          .map((g) => GroupActivityItem.game(g))
+          .toList();
+      final olderTrainings =
+          (results[1] as List<TrainingSessionModel>)
+              .map((s) => GroupActivityItem.training(s))
+              .toList();
+
+      final olderActivities = [...olderGames, ...olderTrainings]
+        ..sort((a, b) => b.startTime.compareTo(a.startTime));
+
+      if (state is GamesListLoaded) {
+        emit((state as GamesListLoaded).copyWith(
+          olderPastActivities: olderActivities,
+          isLoadingOlderActivities: false,
+          olderActivitiesLoaded: true,
+        ));
+      }
+    } catch (e) {
+      if (state is GamesListLoaded) {
+        emit((state as GamesListLoaded).copyWith(
+          isLoadingOlderActivities: false,
+        ));
+      }
+      debugPrint('❌ GamesListBloc: Failed to load older activities: $e');
+    }
+  }
+
   @override
   Future<void> close() {
-    _activitiesSubscription?.cancel();
+    _gamesSubscription?.cancel();
+    _trainingsSubscription?.cancel();
     return super.close();
   }
 }

--- a/lib/features/games/presentation/bloc/games_list/games_list_event.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_event.dart
@@ -43,3 +43,7 @@ class ActivityListUpdated extends GamesListEvent {
 class RefreshGamesList extends GamesListEvent {
   const RefreshGamesList();
 }
+
+class LoadOlderActivities extends GamesListEvent {
+  const LoadOlderActivities();
+}

--- a/lib/features/games/presentation/bloc/games_list/games_list_state.dart
+++ b/lib/features/games/presentation/bloc/games_list/games_list_state.dart
@@ -20,16 +20,49 @@ class GamesListLoading extends GamesListState {
 class GamesListLoaded extends GamesListState {
   final List<GroupActivityItem> upcomingActivities;
   final List<GroupActivityItem> pastActivities;
+  final List<GroupActivityItem> olderPastActivities;
+  final bool isLoadingOlderActivities;
+  final bool olderActivitiesLoaded;
   final String userId;
 
   const GamesListLoaded({
     required this.upcomingActivities,
     required this.pastActivities,
+    this.olderPastActivities = const [],
+    this.isLoadingOlderActivities = false,
+    this.olderActivitiesLoaded = false,
     required this.userId,
   });
 
+  GamesListLoaded copyWith({
+    List<GroupActivityItem>? upcomingActivities,
+    List<GroupActivityItem>? pastActivities,
+    List<GroupActivityItem>? olderPastActivities,
+    bool? isLoadingOlderActivities,
+    bool? olderActivitiesLoaded,
+    String? userId,
+  }) {
+    return GamesListLoaded(
+      upcomingActivities: upcomingActivities ?? this.upcomingActivities,
+      pastActivities: pastActivities ?? this.pastActivities,
+      olderPastActivities: olderPastActivities ?? this.olderPastActivities,
+      isLoadingOlderActivities:
+          isLoadingOlderActivities ?? this.isLoadingOlderActivities,
+      olderActivitiesLoaded:
+          olderActivitiesLoaded ?? this.olderActivitiesLoaded,
+      userId: userId ?? this.userId,
+    );
+  }
+
   @override
-  List<Object?> get props => [upcomingActivities, pastActivities, userId];
+  List<Object?> get props => [
+        upcomingActivities,
+        pastActivities,
+        olderPastActivities,
+        isLoadingOlderActivities,
+        olderActivitiesLoaded,
+        userId,
+      ];
 
   // Helper getters for backward compatibility and filtering
   List<GameModel> get upcomingGames => upcomingActivities

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -60,14 +60,7 @@ class GroupDetailsPage extends StatelessWidget {
         BlocProvider(create: (context) => sl<GroupMemberBloc>()),
         BlocProvider(create: (context) => sl<GroupInviteLinkBloc>()),
         BlocProvider(
-          create: (context) {
-            final authState = context.read<AuthenticationBloc>().state;
-            final userId = authState is AuthenticationAuthenticated
-                ? authState.user.uid
-                : '';
-            return sl<GamesListBloc>()
-              ..add(LoadGamesForGroup(groupId: groupId, userId: userId));
-          },
+          create: (context) => sl<GamesListBloc>(),
         ),
       ],
       child: _GroupDetailsPageContent(
@@ -113,6 +106,9 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
   /// Tracks which member UIDs were used for the last full data load.
   Set<String> _lastLoadedMemberIds = {};
 
+  /// Whether the Activities tab stream has been started.
+  bool _activitiesInitialized = false;
+
   StreamSubscription<GroupModel?>? _groupSubscription;
 
   @override
@@ -123,12 +119,33 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
     _userRepository = widget.userRepositoryOverride ?? sl<UserRepository>();
     _friendRepository = sl<FriendRepository>();
     _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(_onTabChanged);
     _subscribeToGroup();
+  }
+
+  void _onTabChanged() {
+    // Lazy-initialize the activities stream only when the Activities tab is
+    // first selected (tab index 1).
+    if (!_tabController.indexIsChanging &&
+        _tabController.index == 1 &&
+        !_activitiesInitialized) {
+      _activitiesInitialized = true;
+      final authState = context.read<AuthenticationBloc>().state;
+      if (authState is AuthenticationAuthenticated && _group != null) {
+        context.read<GamesListBloc>().add(
+              LoadGamesForGroup(
+                groupId: widget.groupId,
+                userId: authState.user.uid,
+              ),
+            );
+      }
+    }
   }
 
   @override
   void dispose() {
     _groupSubscription?.cancel();
+    _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
     super.dispose();
   }
@@ -190,9 +207,29 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
       _isLoadingFriendships = true;
     });
 
+    // Phase 1: Load member names immediately so the list is visible.
+    try {
+      final members =
+          await _userRepository.getUsersByIds(group.memberIds);
+      if (!mounted) return;
+      setState(() {
+        _members = members;
+        _lastLoadedMemberIds = Set<String>.from(group.memberIds);
+        _isLoading = false;
+        // _isLoadingFriendships remains true — spinner shown per row
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _isLoadingFriendships = false;
+      });
+      return;
+    }
+
+    // Phase 2: Load friendship/request status in background.
     try {
       final results = await Future.wait<dynamic>([
-        _userRepository.getUsersByIds(group.memberIds),
         _friendRepository.batchCheckFriendship(otherMemberIds),
         otherMemberIds.isNotEmpty
             ? _friendRepository.batchCheckFriendRequestStatus(otherMemberIds)
@@ -200,19 +237,14 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
       ]);
 
       if (!mounted) return;
-
       setState(() {
-        _members = results[0] as List<UserModel>;
-        _friendshipStatus = results[1] as Map<String, bool>;
-        _requestStatus = results[2] as Map<String, FriendRequestStatus>;
-        _lastLoadedMemberIds = Set<String>.from(group.memberIds);
-        _isLoading = false;
+        _friendshipStatus = results[0] as Map<String, bool>;
+        _requestStatus = results[1] as Map<String, FriendRequestStatus>;
         _isLoadingFriendships = false;
       });
     } catch (e) {
       if (!mounted) return;
       setState(() {
-        _isLoading = false;
         _isLoadingFriendships = false;
       });
     }
@@ -762,6 +794,32 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                         _buildActivityItem(
                             context, activity, state.userId, true)),
                   ],
+                  // Older activities (loaded on demand)
+                  if (state.olderPastActivities.isNotEmpty)
+                    ...state.olderPastActivities.map((activity) =>
+                        _buildActivityItem(
+                            context, activity, state.userId, true)),
+                  // "Load older activities" button
+                  if (!state.olderActivitiesLoaded)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 12),
+                      child: state.isLoadingOlderActivities
+                          ? const Center(child: CircularProgressIndicator())
+                          : OutlinedButton(
+                              onPressed: () => context
+                                  .read<GamesListBloc>()
+                                  .add(const LoadOlderActivities()),
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: AppColors.secondary,
+                                side:
+                                    BorderSide(color: AppColors.secondary),
+                                minimumSize:
+                                    const Size(double.infinity, 44),
+                              ),
+                              child: Text(l10n.loadOlderActivities),
+                            ),
+                    ),
                   const SizedBox(height: 16),
                 ],
               ],

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -96,7 +96,7 @@
   "resetPassword": "Passwort Zurücksetzen",
   "backToLogin": "Zurück zur Anmeldung",
   "emailSent": "E-Mail Gesendet!",
-  "createAccount": "Konto Erstellen",
+  "createAccount": "Konto erstellen",
   "accountCreatedSuccess": "Konto erfolgreich erstellt! Bitte überprüfen Sie Ihre E-Mail.",
   "alreadyHaveAccount": "Bereits ein Konto? ",
   "signIn": "Anmelden",
@@ -372,7 +372,7 @@
   "performanceStats": "Leistungsstatistiken",
   "eloRatingLabel": "ELO-Wertung",
   "peak": "Höchstwert: {value}",
-  "winRate": "Gewinnrate",
+  "winRate": "Siegquote",
   "winsLosses": "{wins}S - {losses}N",
   "streakLabel": "Serie",
   "winning": "Gewinne",
@@ -393,7 +393,6 @@
   "durationFormat": "{hours}h {minutes}m",
   "durationHours": "{hours}h",
   "durationMinutes": "{minutes}m",
-
   "bestPartner": "Bester Partner",
   "noPartnerDataYet": "Noch keine Partnerdaten",
   "playGamesWithTeammate": "Spielen Sie 5+ Spiele mit einem Teamkollegen",
@@ -420,7 +419,6 @@
   "currentElo": "Aktuelles ELO",
   "peakElo": "Höchstes ELO",
   "gamesPlayed": "Gespielte Spiele",
-  "winRate": "Siegquote",
   "bestWin": "Bester Sieg",
   "winGameToUnlock": "Gewinnen Sie ein Spiel zum Freischalten",
   "beatOpponentsToTrack": "Besiegen Sie Gegner, um Ihre besten Siege zu verfolgen",
@@ -447,18 +445,15 @@
   "playMoreGamesToSeeRoles": "Spielen Sie mehr Spiele, um zu sehen, wie Sie in verschiedenen Rollen abschneiden",
   "noStatsYet": "Noch keine Stats",
   "startPlayingToSeeStats": "Beginnen Sie zu spielen, um Ihre Statistiken zu sehen!",
-
   "playGamesToUnlockRankings": "Spielen Sie, um Ranglisten freizuschalten",
   "globalRank": "Globaler Rang",
   "percentile": "Perzentil",
   "friendsRank": "Freunde Rang",
   "addFriendsAction": "Freunde hinzufügen",
-
   "period30d": "30T",
   "period90d": "90T",
   "period1y": "1J",
   "periodAllTime": "Gesamt",
-
   "monthlyProgressChart": "Monatlicher Fortschritt",
   "playAtLeastNGames": "Spielen Sie mindestens {count} Spiele",
   "nOfNGames": "{current}/{total} Spiele",
@@ -473,17 +468,14 @@
   "periodLabel90Days": "90 Tagen",
   "periodLabelYear": "Jahr",
   "periodLabelAllTime": "Gesamtzeit",
-
   "bestEloThisMonth": "Bestes ELO diesen Monat",
   "bestEloPast90Days": "Bestes ELO letzte 90 Tage",
   "bestEloThisYear": "Bestes ELO dieses Jahr",
   "bestEloAllTime": "Bestes ELO aller Zeiten",
-
   "lastNGames": "Letzte {count} Spiele",
   "noGamesPlayedYet": "Noch keine Spiele gespielt",
   "winsStreakCount": "{count} Siege",
   "lossesStreakCount": "{count} Niederlagen",
-
   "partnerDetailsTitle": "Partner Details",
   "overallRecord": "Gesamtbilanz",
   "games": "Spiele",
@@ -520,11 +512,9 @@
   "pageNotFoundMessage": "Die angeforderte Seite konnte nicht gefunden werden.",
   "inviteOnboardingTitle": "Du wurdest eingeladen!",
   "inviteOnboardingSubtitle": "Du wurdest eingeladen beizutreten:",
-  "createAccount": "Konto erstellen",
   "iHaveAnAccount": "Ich habe ein Konto",
   "joinGroup": "Gruppe beitreten",
   "joinGroupConfirmation": "Gruppe beitreten?",
-  "invitedBy": "Eingeladen von {name}",
   "membersCount": "{count} Mitglieder",
   "inviteExpired": "Dieser Einladungslink ist abgelaufen",
   "inviteLinkRevoked": "Dieser Einladungslink ist nicht mehr gültig",
@@ -534,7 +524,6 @@
   "continueToApp": "Weiter zur App",
   "validatingInvite": "Einladung wird überprüft...",
   "joiningGroup": "Gruppe wird beigetreten...",
-
   "createAccountToJoin": "Erstellen Sie Ihr Konto zum Beitreten:",
   "fullNameHint": "Vollständiger Name",
   "fullNameRequired": "Vollständiger Name ist erforderlich",
@@ -562,19 +551,16 @@
   "invalidEmailError": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
   "networkError": "Verbindung nicht möglich. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
   "creatingAccount": "Konto wird erstellt...",
-
   "verifyEmailWarning": "Bestätigen Sie Ihre E-Mail, um Ihr Konto zu behalten. Noch {daysRemaining} Tage.",
   "verifyNow": "Jetzt bestätigen",
   "dismiss": "Schließen",
   "emailVerifiedSuccess": "E-Mail erfolgreich bestätigt!",
-
   "accountRestricted": "Ihr Konto ist eingeschränkt. Bestätigen Sie Ihre E-Mail, um den vollen Zugang wiederherzustellen. {daysUntilDeletion} Tage bis zur Kontolöschung.",
   "accountScheduledForDeletion": "Ihr Konto ist zur Löschung vorgesehen. Bestätigen Sie jetzt Ihre E-Mail, um Ihr Konto zu behalten.",
   "accountStatusActive": "Aktiv",
   "accountStatusPendingVerification": "Bestätigung ausstehend",
   "accountStatusRestricted": "Eingeschränkt",
   "accountStatusScheduledForDeletion": "Löschung geplant",
-
   "accountDeletionWarning": "Das Konto wird in {daysRemaining} Tagen gelöscht.",
   "featureRestricted": "Diese Funktion erfordert eine E-Mail-Bestätigung.",
   "verifyToUnlock": "Bestätigen Sie Ihre E-Mail, um diese Funktion zu nutzen.",
@@ -583,5 +569,9 @@
   "orLater": "oder später",
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  },
+  "loadOlderActivities": "Ältere Aktivitäten laden",
+  "@loadOlderActivities": {
+    "description": "Button label to load activities older than 90 days in the group details activity feed"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2764,5 +2764,10 @@
   "orLater": "or later",
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  },
+
+  "loadOlderActivities": "Load older activities",
+  "@loadOlderActivities": {
+    "description": "Button label to load activities older than 90 days in the group details activity feed"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -96,7 +96,7 @@
   "resetPassword": "Restablecer Contraseña",
   "backToLogin": "Volver al Inicio de Sesión",
   "emailSent": "¡Correo Enviado!",
-  "createAccount": "Crear Cuenta",
+  "createAccount": "Crear cuenta",
   "accountCreatedSuccess": "¡Cuenta creada exitosamente! Revisa tu correo para verificar.",
   "alreadyHaveAccount": "¿Ya tienes cuenta? ",
   "signIn": "Iniciar Sesión",
@@ -372,7 +372,7 @@
   "performanceStats": "Estadísticas de Rendimiento",
   "eloRatingLabel": "Clasificación ELO",
   "peak": "Máximo: {value}",
-  "winRate": "Tasa de Victoria",
+  "winRate": "Tasa de victoria",
   "winsLosses": "{wins}V - {losses}D",
   "streakLabel": "Racha",
   "winning": "Victorias",
@@ -393,7 +393,6 @@
   "durationFormat": "{hours}h {minutes}m",
   "durationHours": "{hours}h",
   "durationMinutes": "{minutes}m",
-
   "bestPartner": "Mejor Compañero",
   "noPartnerDataYet": "Aún sin datos de compañero",
   "playGamesWithTeammate": "Juega 5+ partidos con un compañero",
@@ -420,7 +419,6 @@
   "currentElo": "ELO actual",
   "peakElo": "ELO máximo",
   "gamesPlayed": "Partidos jugados",
-  "winRate": "Tasa de victoria",
   "bestWin": "Mejor victoria",
   "winGameToUnlock": "Gana un partido para desbloquear",
   "beatOpponentsToTrack": "Vence oponentes para seguir tus mejores victorias",
@@ -447,18 +445,15 @@
   "playMoreGamesToSeeRoles": "Juega más partidos para ver cómo te desempeñas en diferentes roles",
   "noStatsYet": "Sin stats aún",
   "startPlayingToSeeStats": "¡Empieza a jugar para ver tus estadísticas!",
-
   "playGamesToUnlockRankings": "Juega para desbloquear rankings",
   "globalRank": "Ranking Global",
   "percentile": "Percentil",
   "friendsRank": "Ranking Amigos",
   "addFriendsAction": "Añadir amigos",
-
   "period30d": "30d",
   "period90d": "90d",
   "period1y": "1a",
   "periodAllTime": "Todo",
-
   "monthlyProgressChart": "Gráfico de progreso mensual",
   "playAtLeastNGames": "Juega al menos {count} partidos",
   "nOfNGames": "{current}/{total} partidos",
@@ -473,17 +468,14 @@
   "periodLabel90Days": "90 días",
   "periodLabelYear": "año",
   "periodLabelAllTime": "todo el tiempo",
-
   "bestEloThisMonth": "Mejor ELO este mes",
   "bestEloPast90Days": "Mejor ELO últimos 90 días",
   "bestEloThisYear": "Mejor ELO este año",
   "bestEloAllTime": "Mejor ELO de todos los tiempos",
-
   "lastNGames": "Últimos {count} partidos",
   "noGamesPlayedYet": "Sin partidos jugados",
   "winsStreakCount": "{count} victorias",
   "lossesStreakCount": "{count} derrotas",
-
   "partnerDetailsTitle": "Detalles del compañero",
   "overallRecord": "Registro general",
   "games": "Partidos",
@@ -520,11 +512,9 @@
   "pageNotFoundMessage": "La página solicitada no se pudo encontrar.",
   "inviteOnboardingTitle": "¡Has sido invitado!",
   "inviteOnboardingSubtitle": "Has sido invitado a unirte a:",
-  "createAccount": "Crear cuenta",
   "iHaveAnAccount": "Tengo una cuenta",
   "joinGroup": "Unirse al grupo",
   "joinGroupConfirmation": "¿Unirse al grupo?",
-  "invitedBy": "Invitado por {name}",
   "membersCount": "{count} miembros",
   "inviteExpired": "Este enlace de invitación ha expirado",
   "inviteLinkRevoked": "Este enlace de invitación ya no es válido",
@@ -534,7 +524,6 @@
   "continueToApp": "Continuar a la app",
   "validatingInvite": "Validando invitación...",
   "joiningGroup": "Uniéndose al grupo...",
-
   "createAccountToJoin": "Crea tu cuenta para unirte:",
   "fullNameHint": "Nombre completo",
   "fullNameRequired": "El nombre completo es obligatorio",
@@ -562,19 +551,16 @@
   "invalidEmailError": "Por favor ingresa una dirección de correo electrónico válida.",
   "networkError": "No se puede conectar. Verifica tu conexión e inténtalo de nuevo.",
   "creatingAccount": "Creando cuenta...",
-
   "verifyEmailWarning": "Verifica tu email para conservar tu cuenta. {daysRemaining} días restantes.",
   "verifyNow": "Verificar ahora",
   "dismiss": "Cerrar",
   "emailVerifiedSuccess": "¡Email verificado exitosamente!",
-
   "accountRestricted": "Tu cuenta está restringida. Verifica tu email para recuperar el acceso completo. {daysUntilDeletion} días hasta la eliminación de la cuenta.",
   "accountScheduledForDeletion": "Tu cuenta está programada para eliminación. Verifica tu email ahora para conservar tu cuenta.",
   "accountStatusActive": "Activa",
   "accountStatusPendingVerification": "Verificación pendiente",
   "accountStatusRestricted": "Restringida",
   "accountStatusScheduledForDeletion": "Eliminación programada",
-
   "accountDeletionWarning": "La cuenta será eliminada en {daysRemaining} días.",
   "featureRestricted": "Esta función requiere verificación de email.",
   "verifyToUnlock": "Verifica tu email para usar esta función.",
@@ -583,5 +569,9 @@
   "orLater": "o más tarde",
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  },
+  "loadOlderActivities": "Cargar actividades más antiguas",
+  "@loadOlderActivities": {
+    "description": "Button label to load activities older than 90 days in the group details activity feed"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -96,7 +96,7 @@
   "resetPassword": "Réinitialiser le Mot de Passe",
   "backToLogin": "Retour à la Connexion",
   "emailSent": "E-mail Envoyé !",
-  "createAccount": "Créer un Compte",
+  "createAccount": "Créer un compte",
   "accountCreatedSuccess": "Compte créé avec succès ! Veuillez vérifier votre e-mail.",
   "alreadyHaveAccount": "Vous avez déjà un compte ? ",
   "signIn": "Se Connecter",
@@ -372,7 +372,7 @@
   "performanceStats": "Statistiques de Performance",
   "eloRatingLabel": "Classement ELO",
   "peak": "Maximum : {value}",
-  "winRate": "Taux de Victoire",
+  "winRate": "Taux de victoire",
   "winsLosses": "{wins}V - {losses}D",
   "streakLabel": "Série",
   "winning": "Victoires",
@@ -393,7 +393,6 @@
   "durationFormat": "{hours}h {minutes}m",
   "durationHours": "{hours}h",
   "durationMinutes": "{minutes}m",
-
   "bestPartner": "Meilleur Partenaire",
   "noPartnerDataYet": "Pas encore de données partenaire",
   "playGamesWithTeammate": "Jouez 5+ matchs avec un coéquipier",
@@ -420,7 +419,6 @@
   "currentElo": "ELO actuel",
   "peakElo": "ELO maximum",
   "gamesPlayed": "Matchs joués",
-  "winRate": "Taux de victoire",
   "bestWin": "Meilleure victoire",
   "winGameToUnlock": "Gagnez un match pour débloquer",
   "beatOpponentsToTrack": "Battez des adversaires pour suivre vos meilleures victoires",
@@ -447,18 +445,15 @@
   "playMoreGamesToSeeRoles": "Jouez plus de matchs pour voir comment vous performez dans différents rôles",
   "noStatsYet": "Pas encore de stats",
   "startPlayingToSeeStats": "Commencez à jouer pour voir vos statistiques !",
-
   "playGamesToUnlockRankings": "Jouez pour débloquer les classements",
   "globalRank": "Rang Global",
   "percentile": "Percentile",
   "friendsRank": "Rang Amis",
   "addFriendsAction": "Ajouter des amis",
-
   "period30d": "30j",
   "period90d": "90j",
   "period1y": "1an",
   "periodAllTime": "Tout temps",
-
   "monthlyProgressChart": "Graphique de progression mensuel",
   "playAtLeastNGames": "Jouez au moins {count} matchs",
   "nOfNGames": "{current}/{total} matchs",
@@ -473,17 +468,14 @@
   "periodLabel90Days": "90 derniers jours",
   "periodLabelYear": "l'année",
   "periodLabelAllTime": "tout temps",
-
   "bestEloThisMonth": "Meilleur ELO ce mois",
   "bestEloPast90Days": "Meilleur ELO 90 derniers jours",
   "bestEloThisYear": "Meilleur ELO cette année",
   "bestEloAllTime": "Meilleur ELO de tous les temps",
-
   "lastNGames": "{count} derniers matchs",
   "noGamesPlayedYet": "Aucun match joué",
   "winsStreakCount": "{count} victoires",
   "lossesStreakCount": "{count} défaites",
-
   "partnerDetailsTitle": "Détails du partenaire",
   "overallRecord": "Bilan global",
   "games": "Matchs",
@@ -520,11 +512,9 @@
   "pageNotFoundMessage": "La page demandée est introuvable.",
   "inviteOnboardingTitle": "Vous êtes invité !",
   "inviteOnboardingSubtitle": "Vous êtes invité à rejoindre :",
-  "createAccount": "Créer un compte",
   "iHaveAnAccount": "J'ai un compte",
   "joinGroup": "Rejoindre le groupe",
   "joinGroupConfirmation": "Rejoindre le groupe ?",
-  "invitedBy": "Invité par {name}",
   "membersCount": "{count} membres",
   "inviteExpired": "Ce lien d'invitation a expiré",
   "inviteLinkRevoked": "Ce lien d'invitation n'est plus valide",
@@ -534,7 +524,6 @@
   "continueToApp": "Continuer vers l'application",
   "validatingInvite": "Validation de l'invitation...",
   "joiningGroup": "Rejoint le groupe...",
-
   "createAccountToJoin": "Créez votre compte pour rejoindre :",
   "fullNameHint": "Nom complet",
   "fullNameRequired": "Le nom complet est requis",
@@ -562,19 +551,16 @@
   "invalidEmailError": "Veuillez entrer une adresse email valide.",
   "networkError": "Impossible de se connecter. Veuillez vérifier votre connexion et réessayer.",
   "creatingAccount": "Création du compte...",
-
   "verifyEmailWarning": "Vérifiez votre email pour conserver votre compte. {daysRemaining} jours restants.",
   "verifyNow": "Vérifier maintenant",
   "dismiss": "Fermer",
   "emailVerifiedSuccess": "Email vérifié avec succès !",
-
   "accountRestricted": "Votre compte est restreint. Vérifiez votre email pour retrouver un accès complet. {daysUntilDeletion} jours avant la suppression du compte.",
   "accountScheduledForDeletion": "Votre compte est prévu pour suppression. Vérifiez votre email maintenant pour conserver votre compte.",
   "accountStatusActive": "Actif",
   "accountStatusPendingVerification": "Vérification en attente",
   "accountStatusRestricted": "Restreint",
   "accountStatusScheduledForDeletion": "Suppression prévue",
-
   "accountDeletionWarning": "Le compte sera supprimé dans {daysRemaining} jours.",
   "featureRestricted": "Cette fonctionnalité nécessite la vérification de l'email.",
   "verifyToUnlock": "Vérifiez votre email pour utiliser cette fonctionnalité.",
@@ -583,5 +569,9 @@
   "orLater": "ou plus tard",
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  },
+  "loadOlderActivities": "Charger les activités plus anciennes",
+  "@loadOlderActivities": {
+    "description": "Button label to load activities older than 90 days in the group details activity feed"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -96,7 +96,7 @@
   "resetPassword": "Reimposta Password",
   "backToLogin": "Torna al Login",
   "emailSent": "Email Inviata!",
-  "createAccount": "Crea Account",
+  "createAccount": "Crea un account",
   "accountCreatedSuccess": "Account creato con successo! Controlla la tua email per la verifica.",
   "alreadyHaveAccount": "Hai già un account? ",
   "signIn": "Accedi",
@@ -372,7 +372,7 @@
   "performanceStats": "Statistiche di Prestazione",
   "eloRatingLabel": "Classifica ELO",
   "peak": "Picco: {value}",
-  "winRate": "Percentuale Vittorie",
+  "winRate": "Percentuale vittorie",
   "winsLosses": "{wins}V - {losses}S",
   "streakLabel": "Serie",
   "winning": "Vittorie",
@@ -393,7 +393,6 @@
   "durationFormat": "{hours}h {minutes}m",
   "durationHours": "{hours}h",
   "durationMinutes": "{minutes}m",
-
   "bestPartner": "Miglior Partner",
   "noPartnerDataYet": "Nessun dato partner ancora",
   "playGamesWithTeammate": "Gioca 5+ partite con un compagno",
@@ -420,7 +419,6 @@
   "currentElo": "ELO attuale",
   "peakElo": "ELO massimo",
   "gamesPlayed": "Partite giocate",
-  "winRate": "Percentuale vittorie",
   "bestWin": "Migliore vittoria",
   "winGameToUnlock": "Vinci una partita per sbloccare",
   "beatOpponentsToTrack": "Batti gli avversari per tracciare le tue migliori vittorie",
@@ -447,18 +445,15 @@
   "playMoreGamesToSeeRoles": "Gioca più partite per vedere come ti comporti in diversi ruoli",
   "noStatsYet": "Nessuna stat ancora",
   "startPlayingToSeeStats": "Inizia a giocare per vedere le tue statistiche!",
-
   "playGamesToUnlockRankings": "Gioca per sbloccare le classifiche",
   "globalRank": "Classifica Globale",
   "percentile": "Percentile",
   "friendsRank": "Classifica Amici",
   "addFriendsAction": "Aggiungi amici",
-
   "period30d": "30g",
   "period90d": "90g",
   "period1y": "1a",
   "periodAllTime": "Sempre",
-
   "monthlyProgressChart": "Grafico progresso mensile",
   "playAtLeastNGames": "Gioca almeno {count} partite",
   "nOfNGames": "{current}/{total} partite",
@@ -473,17 +468,14 @@
   "periodLabel90Days": "90 giorni",
   "periodLabelYear": "anno",
   "periodLabelAllTime": "tutto il tempo",
-
   "bestEloThisMonth": "Miglior ELO questo mese",
   "bestEloPast90Days": "Miglior ELO ultimi 90 giorni",
   "bestEloThisYear": "Miglior ELO quest'anno",
   "bestEloAllTime": "Miglior ELO di sempre",
-
   "lastNGames": "Ultime {count} partite",
   "noGamesPlayedYet": "Nessuna partita giocata",
   "winsStreakCount": "{count} vittorie",
   "lossesStreakCount": "{count} sconfitte",
-
   "partnerDetailsTitle": "Dettagli partner",
   "overallRecord": "Bilancio generale",
   "games": "Partite",
@@ -520,11 +512,9 @@
   "pageNotFoundMessage": "La pagina richiesta non è stata trovata.",
   "inviteOnboardingTitle": "Sei stato invitato!",
   "inviteOnboardingSubtitle": "Sei stato invitato a unirti a:",
-  "createAccount": "Crea un account",
   "iHaveAnAccount": "Ho un account",
   "joinGroup": "Unisciti al gruppo",
   "joinGroupConfirmation": "Unirsi al gruppo?",
-  "invitedBy": "Invitato da {name}",
   "membersCount": "{count} membri",
   "inviteExpired": "Questo link di invito è scaduto",
   "inviteLinkRevoked": "Questo link di invito non è più valido",
@@ -534,7 +524,6 @@
   "continueToApp": "Continua all'app",
   "validatingInvite": "Convalida dell'invito...",
   "joiningGroup": "Entrando nel gruppo...",
-
   "createAccountToJoin": "Crea il tuo account per unirti:",
   "fullNameHint": "Nome completo",
   "fullNameRequired": "Il nome completo è obbligatorio",
@@ -562,19 +551,16 @@
   "invalidEmailError": "Inserisci un indirizzo email valido.",
   "networkError": "Impossibile connettersi. Controlla la tua connessione e riprova.",
   "creatingAccount": "Creazione account...",
-
   "verifyEmailWarning": "Verifica la tua email per mantenere il tuo account. {daysRemaining} giorni rimanenti.",
   "verifyNow": "Verifica ora",
   "dismiss": "Chiudi",
   "emailVerifiedSuccess": "Email verificata con successo!",
-
   "accountRestricted": "Il tuo account è limitato. Verifica la tua email per riottenere l'accesso completo. {daysUntilDeletion} giorni alla cancellazione dell'account.",
   "accountScheduledForDeletion": "Il tuo account è in programma per la cancellazione. Verifica la tua email ora per mantenere il tuo account.",
   "accountStatusActive": "Attivo",
   "accountStatusPendingVerification": "Verifica in sospeso",
   "accountStatusRestricted": "Limitato",
   "accountStatusScheduledForDeletion": "Cancellazione programmata",
-
   "accountDeletionWarning": "L'account verrà eliminato tra {daysRemaining} giorni.",
   "featureRestricted": "Questa funzione richiede la verifica dell'email.",
   "verifyToUnlock": "Verifica la tua email per usare questa funzione.",
@@ -583,5 +569,9 @@
   "orLater": "o più tardi",
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
+  },
+  "loadOlderActivities": "Carica attività più vecchie",
+  "@loadOlderActivities": {
+    "description": "Button label to load activities older than 90 days in the group details activity feed"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3505,6 +3505,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'or later'**
   String get orLater;
+
+  /// Button label to load activities older than 90 days in the group details activity feed
+  ///
+  /// In en, this message translates to:
+  /// **'Load older activities'**
+  String get loadOlderActivities;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1914,4 +1914,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get orLater => 'oder später';
+
+  @override
+  String get loadOlderActivities => 'Ältere Aktivitäten laden';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1879,4 +1879,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get orLater => 'or later';
+
+  @override
+  String get loadOlderActivities => 'Load older activities';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1904,4 +1904,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get orLater => 'o más tarde';
+
+  @override
+  String get loadOlderActivities => 'Cargar actividades más antiguas';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1917,4 +1917,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get orLater => 'ou plus tard';
+
+  @override
+  String get loadOlderActivities => 'Charger les activités plus anciennes';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1900,4 +1900,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get orLater => 'o più tardi';
+
+  @override
+  String get loadOlderActivities => 'Carica attività più vecchie';
 }

--- a/test/unit/core/data/repositories/mock_game_repository.dart
+++ b/test/unit/core/data/repositories/mock_game_repository.dart
@@ -599,6 +599,43 @@ class MockGameRepository implements GameRepository {
   }
 
   @override
+  Stream<List<GameModel>> getRecentGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async* {
+    final cutoff = DateTime.now().subtract(Duration(days: pastDays));
+    yield _games.values
+        .where((game) =>
+            game.groupId == groupId &&
+            game.scheduledAt.isAfter(cutoff))
+        .toList();
+
+    await for (final games in _gamesController.stream) {
+      final updatedCutoff = DateTime.now().subtract(Duration(days: pastDays));
+      yield games
+          .where((game) =>
+              game.groupId == groupId &&
+              game.scheduledAt.isAfter(updatedCutoff))
+          .toList();
+    }
+  }
+
+  @override
+  Future<List<GameModel>> getOlderGamesForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async {
+    final cutoff = DateTime.now().subtract(Duration(days: pastDays));
+    final games = _games.values
+        .where((game) =>
+            game.groupId == groupId &&
+            !game.scheduledAt.isAfter(cutoff))
+        .toList();
+    games.sort((a, b) => b.scheduledAt.compareTo(a.scheduledAt));
+    return games;
+  }
+
+  @override
   Stream<GameHistoryPage> getCompletedGames({
     String? groupId,
     int limit = 20,

--- a/test/unit/core/data/repositories/mock_training_session_repository.dart
+++ b/test/unit/core/data/repositories/mock_training_session_repository.dart
@@ -115,6 +115,43 @@ class MockTrainingSessionRepository implements TrainingSessionRepository {
   }
 
   @override
+  Stream<List<TrainingSessionModel>> getRecentTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async* {
+    final cutoff = DateTime.now().subtract(Duration(days: pastDays));
+    yield _sessions.values
+        .where((session) =>
+            session.groupId == groupId &&
+            session.startTime.isAfter(cutoff))
+        .toList();
+
+    await for (final sessions in _sessionsController.stream) {
+      final updatedCutoff = DateTime.now().subtract(Duration(days: pastDays));
+      yield sessions
+          .where((session) =>
+              session.groupId == groupId &&
+              session.startTime.isAfter(updatedCutoff))
+          .toList();
+    }
+  }
+
+  @override
+  Future<List<TrainingSessionModel>> getOlderTrainingSessionsForGroup(
+    String groupId, {
+    int pastDays = 90,
+  }) async {
+    final cutoff = DateTime.now().subtract(Duration(days: pastDays));
+    final sessions = _sessions.values
+        .where((session) =>
+            session.groupId == groupId &&
+            !session.startTime.isAfter(cutoff))
+        .toList()
+      ..sort((a, b) => b.startTime.compareTo(a.startTime));
+    return sessions;
+  }
+
+  @override
   Stream<List<TrainingSessionModel>> getTrainingSessionsForUser(String userId) {
     return _sessionsController.stream.map((sessions) => sessions
         .where((session) => session.isParticipant(userId))

--- a/test/unit/features/games/presentation/bloc/games_list/games_list_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/games_list/games_list_bloc_test.dart
@@ -412,24 +412,24 @@ void main() {
       build: () {
         final mockGameRepository = MockGameRepository();
         final mockTrainingRepository = MockTrainingSessionRepository();
-        
+
         final futureGame = createTestGame(
           id: 'game-1',
           title: 'Future Game',
           groupId: testGroupId,
           scheduledAt: DateTime.now().add(const Duration(days: 2)),
         );
-        
+
         final futureTraining = createTestTrainingSession(
           id: 'training-1',
           title: 'Future Training',
           groupId: testGroupId,
           startTime: DateTime.now().add(const Duration(days: 1)),
         );
-        
+
         mockGameRepository.addGame(futureGame);
         mockTrainingRepository.addSession(futureTraining);
-        
+
         return GamesListBloc(
           gameRepository: mockGameRepository,
           trainingSessionRepository: mockTrainingRepository,
@@ -438,13 +438,14 @@ void main() {
       act: (bloc) => bloc.add(
         const LoadGamesForGroup(groupId: testGroupId, userId: testUserId),
       ),
-      expect: () => [
-        const GamesListLoading(),
-        isA<GamesListLoaded>()
-            .having((s) => s.upcomingActivities.length, 'upcoming activities count', 2)
-            .having((s) => s.pastActivities.length, 'past activities count', 0)
-            .having((s) => s.userId, 'userId', testUserId),
-      ],
+      // With independent stream subscriptions, each stream emits independently.
+      // Use verify to check only the final settled state rather than intermediate states.
+      verify: (bloc) {
+        final state = bloc.state as GamesListLoaded;
+        expect(state.upcomingActivities.length, 2);
+        expect(state.pastActivities.length, 0);
+        expect(state.userId, testUserId);
+      },
     );
 
     blocTest<GamesListBloc, GamesListState>(


### PR DESCRIPTION
## Summary

- **90-day cutoff + Load older button**: `getRecentGamesForGroup` / `getRecentTrainingSessionsForGroup` fetch only upcoming and past-90-day data. A new "Load older activities" button triggers `LoadOlderActivities` event for on-demand fetching of older records.
- **Lazy BLoC init**: `GamesListBloc` stream no longer starts on page open. A `TabController` listener fires `LoadGamesForGroup` only when the Activities tab is first selected.
- **2-phase member loading**: Phase 1 fetches member names and clears the full-page spinner immediately. Phase 2 fetches friendship/request status in the background with per-row spinners.
- **Independent streams**: Replaced `Rx.combineLatest2` with two separate `StreamSubscription`s — each stream now emits as soon as its data arrives without waiting for the other.

## Test plan

- [x] All existing BLoC tests pass (`flutter test test/unit/features/games/presentation/bloc/games_list/`)
- [x] Updated "emits combined activities" test to use `verify` (final state check) instead of `expect` (all-states check) to accommodate independent stream timing
- [x] `flutter analyze` shows no new issues
- [x] Mock repositories updated with `getRecentGamesForGroup`, `getOlderGamesForGroup`, `getRecentTrainingSessionsForGroup`, `getOlderTrainingSessionsForGroup`
- [x] `loadOlderActivities` l10n key added to all 5 languages (EN, FR, DE, ES, IT)