### PR TITLE
fix(groups): fire clipboard write synchronously to fix iOS 16+ paste failure

### DIFF
--- a/lib/features/groups/presentation/widgets/invite_link_section.dart
+++ b/lib/features/groups/presentation/widgets/invite_link_section.dart
@@ -186,13 +186,15 @@ class InviteLinkSection extends StatelessWidget {
     );
   }
 
-  Future<void> _copyToClipboard(
+  void _copyToClipboard(
     BuildContext context,
     String url,
     AppLocalizations l10n,
-  ) async {
-    await Clipboard.setData(ClipboardData(text: url));
-    if (!context.mounted) return;
+  ) {
+    // Fire synchronously within the user gesture handler — on iOS 16+,
+    // async clipboard writes are not reliably registered as user-initiated
+    // by the system pasteboard, causing paste to silently fail in other apps.
+    Clipboard.setData(ClipboardData(text: url.trim())).ignore();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(l10n.linkCopied),


### PR DESCRIPTION
## Summary

- On iOS 16+, `await Clipboard.setData()` in an async method is not considered user-initiated by the system pasteboard, so the paste menu never appears in other apps — even though the snackbar fires normally
- Fix: make `_copyToClipboard` synchronous and use `.ignore()` to fire-and-forget, keeping the write inside the gesture handler context
- Added `url.trim()` to strip any accidental whitespace from the deep link URL

## Root cause

Apple's `UIPasteboard` security model (iOS 16+) only grants paste access to apps when the write is directly initiated by a user gesture on the main thread. An `await` introduces a microtask boundary that breaks the gesture attribution.

## Test plan

- [x] All 12 existing widget tests pass (`flutter test test/widget/features/groups/presentation/widgets/invite_link_section_test.dart`)
- [x] `flutter analyze` — 0 warnings
- [ ] Manual verify on TestFlight: generate an invite link, tap "Copy Link", paste in Messages/Notes — paste option should appear