### PR TITLE
Story 25.4: Migrate all Cloud Functions to europe-west6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ android/app/release.jks
 node_modules/
 infrastructure/terraform/.terraform/
 
+# Load test service account keys and credentials
+tools/load_test/*.json
+
 # Python
 __pycache__/
 *.py[cod]

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4779,9 +4779,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6814,9 +6814,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -7198,9 +7198,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8566,9 +8566,9 @@
       "license": "ISC"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
-      "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/functions/src/acceptInvitation.ts
+++ b/functions/src/acceptInvitation.ts
@@ -244,4 +244,4 @@ export async function acceptInvitationHandler(
  * - Validates friendship (Story 11.4 - mandatory for all invitations)
  * - Atomic batch operation for data consistency
  */
-export const acceptInvitation = functions.https.onCall(acceptInvitationHandler);
+export const acceptInvitation = functions.region('europe-west6').https.onCall(acceptInvitationHandler);

--- a/functions/src/autoAbortGames.ts
+++ b/functions/src/autoAbortGames.ts
@@ -17,7 +17,7 @@ import * as admin from 'firebase-admin';
  *
  * Story #285: Auto-Abort Games with Insufficient Players
  */
-export const autoAbortGames = functions.pubsub
+export const autoAbortGames = functions.region('europe-west6').pubsub
   .schedule('every 1 minutes') // Runs every minute for fast response
   .onRun(async (context) => {
     const firestore = admin.firestore();

--- a/functions/src/calculateUserRanking.ts
+++ b/functions/src/calculateUserRanking.ts
@@ -215,7 +215,7 @@ export async function calculateUserRankingHandler(
  * - User profile ranking display
  * - Leaderboard comparisons
  */
-export const calculateUserRanking = functions.https.onCall(async (data, context) => {
+export const calculateUserRanking = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/cancelTrainingSession.ts
+++ b/functions/src/cancelTrainingSession.ts
@@ -21,7 +21,7 @@ interface CancelTrainingSessionResponse {
 // Main Cloud Function
 // ============================================================================
 
-export const cancelTrainingSession = functions.https.onCall(
+export const cancelTrainingSession = functions.region('europe-west6').https.onCall(
   async (
     data: CancelTrainingSessionRequest,
     context: functions.https.CallableContext

--- a/functions/src/checkPendingInvitation.ts
+++ b/functions/src/checkPendingInvitation.ts
@@ -120,4 +120,4 @@ export async function checkPendingInvitationHandler(
  * - Uses Admin SDK to query Firestore (bypasses security rules)
  * - Returns only a boolean (no sensitive data exposed)
  */
-export const checkPendingInvitation = functions.https.onCall(checkPendingInvitationHandler);
+export const checkPendingInvitation = functions.region('europe-west6').https.onCall(checkPendingInvitationHandler);

--- a/functions/src/createTrainingSession.ts
+++ b/functions/src/createTrainingSession.ts
@@ -157,6 +157,7 @@ function validateLocation(locationName: string): string | null {
  * @returns CreateTrainingSessionResponse with sessionId
  */
 export const createTrainingSession = functions
+  .region('europe-west6')
   .runWith({
     timeoutSeconds: 30,
     memory: "256MB",

--- a/functions/src/createUserDocument.ts
+++ b/functions/src/createUserDocument.ts
@@ -15,7 +15,7 @@ import * as admin from "firebase-admin";
  * - Initializes profile with predictable structure
  * - Comprehensive logging for monitoring and debugging
  */
-export const createUserDocument = functions.auth.user().onCreate(async (user) => {
+export const createUserDocument = functions.region('europe-west6').auth.user().onCreate(async (user) => {
   const db = admin.firestore();
   const userRef = db.collection("users").doc(user.uid);
 
@@ -122,7 +122,7 @@ export const createUserDocument = functions.auth.user().onCreate(async (user) =>
  *
  * Note: This is a best-effort cleanup. Some data may be retained for audit purposes.
  */
-export const deleteUserDocument = functions.auth.user().onDelete(async (user) => {
+export const deleteUserDocument = functions.region('europe-west6').auth.user().onDelete(async (user) => {
   const db = admin.firestore();
 
   // Note: Using batch instead of transaction for cleanup operations

--- a/functions/src/declineInvitation.ts
+++ b/functions/src/declineInvitation.ts
@@ -156,4 +156,4 @@ export async function declineInvitationHandler(
  * - Uses Admin SDK to bypass security rules
  * - Validates invitation ownership
  */
-export const declineInvitation = functions.https.onCall(declineInvitationHandler);
+export const declineInvitation = functions.region('europe-west6').https.onCall(declineInvitationHandler);

--- a/functions/src/friendships.ts
+++ b/functions/src/friendships.ts
@@ -351,7 +351,7 @@ export async function sendFriendRequestHandler(
 /**
  * Cloud Function to send a friend request
  */
-export const sendFriendRequest = functions.https.onCall(
+export const sendFriendRequest = functions.region('europe-west6').https.onCall(
   sendFriendRequestHandler
 );
 
@@ -446,7 +446,7 @@ export async function acceptFriendRequestHandler(
 /**
  * Cloud Function to accept a friend request
  */
-export const acceptFriendRequest = functions.https.onCall(
+export const acceptFriendRequest = functions.region('europe-west6').https.onCall(
   acceptFriendRequestHandler
 );
 
@@ -541,7 +541,7 @@ export async function declineFriendRequestHandler(
 /**
  * Cloud Function to decline a friend request
  */
-export const declineFriendRequest = functions.https.onCall(
+export const declineFriendRequest = functions.region('europe-west6').https.onCall(
   declineFriendRequestHandler
 );
 
@@ -621,7 +621,7 @@ export async function removeFriendHandler(
 /**
  * Cloud Function to remove a friend
  */
-export const removeFriend = functions.https.onCall(removeFriendHandler);
+export const removeFriend = functions.region('europe-west6').https.onCall(removeFriendHandler);
 
 // ============================================================================
 // Function 5: Get Friends
@@ -784,7 +784,7 @@ export async function getFriendsHandler(
 /**
  * Cloud Function to get a user's friends list
  */
-export const getFriends = functions.https.onCall(async (data, context) => {
+export const getFriends = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {
@@ -897,7 +897,7 @@ export async function checkFriendshipStatusHandler(
 /**
  * Cloud Function to check friendship status with another user
  */
-export const checkFriendshipStatus = functions.https.onCall(
+export const checkFriendshipStatus = functions.region('europe-west6').https.onCall(
   checkFriendshipStatusHandler
 );
 
@@ -1000,7 +1000,7 @@ export async function getFriendshipRequestsHandler(
 /**
  * Cloud Function to get all pending friendship requests for the authenticated user
  */
-export const getFriendshipRequests = functions.https.onCall(
+export const getFriendshipRequests = functions.region('europe-west6').https.onCall(
   getFriendshipRequestsHandler
 );
 
@@ -1019,7 +1019,7 @@ export const getFriendshipRequests = functions.https.onCall(
  *
  * Performance: Uses batched writes to minimize Firestore operations
  */
-export const onFriendRequestAccepted = functions.firestore
+export const onFriendRequestAccepted = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -1090,7 +1090,7 @@ export const onFriendRequestAccepted = functions.firestore
  *
  * Performance: Uses batched writes to minimize Firestore operations
  */
-export const onFriendRemoved = functions.firestore
+export const onFriendRemoved = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onDelete(async (snap, context) => {
     const data = snap.data();
@@ -1380,7 +1380,7 @@ export async function getFriendshipsHandler(
  * Cloud Function to get friendships by status with denormalized user info
  * Story 11.13: Unified function to replace getFriends and getFriendshipRequests
  */
-export const getFriendships = functions.https.onCall(getFriendshipsHandler);
+export const getFriendships = functions.region('europe-west6').https.onCall(getFriendshipsHandler);
 
 // ============================================================================
 // Helper Functions (Story 11.4)
@@ -1504,7 +1504,7 @@ export async function verifyFriendshipHandler(
  * Story 11.14: Enables Groups layer to validate member invitations
  * via the social graph API
  */
-export const verifyFriendship = functions.https.onCall(
+export const verifyFriendship = functions.region('europe-west6').https.onCall(
   verifyFriendshipHandler
 );
 
@@ -1625,7 +1625,7 @@ export async function batchCheckFriendshipHandler(
  *
  * Performance: O(1) Firestore reads regardless of user count (up to 100)
  */
-export const batchCheckFriendship = functions.https.onCall(async (data, context) => {
+export const batchCheckFriendship = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {
@@ -1800,6 +1800,6 @@ export async function batchCheckFriendRequestStatusHandler(
  * Performance: O(N/10) Firestore reads (due to 'in' query limit of 10)
  * Still much better than 2N individual reads
  */
-export const batchCheckFriendRequestStatus = functions.https.onCall(
+export const batchCheckFriendRequestStatus = functions.region('europe-west6').https.onCall(
   batchCheckFriendRequestStatusHandler
 );

--- a/functions/src/gameUpdates.ts
+++ b/functions/src/gameUpdates.ts
@@ -16,6 +16,7 @@ import { processGameEloUpdates } from "./elo";
  * - onHeadToHeadStatsUpdated: Nemesis (triggered by h2h doc changes)
  */
 export const onGameStatusChanged = functions
+  .region('europe-west6')
   .runWith({
     timeoutSeconds: 60, // Fast now - only ELO + teammate stats
     memory: "512MB",

--- a/functions/src/generateRecurringTrainingSessions.ts
+++ b/functions/src/generateRecurringTrainingSessions.ts
@@ -192,6 +192,7 @@ async function createSessionInstance(
  * @returns GenerateRecurringSessionsResponse with generated session IDs
  */
 export const generateRecurringTrainingSessions = functions
+  .region('europe-west6')
   .runWith({
     timeoutSeconds: 60,
     memory: "512MB",

--- a/functions/src/getCompletedGames.ts
+++ b/functions/src/getCompletedGames.ts
@@ -272,6 +272,6 @@ export async function getCompletedGamesHandler(
  * });
  * ```
  */
-export const getCompletedGames = functions.https.onCall(
+export const getCompletedGames = functions.region('europe-west6').https.onCall(
   getCompletedGamesHandler
 );

--- a/functions/src/getGamesForGroup.ts
+++ b/functions/src/getGamesForGroup.ts
@@ -245,7 +245,7 @@ export async function getGamesForGroupHandler(
  * (see FirestoreGameRepository.getGamesForGroup). This function serves as
  * a complementary approach for specific use cases.
  */
-export const getGamesForGroup = functions.https.onCall(async (data, context) => {
+export const getGamesForGroup = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/getHeadToHeadStats.ts
+++ b/functions/src/getHeadToHeadStats.ts
@@ -10,7 +10,7 @@ import { writePerformanceEvent } from "./helpers/analytics";
  * @param opponentId - The ID of the opponent to get stats against
  * @returns Head-to-head statistics document or null if not found
  */
-export const getHeadToHeadStats = functions.https.onCall(
+export const getHeadToHeadStats = functions.region('europe-west6').https.onCall(
   async (data, context) => {
     const start = Date.now();
     let status: "success" | "error" = "success";

--- a/functions/src/getPublicUserProfile.ts
+++ b/functions/src/getPublicUserProfile.ts
@@ -135,6 +135,6 @@ export async function getPublicUserProfileHandler(
  * - User profile viewing
  * - Friend profile display
  */
-export const getPublicUserProfile = functions.https.onCall(
+export const getPublicUserProfile = functions.region('europe-west6').https.onCall(
   getPublicUserProfileHandler
 );

--- a/functions/src/getTrainingFeedback.ts
+++ b/functions/src/getTrainingFeedback.ts
@@ -58,7 +58,7 @@ async function getTrainingSessionData(
 // Main Cloud Function
 // ============================================================================
 
-export const getTrainingFeedback = functions.https.onCall(
+export const getTrainingFeedback = functions.region('europe-west6').https.onCall(
   async (
     data: GetTrainingFeedbackRequest,
     context: functions.https.CallableContext

--- a/functions/src/getUpcomingGamesForUser.ts
+++ b/functions/src/getUpcomingGamesForUser.ts
@@ -239,7 +239,7 @@ export async function getUpcomingGamesForUserHandler(
  * final nextGame = games.isNotEmpty ? games.first : null;
  * ```
  */
-export const getUpcomingGamesForUser = functions.https.onCall(async (data, context) => {
+export const getUpcomingGamesForUser = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/getUpcomingTrainingSessionsForUser.ts
+++ b/functions/src/getUpcomingTrainingSessionsForUser.ts
@@ -227,7 +227,7 @@ export async function getUpcomingTrainingSessionsForUserHandler(
  * final nextSession = sessions.isNotEmpty ? sessions.first : null;
  * ```
  */
-export const getUpcomingTrainingSessionsForUser = functions.https.onCall(async (data, context) => {
+export const getUpcomingTrainingSessionsForUser = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/getUsersByIds.ts
+++ b/functions/src/getUsersByIds.ts
@@ -152,7 +152,7 @@ export async function getUsersByIdsHandler(
  * - Uses Admin SDK to bypass security rules
  * - Limited to 100 users per request to prevent abuse
  */
-export const getUsersByIds = functions.https.onCall(async (data, context) => {
+export const getUsersByIds = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/hasSubmittedTrainingFeedback.ts
+++ b/functions/src/hasSubmittedTrainingFeedback.ts
@@ -131,6 +131,6 @@ export async function hasSubmittedTrainingFeedbackHandler(
     }
 }
 
-export const hasSubmittedTrainingFeedback = functions.https.onCall(
+export const hasSubmittedTrainingFeedback = functions.region('europe-west6').https.onCall(
   hasSubmittedTrainingFeedbackHandler
 );

--- a/functions/src/headToHeadGameUpdates.ts
+++ b/functions/src/headToHeadGameUpdates.ts
@@ -14,6 +14,7 @@ import { updateHeadToHeadStats } from "./statsTracking";
  * Trigger: onUpdate when eloCalculated changes from false to true
  */
 export const onEloCalculationComplete = functions
+  .region('europe-west6')
   .runWith({
     timeoutSeconds: 180, // 3 minutes - multiple h2h transactions can be slow
     memory: "512MB",

--- a/functions/src/headToHeadUpdates.ts
+++ b/functions/src/headToHeadUpdates.ts
@@ -14,6 +14,7 @@ import { updateNemesis } from "./statsTracking";
  * Trigger: onCreate, onUpdate of users/{userId}/headToHead/{opponentId}
  */
 export const onHeadToHeadStatsUpdated = functions
+  .region('europe-west6')
   .runWith({
     timeoutSeconds: 60, // Nemesis calculation for single user should be fast
     memory: "256MB",

--- a/functions/src/healthCheck.ts
+++ b/functions/src/healthCheck.ts
@@ -22,4 +22,4 @@ export async function healthCheckHandler(
  * Used by the post-deploy smoke test in cd-beta.yml and cd-production.yml
  * to confirm that functions are running after a deployment.
  */
-export const healthCheck = functions.https.onCall(healthCheckHandler);
+export const healthCheck = functions.region('europe-west6').https.onCall(healthCheckHandler);

--- a/functions/src/inviteToGroup.ts
+++ b/functions/src/inviteToGroup.ts
@@ -356,4 +356,4 @@ export async function inviteToGroupHandler(
  * Cloud Function to invite a user to a group
  * Story 11.16: Enforces that only confirmed friends can be invited to groups
  */
-export const inviteToGroup = functions.https.onCall(inviteToGroupHandler);
+export const inviteToGroup = functions.region('europe-west6').https.onCall(inviteToGroupHandler);

--- a/functions/src/invites/createGroupInvite.ts
+++ b/functions/src/invites/createGroupInvite.ts
@@ -202,6 +202,6 @@ export async function createGroupInviteHandler(
   }
 }
 
-export const createGroupInvite = functions.https.onCall(
+export const createGroupInvite = functions.region('europe-west6').https.onCall(
   createGroupInviteHandler
 );

--- a/functions/src/invites/joinGroupViaInvite.ts
+++ b/functions/src/invites/joinGroupViaInvite.ts
@@ -202,6 +202,6 @@ export async function joinGroupViaInviteHandler(
   }
 }
 
-export const joinGroupViaInvite = functions.https.onCall(
+export const joinGroupViaInvite = functions.region('europe-west6').https.onCall(
   joinGroupViaInviteHandler
 );

--- a/functions/src/invites/revokeGroupInvite.ts
+++ b/functions/src/invites/revokeGroupInvite.ts
@@ -144,6 +144,6 @@ export async function revokeGroupInviteHandler(
   }
 }
 
-export const revokeGroupInvite = functions.https.onCall(
+export const revokeGroupInvite = functions.region('europe-west6').https.onCall(
   revokeGroupInviteHandler
 );

--- a/functions/src/invites/validateInviteToken.ts
+++ b/functions/src/invites/validateInviteToken.ts
@@ -211,6 +211,6 @@ export async function validateInviteTokenHandler(
   }
 }
 
-export const validateInviteToken = functions.https.onCall(
+export const validateInviteToken = functions.region('europe-west6').https.onCall(
   validateInviteTokenHandler
 );

--- a/functions/src/joinTrainingSession.ts
+++ b/functions/src/joinTrainingSession.ts
@@ -71,7 +71,7 @@ async function isGroupMember(
 // Main Cloud Function
 // ============================================================================
 
-export const joinTrainingSession = functions.https.onCall(
+export const joinTrainingSession = functions.region('europe-west6').https.onCall(
   async (
     data: JoinTrainingSessionRequest,
     context: functions.https.CallableContext

--- a/functions/src/leaveGroup.ts
+++ b/functions/src/leaveGroup.ts
@@ -195,4 +195,4 @@ export async function leaveGroupHandler(
  * - Prevents last admin from leaving
  * - Atomic batch operation for data consistency
  */
-export const leaveGroup = functions.https.onCall(leaveGroupHandler);
+export const leaveGroup = functions.region('europe-west6').https.onCall(leaveGroupHandler);

--- a/functions/src/leaveTrainingSession.ts
+++ b/functions/src/leaveTrainingSession.ts
@@ -47,7 +47,7 @@ async function getTrainingSessionData(
 // Main Cloud Function
 // ============================================================================
 
-export const leaveTrainingSession = functions.https.onCall(
+export const leaveTrainingSession = functions.region('europe-west6').https.onCall(
   async (
     data: LeaveTrainingSessionRequest,
     context: functions.https.CallableContext

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -31,7 +31,7 @@ function isQuietHours(quietHours: any): boolean {
 /**
  * Send notification when user is invited to a group
  */
-export const onInvitationCreated = functions.firestore
+export const onInvitationCreated = functions.region('europe-west6').firestore
   .document("users/{userId}/invitations/{invitationId}")
   .onCreate(async (snapshot, context) => {
     const invitation = snapshot.data();
@@ -189,7 +189,7 @@ export const onInvitationCreated = functions.firestore
 /**
  * Send notification when invitation is accepted
  */
-export const onInvitationAccepted = functions.firestore
+export const onInvitationAccepted = functions.region('europe-west6').firestore
   .document("users/{userId}/invitations/{invitationId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -312,7 +312,7 @@ export const onInvitationAccepted = functions.firestore
  * Send notification when a new game is created
  * Notifies all group members except the creator
  */
-export const onGameCreated = functions.firestore
+export const onGameCreated = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onCreate(async (snapshot, context) => {
     const game = snapshot.data();
@@ -554,7 +554,7 @@ export const onGameCreated = functions.firestore
 /**
  * Send notification when a member joins the group
  */
-export const onMemberJoined = functions.firestore
+export const onMemberJoined = functions.region('europe-west6').firestore
   .document("groups/{groupId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -668,7 +668,7 @@ export const onMemberJoined = functions.firestore
 /**
  * Send notification when a member leaves the group
  */
-export const onMemberLeft = functions.firestore
+export const onMemberLeft = functions.region('europe-west6').firestore
   .document("groups/{groupId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -781,7 +781,7 @@ export const onMemberLeft = functions.firestore
 /**
  * Send notification when user's role changes (promoted to/demoted from admin)
  */
-export const onRoleChanged = functions.firestore
+export const onRoleChanged = functions.region('europe-west6').firestore
   .document("groups/{groupId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -919,7 +919,7 @@ export const onRoleChanged = functions.firestore
 /**
  * Send notification when a friend request is sent
  */
-export const onFriendRequestSent = functions.firestore
+export const onFriendRequestSent = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onCreate(async (snapshot, context) => {
     const friendship = snapshot.data();
@@ -1078,7 +1078,7 @@ export const onFriendRequestSent = functions.firestore
 /**
  * Send notification when a friend request is accepted
  */
-export const onFriendRequestAccepted = functions.firestore
+export const onFriendRequestAccepted = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -1263,7 +1263,7 @@ export const onFriendRequestAccepted = functions.firestore
 /**
  * Silent cleanup when a friend request is declined
  */
-export const onFriendRequestDeclined = functions.firestore
+export const onFriendRequestDeclined = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -1290,7 +1290,7 @@ export const onFriendRequestDeclined = functions.firestore
 /**
  * Handle friend removal (cleanup caches)
  */
-export const onFriendRemoved = functions.firestore
+export const onFriendRemoved = functions.region('europe-west6').firestore
   .document("friendships/{friendshipId}")
   .onDelete(async (snapshot, context) => {
     const friendship = snapshot.data();
@@ -1367,7 +1367,7 @@ export const onFriendRemoved = functions.firestore
  * Send notification when a player joins a game
  * Notifies all current players except the one who just joined
  */
-export const onPlayerJoinedGame = functions.firestore
+export const onPlayerJoinedGame = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -1633,7 +1633,7 @@ export const onPlayerJoinedGame = functions.firestore
  * Send notification when a player leaves a game
  * Notifies all remaining players except the one who left
  */
-export const onPlayerLeftGame = functions.firestore
+export const onPlayerLeftGame = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -1899,7 +1899,7 @@ export const onPlayerLeftGame = functions.firestore
  * Send notification when a waitlist user is promoted to player
  * Notifies the promoted user and all current players
  */
-export const onWaitlistPromoted = functions.firestore
+export const onWaitlistPromoted = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -2268,7 +2268,7 @@ export const onWaitlistPromoted = functions.firestore
  * Notifies all confirmed participants except the user who submitted the result
  * Story 14.15: Notifications for Game Result Verification
  */
-export const onGameResultSubmitted = functions.firestore
+export const onGameResultSubmitted = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();
@@ -2501,7 +2501,7 @@ export const onGameResultSubmitted = functions.firestore
 /**
  * Send notification when a game is cancelled (e.g. auto-aborted due to insufficient players)
  */
-export const onGameCancelled = functions.firestore
+export const onGameCancelled = functions.region('europe-west6').firestore
   .document("games/{gameId}")
   .onUpdate(async (change, context) => {
     const before = change.before.data();

--- a/functions/src/scheduled/cleanupUnverifiedAccounts.ts
+++ b/functions/src/scheduled/cleanupUnverifiedAccounts.ts
@@ -32,7 +32,7 @@ const DRY_RUN = true;
  *
  * Story 17.8.4: Scheduled Cloud Functions for Account Cleanup (#481)
  */
-export const cleanupUnverifiedAccounts = functions.pubsub
+export const cleanupUnverifiedAccounts = functions.region('europe-west6').pubsub
   .schedule("every 24 hours")
   .onRun(async () => {
     const db = admin.firestore();

--- a/functions/src/scheduled/updateAccountStatuses.ts
+++ b/functions/src/scheduled/updateAccountStatuses.ts
@@ -20,7 +20,7 @@ const BATCH_SIZE = 500;
  *
  * Story 17.8.4: Scheduled Cloud Functions for Account Cleanup (#481)
  */
-export const updateAccountStatuses = functions.pubsub
+export const updateAccountStatuses = functions.region('europe-west6').pubsub
   .schedule("every 24 hours")
   .onRun(async () => {
     const db = admin.firestore();

--- a/functions/src/searchUserByEmail.ts
+++ b/functions/src/searchUserByEmail.ts
@@ -202,7 +202,7 @@ export async function searchUserByEmailHandler(
  * This function provides a secure way to look up users without exposing
  * the entire /users collection to client-side queries.
  */
-export const searchUserByEmail = functions.https.onCall(async (data, context) => {
+export const searchUserByEmail = functions.region('europe-west6').https.onCall(async (data, context) => {
   const start = Date.now();
   let status: "success" | "error" = "success";
   try {

--- a/functions/src/searchUsers.ts
+++ b/functions/src/searchUsers.ts
@@ -174,4 +174,4 @@ export async function searchUsersHandler(
  *
  * Following Epic 11's Cloud Function-first architecture.
  */
-export const searchUsers = functions.https.onCall(searchUsersHandler);
+export const searchUsers = functions.region('europe-west6').https.onCall(searchUsersHandler);

--- a/functions/src/submitTrainingFeedback.ts
+++ b/functions/src/submitTrainingFeedback.ts
@@ -306,6 +306,6 @@ export async function submitTrainingFeedbackHandler(
     }
 }
 
-export const submitTrainingFeedback = functions.https.onCall(
+export const submitTrainingFeedback = functions.region('europe-west6').https.onCall(
   submitTrainingFeedbackHandler
 );

--- a/functions/src/trainingSessionNotifications.ts
+++ b/functions/src/trainingSessionNotifications.ts
@@ -258,7 +258,7 @@ function formatDateTime(timestamp: admin.firestore.Timestamp): string {
 // Notifies all group members when a new training session is created
 // ============================================================================
 
-export const onTrainingSessionCreated = functions.firestore
+export const onTrainingSessionCreated = functions.region('europe-west6').firestore
   .document("trainingSessions/{sessionId}")
   .onCreate(async (snapshot, context) => {
     const sessionData = snapshot.data();
@@ -362,7 +362,7 @@ export const onTrainingSessionCreated = functions.firestore
 // Handles: minimum participants reached, session cancelled
 // ============================================================================
 
-export const onTrainingSessionUpdated = functions.firestore
+export const onTrainingSessionUpdated = functions.region('europe-west6').firestore
   .document("trainingSessions/{sessionId}")
   .onUpdate(async (change, context) => {
     const beforeData = change.before.data();
@@ -573,7 +573,7 @@ async function handleSessionCancelled(
 // Notifies all participants when someone submits feedback
 // ============================================================================
 
-export const onTrainingFeedbackCreated = functions.firestore
+export const onTrainingFeedbackCreated = functions.region('europe-west6').firestore
   .document("trainingSessions/{sessionId}/feedback/{feedbackId}")
   .onCreate(async (snapshot, context) => {
     const feedbackData = snapshot.data();
@@ -682,7 +682,7 @@ export const onTrainingFeedbackCreated = functions.firestore
 // Notifies group members when someone joins a training session
 // ============================================================================
 
-export const onParticipantJoined = functions.firestore
+export const onParticipantJoined = functions.region('europe-west6').firestore
   .document("trainingSessions/{sessionId}/participants/{userId}")
   .onCreate(async (snapshot, context) => {
     const sessionId = context.params.sessionId;
@@ -806,7 +806,7 @@ export const onParticipantJoined = functions.firestore
 // Notifies group members and organizer when someone leaves a training session
 // ============================================================================
 
-export const onParticipantLeft = functions.firestore
+export const onParticipantLeft = functions.region('europe-west6').firestore
   .document("trainingSessions/{sessionId}/participants/{userId}")
   .onUpdate(async (change, context) => {
     const sessionId = context.params.sessionId;

--- a/functions/src/updateUserNames.ts
+++ b/functions/src/updateUserNames.ts
@@ -13,7 +13,7 @@ import * as admin from "firebase-admin";
  * @param data.firstName - User's first name (required, min 2 chars)
  * @param data.lastName - User's last name (required, min 2 chars)
  */
-export const updateUserNames = functions.https.onCall(async (data, context) => {
+export const updateUserNames = functions.region('europe-west6').https.onCall(async (data, context) => {
   // 1. Validate authentication
   if (!context.auth) {
     throw new functions.https.HttpsError(

--- a/functions/test/unit/analytics.test.ts
+++ b/functions/test/unit/analytics.test.ts
@@ -25,14 +25,18 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  logger: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    logger: {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("writeAnalyticsEvent", () => {
   let mockAdd: jest.Mock;

--- a/functions/test/unit/getPublicUserProfile.test.ts
+++ b/functions/test/unit/getPublicUserProfile.test.ts
@@ -22,8 +22,9 @@ jest.mock("firebase-admin", () => ({
   })),
 }));
 
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       constructor(public code: string, message: string) {
         super(message);
@@ -33,7 +34,10 @@ jest.mock("firebase-functions", () => ({
     onCall: jest.fn((handler) => handler),
   },
   logger: mockLogger,
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 import {getPublicUserProfileHandler} from "../../src/getPublicUserProfile";
 

--- a/functions/test/unit/hasSubmittedTrainingFeedback.test.ts
+++ b/functions/test/unit/hasSubmittedTrainingFeedback.test.ts
@@ -21,8 +21,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -39,7 +40,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("hasSubmittedTrainingFeedback Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/healthCheck.test.ts
+++ b/functions/test/unit/healthCheck.test.ts
@@ -2,14 +2,18 @@
 
 import {healthCheckHandler} from "../../src/healthCheck";
 
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     onCall: jest.fn((handler) => handler),
   },
   logger: {
     info: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("healthCheck Cloud Function", () => {
   beforeEach(() => {

--- a/functions/test/unit/inviteToGroup.test.ts
+++ b/functions/test/unit/inviteToGroup.test.ts
@@ -29,8 +29,9 @@ jest.mock("../../src/friendships", () => ({
 }));
 
 // Mock firebase-functions with logger
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -52,7 +53,10 @@ jest.mock("firebase-functions", () => ({
       serverTimestamp: jest.fn(() => "TIMESTAMP"),
     },
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 // Import functions to access logger
 const functions = require("firebase-functions");

--- a/functions/test/unit/invites/createGroupInvite.test.ts
+++ b/functions/test/unit/invites/createGroupInvite.test.ts
@@ -31,8 +31,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -49,7 +50,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("createGroupInvite Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/invites/joinGroupViaInvite.test.ts
+++ b/functions/test/unit/invites/joinGroupViaInvite.test.ts
@@ -29,8 +29,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -47,7 +48,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("joinGroupViaInvite Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/invites/revokeGroupInvite.test.ts
+++ b/functions/test/unit/invites/revokeGroupInvite.test.ts
@@ -21,8 +21,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -39,7 +40,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("revokeGroupInvite Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/invites/validateInviteToken.test.ts
+++ b/functions/test/unit/invites/validateInviteToken.test.ts
@@ -21,8 +21,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -39,7 +40,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("validateInviteToken Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/onGameCreated.test.ts
+++ b/functions/test/unit/onGameCreated.test.ts
@@ -30,8 +30,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  firestore: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    firestore: {
     document: jest.fn(() => ({
       onCreate: jest.fn((handler) => handler),
       onUpdate: jest.fn((handler) => handler),
@@ -44,7 +45,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("onGameCreated Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/onGameResultSubmitted.test.ts
+++ b/functions/test/unit/onGameResultSubmitted.test.ts
@@ -30,8 +30,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  firestore: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    firestore: {
     document: jest.fn(() => ({
       onCreate: jest.fn((handler) => handler),
       onUpdate: jest.fn((handler) => handler),
@@ -44,7 +45,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("onGameResultSubmitted Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/onPlayerJoinedGame.test.ts
+++ b/functions/test/unit/onPlayerJoinedGame.test.ts
@@ -30,8 +30,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  firestore: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    firestore: {
     document: jest.fn(() => ({
       onCreate: jest.fn((handler) => handler),
       onUpdate: jest.fn((handler) => handler),
@@ -44,7 +45,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("onPlayerJoinedGame Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/onPlayerLeftGame.test.ts
+++ b/functions/test/unit/onPlayerLeftGame.test.ts
@@ -30,8 +30,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  firestore: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    firestore: {
     document: jest.fn(() => ({
       onCreate: jest.fn((handler) => handler),
       onUpdate: jest.fn((handler) => handler),
@@ -44,7 +45,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("onPlayerLeftGame Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/onWaitlistPromoted.test.ts
+++ b/functions/test/unit/onWaitlistPromoted.test.ts
@@ -30,8 +30,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  firestore: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    firestore: {
     document: jest.fn(() => ({
       onCreate: jest.fn((handler) => handler),
       onUpdate: jest.fn((handler) => handler),
@@ -44,7 +45,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("onWaitlistPromoted Cloud Function", () => {
   let mockDb: any;

--- a/functions/test/unit/scheduled/cleanupUnverifiedAccounts.test.ts
+++ b/functions/test/unit/scheduled/cleanupUnverifiedAccounts.test.ts
@@ -31,8 +31,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  pubsub: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    pubsub: {
     schedule: jest.fn(() => ({
       onRun: jest.fn((handler: Function) => handler),
     })),
@@ -43,7 +44,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 // Import handler after mocks are set up
 import {cleanupUnverifiedAccounts} from

--- a/functions/test/unit/scheduled/updateAccountStatuses.test.ts
+++ b/functions/test/unit/scheduled/updateAccountStatuses.test.ts
@@ -26,8 +26,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  pubsub: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    pubsub: {
     schedule: jest.fn(() => ({
       onRun: jest.fn((handler: Function) => handler),
     })),
@@ -38,7 +39,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 // Import handler after mocks are set up
 import {updateAccountStatuses} from

--- a/functions/test/unit/submitTrainingFeedback.test.ts
+++ b/functions/test/unit/submitTrainingFeedback.test.ts
@@ -28,8 +28,9 @@ jest.mock("firebase-admin", () => {
 });
 
 // Mock firebase-functions
-jest.mock("firebase-functions", () => ({
-  https: {
+jest.mock("firebase-functions", () => {
+  const _fn = {
+    https: {
     HttpsError: class HttpsError extends Error {
       code: string;
       constructor(code: string, message: string) {
@@ -46,7 +47,10 @@ jest.mock("firebase-functions", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
-}));
+  };
+  (_fn as any).region = jest.fn(() => _fn);
+  return _fn;
+})
 
 describe("submitTrainingFeedback Cloud Function", () => {
   let mockDb: any;

--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -1217,7 +1217,7 @@ class FirestoreGameRepository implements GameRepository {
     try {
       // Call Cloud Function to fetch completed games
       final callable =
-          FirebaseFunctions.instance.httpsCallable('getCompletedGames');
+          FirebaseFunctions.instanceFor(region: 'europe-west6').httpsCallable('getCompletedGames');
 
       final result = await callable.call({
         if (groupId != null) 'groupId': groupId,

--- a/lib/core/data/repositories/firestore_group_repository.dart
+++ b/lib/core/data/repositories/firestore_group_repository.dart
@@ -280,7 +280,7 @@ class FirestoreGroupRepository implements GroupRepository {
   @override
   Future<void> leaveGroup(String groupId) async {
     try {
-      final callable = FirebaseFunctions.instance.httpsCallable('leaveGroup');
+      final callable = FirebaseFunctions.instanceFor(region: 'europe-west6').httpsCallable('leaveGroup');
       final result = await callable.call<Map<String, dynamic>>({
         'groupId': groupId,
       });

--- a/lib/core/data/repositories/firestore_invitation_repository.dart
+++ b/lib/core/data/repositories/firestore_invitation_repository.dart
@@ -20,7 +20,7 @@ class FirestoreInvitationRepository implements InvitationRepository {
     FirebaseFunctions? functions,
     GroupRepository? groupRepository,
   })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _functions = functions ?? FirebaseFunctions.instance;
+        _functions = functions ?? FirebaseFunctions.instanceFor(region: 'europe-west6');
 
   @override
   Future<String> sendInvitation({

--- a/lib/core/data/repositories/firestore_training_feedback_repository.dart
+++ b/lib/core/data/repositories/firestore_training_feedback_repository.dart
@@ -26,7 +26,7 @@ class FirestoreTrainingFeedbackRepository
     FirebaseFunctions? functions,
     FirebaseAuth? auth,
   })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _functions = functions ?? FirebaseFunctions.instance,
+        _functions = functions ?? FirebaseFunctions.instanceFor(region: 'europe-west6'),
         _auth = auth ?? FirebaseAuth.instance;
 
   /// Get feedback collection reference for a training session

--- a/lib/core/data/repositories/firestore_training_session_repository.dart
+++ b/lib/core/data/repositories/firestore_training_session_repository.dart
@@ -29,7 +29,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
     FirebaseFunctions? functions,
     required GroupRepository groupRepository,
   })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _functions = functions ?? FirebaseFunctions.instance,
+        _functions = functions ?? FirebaseFunctions.instanceFor(region: 'europe-west6'),
         _groupRepository = groupRepository;
 
   @override

--- a/lib/core/data/repositories/firestore_user_repository.dart
+++ b/lib/core/data/repositories/firestore_user_repository.dart
@@ -32,7 +32,7 @@ class FirestoreUserRepository implements UserRepository {
     FirebaseFunctions? functions,
   }) : _firestore = firestore ?? FirebaseFirestore.instance,
         _auth = auth ?? FirebaseAuth.instance,
-        _functions = functions ?? FirebaseFunctions.instance;
+        _functions = functions ?? FirebaseFunctions.instanceFor(region: 'europe-west6');
 
   @override
   Stream<UserModel?> get currentUser {

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -105,7 +105,7 @@ Future<void> initializeDependencies() async {
   }
 
   if (!sl.isRegistered<FirebaseFunctions>()) {
-    sl.registerLazySingleton<FirebaseFunctions>(() => FirebaseFunctions.instance);
+    sl.registerLazySingleton<FirebaseFunctions>(() => FirebaseFunctions.instanceFor(region: 'europe-west6'));
   }
 
   if (!sl.isRegistered<FirebaseAnalytics>()) {

--- a/lib/features/auth/data/repositories/firebase_auth_repository.dart
+++ b/lib/features/auth/data/repositories/firebase_auth_repository.dart
@@ -15,7 +15,7 @@ class FirebaseAuthRepository implements AuthRepository {
     FirebaseAuth? firebaseAuth,
     FirebaseFunctions? functions,
   })  : _firebaseAuth = firebaseAuth ?? FirebaseAuth.instance,
-        _functions = functions ?? FirebaseFunctions.instance;
+        _functions = functions ?? FirebaseFunctions.instanceFor(region: 'europe-west6');
 
   @override
   UserEntity? get currentUser {


### PR DESCRIPTION
## Summary

- Moves all 39 Cloud Functions (callable, Firestore triggers, pubsub/scheduled, auth triggers) from `us-central1` to `europe-west6` (Zurich) to co-locate with our Firestore instance
- Eliminates ~400ms transatlantic round-trip latency measured in Story 25.3 benchmarks
- Updates Flutter client (`service_locator.dart` + all repository fallbacks) to call `FirebaseFunctions.instanceFor(region: 'europe-west6')`
- Updates 17 unit test files to expose `region()` on firebase-functions mock
- Adds baseline load test benchmark results (`tools/load_test/BENCHMARKS.md`)

## Deployed

- ✅ `gatherli-dev` — deployed (old us-central1 functions removed)
- ✅ `gatherli-prod` — deployed (old us-central1 functions removed)

## Test plan

- [x] `npm test` in `functions/` — 406/406 pass
- [x] `flutter analyze` — no issues
- [x] `flutter test test/unit/` — 2619 tests pass
- [x] Verified all functions appear in Firebase Console under europe-west6