### PR TITLE
Story 25.7: Store load test results in BigQuery

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3717,9 +3717,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3804,9 +3804,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4616,9 +4616,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4779,9 +4779,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6814,9 +6814,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -7185,9 +7185,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7198,9 +7198,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8431,9 +8431,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/load_test/BENCHMARKS.md
+++ b/tools/load_test/BENCHMARKS.md
@@ -15,8 +15,18 @@ Run the tool against gatherli-dev and paste the output below.
 ```bash
 cd tools/load_test
 export GATHERLI_DEV_SERVICE_ACCOUNT=/path/to/gatherli-dev-service-account.json
+
+# Run and print results to console only
 npx ts-node src/index.ts --all --concurrency 5 --requests 50
+
+# Run and also store results in BigQuery (first time: create the table)
+npx ts-node src/index.ts --setup-bigquery
+npx ts-node src/index.ts --all --concurrency 5 --requests 50 --bigquery --notes "post-migration"
 ```
+
+Results land in BigQuery table `load_test.results` in the `gatherli-dev` project.
+Use `--dataset <name>` to override the dataset name (default: `load_test`).
+The service account must have the **BigQuery Data Editor** role on the dataset.
 
 ---
 

--- a/tools/load_test/package-lock.json
+++ b/tools/load_test/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gatherli-load-test",
       "version": "1.0.0",
       "dependencies": {
+        "@google-cloud/bigquery": "^8.1.1",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "firebase-admin": "^12.0.0"
@@ -632,6 +633,239 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.1.tgz",
+      "integrity": "sha512-2GHlohfA/VJffTvibMazMsZi6jPRx8MmaMberyDTL8rnhVs/frKSXVVRtLU83uSAy2j/5SD4mOs4jMQgJPON2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^6.0.0",
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "arrify": "^3.0.0",
+        "big.js": "^6.2.2",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "stream-events": "^1.0.5",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/paginator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+      "integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/bigquery/node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.0.tgz",
+      "integrity": "sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.0.0-rc.1",
+        "html-entities": "^2.5.2",
+        "retry-request": "^8.0.0",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
@@ -663,12 +897,20 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+      "integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
       "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -678,7 +920,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
       "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -1686,7 +1927,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1766,7 +2006,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1962,8 +2201,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.11",
@@ -1978,12 +2216,24 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -2348,6 +2598,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2450,7 +2709,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -2499,7 +2757,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2661,8 +2918,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -2746,6 +3002,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2822,6 +3101,18 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -3201,8 +3492,7 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3250,7 +3540,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -3315,7 +3604,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4581,7 +4869,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -4995,6 +5282,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5076,7 +5383,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5364,7 +5670,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5586,7 +5891,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -5595,15 +5899,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -5700,8 +6002,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6050,8 +6351,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "10.0.0",
@@ -6096,6 +6396,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6200,7 +6509,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/tools/load_test/package.json
+++ b/tools/load_test/package.json
@@ -8,6 +8,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@google-cloud/bigquery": "^8.1.1",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "firebase-admin": "^12.0.0"
@@ -23,6 +24,8 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "testMatch": ["**/test/**/*.test.ts"]
+    "testMatch": [
+      "**/test/**/*.test.ts"
+    ]
   }
 }

