### PR TITLE
fix(groups): actually copy invite link to clipboard in group details page

### DIFF
--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -926,8 +928,10 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
     );
   }
 
-  void _shareInviteLink(BuildContext context, String link) {
+  Future<void> _shareInviteLink(BuildContext context, String link) async {
     final l10n = AppLocalizations.of(context)!;
+    await Clipboard.setData(ClipboardData(text: link));
+    if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(l10n.linkCopied),
@@ -935,9 +939,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
         behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
           label: l10n.shareLink,
-          onPressed: () {
-            // Share handled by invite link section logic
-          },
+          onPressed: () => Share.share(l10n.inviteLinkShareMessage(link)),
         ),
       ),
     );


### PR DESCRIPTION
## Root cause

`_shareInviteLink` in `group_details_page.dart` was showing a "Link copied to clipboard" snackbar **without ever calling `Clipboard.setData`**. The Share action button was also a no-op (`onPressed: () {}`).

The `InviteLinkSection` widget (which has correct copy logic) is **never used** in the group details page. The page has its own `BlocConsumer` listener that fires directly on `GroupInviteLinkGenerated` and calls this broken stub — so all previous clipboard fixes were on dead code.

This explains why paste never appeared on iOS, Android emulator, and TestFlight consistently.

## Fix

- `await Clipboard.setData(ClipboardData(text: link))` — actually copies the link
- `context.mounted` guard before showing snackbar
- `Share.share(l10n.inviteLinkShareMessage(link))` — wires up the Share action button

## Test plan

- [ ] Tap "Invite with link" → snackbar "Link copied" appears → paste in Notes/any app works
- [ ] Tap "Share" in the snackbar action → native share sheet opens with the link
- [x] `flutter analyze` — 0 warnings