### PR TITLE
fix(groups): make invite URL selectable and restore await on clipboard write

### DIFF
--- a/lib/features/groups/presentation/widgets/invite_link_section.dart
+++ b/lib/features/groups/presentation/widgets/invite_link_section.dart
@@ -125,7 +125,7 @@ class InviteLinkSection extends StatelessWidget {
             borderRadius: BorderRadius.circular(8),
             border: Border.all(color: AppColors.divider),
           ),
-          child: Text(
+          child: SelectableText(
             state.deepLinkUrl,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: AppColors.secondary,
@@ -186,15 +186,15 @@ class InviteLinkSection extends StatelessWidget {
     );
   }
 
-  void _copyToClipboard(
+  Future<void> _copyToClipboard(
     BuildContext context,
     String url,
     AppLocalizations l10n,
-  ) {
-    // Fire synchronously within the user gesture handler — on iOS 16+,
-    // async clipboard writes are not reliably registered as user-initiated
-    // by the system pasteboard, causing paste to silently fail in other apps.
-    Clipboard.setData(ClipboardData(text: url.trim())).ignore();
+  ) async {
+    final trimmedUrl = url.trim();
+    if (trimmedUrl.isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: trimmedUrl));
+    if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(l10n.linkCopied),


### PR DESCRIPTION
## Summary

- **`SelectableText` for URL display**: The URL was rendered as a plain `Text` widget, making it impossible to long-press and select on iOS. Switching to `SelectableText` lets the user copy the link using native iOS text selection — this path is guaranteed to work regardless of any Flutter clipboard API behaviour.
- **Restore `async/await` on copy button**: The previous `.ignore()` approach silently swallowed any clipboard write errors. `await` ensures the snackbar only fires after the write actually completed, and `context.mounted` guards the snackbar call.

## Why the previous fix didn't help

The sync `.ignore()` approach was based on the assumption that iOS 16+ requires clipboard writes to be user-initiated synchronously. However, iOS restricts clipboard **reads** (requiring consent dialogs), not writes — so the async/sync distinction made no difference.

The root cause is likely either:
- The Flutter `Clipboard.setData` platform channel was silently failing (we'd never know with `.ignore()`)
- Or the URL appeared empty from the user's perspective because the plain `Text` gave no visual feedback that the URL was there and valid

With `SelectableText`, the user now has a native fallback that definitely works.

## Test plan

- [x] All 12 widget tests pass
- [x] `flutter analyze` — 0 warnings
- [ ] Manual verify on TestFlight: generate invite link → long-press URL text → iOS native copy menu appears → paste in Notes works
- [ ] Copy button still shows snackbar after tapping