--- a/tools/load_test/src/bigquery.ts
+++ b/tools/load_test/src/bigquery.ts
@@ -1,0 +1,111 @@
+// BigQuery sink for load test results.
+// Inserts one row per scenario after a run when --bigquery flag is passed.
+
+import { BigQuery } from "@google-cloud/bigquery";
+import { Stats } from "./reporter";
+
+export interface BenchmarkRow {
+  run_id: string;
+  run_timestamp: string; // ISO string — BigQuery TIMESTAMP
+  scenario: string;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  min_ms: number;
+  max_ms: number;
+  requests: number;
+  concurrency: number;
+  errors: number;
+  duration_ms: number;
+  git_sha: string;
+  notes: string;
+}
+
+const TABLE_SCHEMA = [
+  { name: "run_id",         type: "STRING" },
+  { name: "run_timestamp",  type: "TIMESTAMP" },
+  { name: "scenario",       type: "STRING" },
+  { name: "p50_ms",         type: "INT64" },
+  { name: "p95_ms",         type: "INT64" },
+  { name: "p99_ms",         type: "INT64" },
+  { name: "min_ms",         type: "INT64" },
+  { name: "max_ms",         type: "INT64" },
+  { name: "requests",       type: "INT64" },
+  { name: "concurrency",    type: "INT64" },
+  { name: "errors",         type: "INT64" },
+  { name: "duration_ms",    type: "INT64" },
+  { name: "git_sha",        type: "STRING" },
+  { name: "notes",          type: "STRING" },
+];
+
+export class BenchmarkSink {
+  private bq: BigQuery;
+  private datasetId: string;
+  private tableId: string;
+
+  constructor(keyFilename: string, datasetId: string, tableId: string) {
+    this.bq = new BigQuery({ keyFilename });
+    this.datasetId = datasetId;
+    this.tableId = tableId;
+  }
+
+  /** Create the dataset and table if they do not already exist. */
+  async setup(): Promise<void> {
+    const [datasets] = await this.bq.getDatasets();
+    const datasetExists = datasets.some((d) => d.id === this.datasetId);
+
+    if (!datasetExists) {
+      await this.bq.createDataset(this.datasetId, { location: "EU" });
+      console.log(`✅ BigQuery dataset created: ${this.datasetId}`);
+    }
+
+    const dataset = this.bq.dataset(this.datasetId);
+    const [tables] = await dataset.getTables();
+    const tableExists = tables.some((t) => t.id === this.tableId);
+
+    if (!tableExists) {
+      await dataset.createTable(this.tableId, { schema: TABLE_SCHEMA });
+      console.log(`✅ BigQuery table created: ${this.datasetId}.${this.tableId}`);
+    } else {
+      console.log(`ℹ️  BigQuery table already exists: ${this.datasetId}.${this.tableId}`);
+    }
+  }
+
+  /** Insert a batch of rows (one per scenario). */
+  async insertRows(rows: BenchmarkRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    await this.bq
+      .dataset(this.datasetId)
+      .table(this.tableId)
+      .insert(rows);
+    console.log(`📤 Inserted ${rows.length} row(s) into BigQuery (${this.datasetId}.${this.tableId})`);
+  }
+}
+
+/** Build a BenchmarkRow from a completed scenario's stats. */
+export function buildRow(params: {
+  runId: string;
+  scenario: string;
+  stats: Stats;
+  concurrency: number;
+  wallClockMs: number;
+  gitSha: string;
+  notes: string;
+}): BenchmarkRow {
+  return {
+    run_id:        params.runId,
+    run_timestamp: new Date(params.runId).toISOString(),
+    scenario:      params.scenario,
+    p50_ms:        params.stats.p50,
+    p95_ms:        params.stats.p95,
+    p99_ms:        params.stats.p99,
+    min_ms:        params.stats.min,
+    max_ms:        params.stats.max,
+    requests:      params.stats.count,
+    concurrency:   params.concurrency,
+    errors:        params.stats.errors,
+    duration_ms:   params.wallClockMs,
+    git_sha:       params.gitSha,
+    notes:         params.notes,
+  };
+}

--- a/tools/load_test/src/index.ts
+++ b/tools/load_test/src/index.ts
@@ -6,9 +6,12 @@ import * as admin from "firebase-admin";
 import * as path from "path";
 import * as fs from "fs";
 
+import { execSync } from "child_process";
+
 import { runScenario, Scenario } from "./runner";
 import { computeStats, printReport } from "./reporter";
 import { seedTestData, cleanupTestData } from "./seed";
+import { BenchmarkSink, BenchmarkRow, buildRow } from "./bigquery";
 
 import { makeScenario as makeGetGamesForGroup } from "./scenarios/getGamesForGroup";
 import { makeScenario as makeGetUpcomingGamesForUser } from "./scenarios/getUpcomingGamesForUser";
@@ -84,6 +87,10 @@ async function main(): Promise<void> {
     .option("--concurrency <n>", "Number of parallel workers", "5")
     .option("--requests <n>", "Total number of requests per scenario", "50")
     .option("--dry-run", "Print what would be called without executing")
+    .option("--bigquery", "Insert results into BigQuery after the run")
+    .option("--notes <text>", "Label for this run stored in BigQuery (e.g. 'post-migration')", "")
+    .option("--dataset <name>", "BigQuery dataset name", "load_test")
+    .option("--setup-bigquery", "Create the BigQuery dataset and table, then exit")
     .parse(process.argv);
 
   const opts = program.opts<{
@@ -94,6 +101,10 @@ async function main(): Promise<void> {
     concurrency: string;
     requests: string;
     dryRun?: boolean;
+    bigquery?: boolean;
+    notes: string;
+    dataset: string;
+    setupBigquery?: boolean;
   }>();
 
   const concurrency = parseInt(opts.concurrency, 10);
@@ -105,6 +116,14 @@ async function main(): Promise<void> {
   }
 
   const db = !dryRun ? admin.firestore() : null;
+  const keyPath = process.env.GATHERLI_DEV_SERVICE_ACCOUNT!;
+
+  // Setup BigQuery table only
+  if (opts.setupBigquery) {
+    const sink = new BenchmarkSink(path.resolve(keyPath), opts.dataset, "results");
+    await sink.setup();
+    process.exit(0);
+  }
 
   // Seed only
   if (opts.seed) {
@@ -138,6 +157,17 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Shared run metadata
+  const runId = new Date().toISOString();
+  const gitSha = (() => {
+    try {
+      return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+    } catch {
+      return "unknown";
+    }
+  })();
+  const collectedRows: BenchmarkRow[] = [];
+
   for (const name of scenarioNames) {
     const factory = registry[name];
     if (!factory) {
@@ -154,7 +184,26 @@ async function main(): Promise<void> {
     if (!dryRun) {
       const stats = computeStats(results);
       printReport(name, stats, concurrency, wallClockMs);
+
+      if (opts.bigquery) {
+        collectedRows.push(buildRow({
+          runId,
+          scenario: name,
+          stats,
+          concurrency,
+          wallClockMs,
+          gitSha,
+          notes: opts.notes,
+        }));
+      }
     }
+  }
+
+  // Insert all rows in one batch after all scenarios complete
+  if (opts.bigquery && collectedRows.length > 0) {
+    console.log(`\n📤 Uploading ${collectedRows.length} result(s) to BigQuery...`);
+    const sink = new BenchmarkSink(path.resolve(keyPath), opts.dataset, "results");
+    await sink.insertRows(collectedRows);
   }
 }
 

--- a/tools/load_test/test/bigquery.test.ts
+++ b/tools/load_test/test/bigquery.test.ts
@@ -1,0 +1,146 @@
+// Unit tests for the BigQuery benchmark sink helper
+// Story 25.7: Store load test results in BigQuery
+
+import { buildRow, BenchmarkSink } from "../src/bigquery";
+import { Stats } from "../src/reporter";
+
+// Mock @google-cloud/bigquery
+jest.mock("@google-cloud/bigquery", () => {
+  const mockInsert = jest.fn().mockResolvedValue([]);
+  const mockTable = jest.fn(() => ({ insert: mockInsert }));
+  const mockCreateTable = jest.fn().mockResolvedValue([{}]);
+  const mockGetTables = jest.fn().mockResolvedValue([[{ id: "results" }]]);
+  const mockDataset = jest.fn(() => ({
+    getTables: mockGetTables,
+    createTable: mockCreateTable,
+    table: mockTable,
+  }));
+  const mockGetDatasets = jest.fn().mockResolvedValue([[{ id: "load_test" }]]);
+  const mockCreateDataset = jest.fn().mockResolvedValue([{}]);
+
+  return {
+    BigQuery: jest.fn(() => ({
+      getDatasets: mockGetDatasets,
+      createDataset: mockCreateDataset,
+      dataset: mockDataset,
+    })),
+    _mockInsert: mockInsert,
+    _mockTable: mockTable,
+    _mockGetTables: mockGetTables,
+    _mockCreateTable: mockCreateTable,
+    _mockDataset: mockDataset,
+    _mockGetDatasets: mockGetDatasets,
+  };
+});
+
+const bqModule = require("@google-cloud/bigquery");
+
+const sampleStats: Stats = {
+  count: 50,
+  errors: 0,
+  min: 300,
+  max: 1200,
+  p50: 500,
+  p95: 900,
+  p99: 1100,
+  totalMs: 25000,
+};
+
+describe("buildRow", () => {
+  it("maps stats and metadata to a BenchmarkRow correctly", () => {
+    const row = buildRow({
+      runId: "2026-03-26T12:00:00.000Z",
+      scenario: "getGamesForGroup",
+      stats: sampleStats,
+      concurrency: 5,
+      wallClockMs: 14800,
+      gitSha: "abc1234",
+      notes: "post-migration",
+    });
+
+    expect(row.scenario).toBe("getGamesForGroup");
+    expect(row.p50_ms).toBe(500);
+    expect(row.p95_ms).toBe(900);
+    expect(row.p99_ms).toBe(1100);
+    expect(row.min_ms).toBe(300);
+    expect(row.max_ms).toBe(1200);
+    expect(row.requests).toBe(50);
+    expect(row.concurrency).toBe(5);
+    expect(row.errors).toBe(0);
+    expect(row.duration_ms).toBe(14800);
+    expect(row.git_sha).toBe("abc1234");
+    expect(row.notes).toBe("post-migration");
+    expect(row.run_id).toBe("2026-03-26T12:00:00.000Z");
+    expect(row.run_timestamp).toBe("2026-03-26T12:00:00.000Z");
+  });
+
+  it("includes error count in the row", () => {
+    const statsWithErrors: Stats = { ...sampleStats, errors: 3 };
+    const row = buildRow({
+      runId: "2026-03-26T12:00:00.000Z",
+      scenario: "getFriends",
+      stats: statsWithErrors,
+      concurrency: 5,
+      wallClockMs: 8000,
+      gitSha: "def5678",
+      notes: "",
+    });
+
+    expect(row.errors).toBe(3);
+  });
+});
+
+describe("BenchmarkSink", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not recreate an existing dataset and table during setup", async () => {
+    bqModule._mockGetDatasets.mockResolvedValue([[{ id: "load_test" }]]);
+    bqModule._mockGetTables.mockResolvedValue([[{ id: "results" }]]);
+
+    const sink = new BenchmarkSink("/fake/key.json", "load_test", "results");
+    await sink.setup();
+
+    expect(bqModule._mockCreateTable).not.toHaveBeenCalled();
+  });
+
+  it("creates the table when it does not exist", async () => {
+    bqModule._mockGetDatasets.mockResolvedValue([[{ id: "load_test" }]]);
+    bqModule._mockGetTables.mockResolvedValue([[]]); // no tables
+
+    const sink = new BenchmarkSink("/fake/key.json", "load_test", "results");
+    await sink.setup();
+
+    expect(bqModule._mockCreateTable).toHaveBeenCalledWith(
+      "results",
+      expect.objectContaining({ schema: expect.any(Array) })
+    );
+  });
+
+  it("inserts rows into the correct table", async () => {
+    const sink = new BenchmarkSink("/fake/key.json", "load_test", "results");
+    const rows = [
+      buildRow({
+        runId: "2026-03-26T12:00:00.000Z",
+        scenario: "getGamesForGroup",
+        stats: sampleStats,
+        concurrency: 5,
+        wallClockMs: 14800,
+        gitSha: "abc1234",
+        notes: "test",
+      }),
+    ];
+
+    await sink.insertRows(rows);
+
+    expect(bqModule._mockTable).toHaveBeenCalledWith("results");
+    expect(bqModule._mockInsert).toHaveBeenCalledWith(rows);
+  });
+
+  it("does nothing when inserting an empty row array", async () => {
+    const sink = new BenchmarkSink("/fake/key.json", "load_test", "results");
+    await sink.insertRows([]);
+    expect(bqModule._mockInsert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--bigquery` flag to the load test CLI — results are inserted into BigQuery after all scenarios complete
- New `src/bigquery.ts`: `BenchmarkSink` class handles dataset/table setup and row insertion; `buildRow()` maps scenario stats to the table schema
- Each run stores: `run_id`, `run_timestamp`, `scenario`, `p50/p95/p99/min/max_ms`, `requests`, `concurrency`, `errors`, `duration_ms`, `git_sha`, `notes`
- `--setup-bigquery` creates the `load_test.results` table on first use
- `--notes <label>` tags each run (e.g. `"post-migration"`)
- Updated `BENCHMARKS.md` with usage instructions

## Usage

```bash
# First time only — create the table
npx ts-node src/index.ts --setup-bigquery

# Run with BigQuery storage
npx ts-node src/index.ts --all --concurrency 5 --requests 50 \
  --bigquery --notes "post-parallelisation"
```

## Test plan

- [x] 20 unit tests pass (bigquery.test.ts: 8 tests, existing reporter + runner tests unchanged)
- [ ] `--setup-bigquery` run against gatherli-dev to create the table
- [ ] Full run with `--bigquery` to verify rows appear in BigQuery console