### PR TITLE
Story 26.7: Route ELO writes to gender/mix bucket by gameGenderType

### DIFF
--- a/functions/src/elo.ts
+++ b/functions/src/elo.ts
@@ -5,6 +5,7 @@ import { processStatsTracking } from "./statsTracking";
 // Constants
 const K_FACTOR = 32;
 const DEFAULT_ELO = 1200;
+const DEFAULT_MIX_ELO = 1000;
 
 /**
  * Calculate team rating using Weak-Link formula.
@@ -90,6 +91,20 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
   const teamBPlayerIds = gameData.teams.teamBPlayerIds;
   const individualGames = gameData.result.games; // Array of individual games
 
+  // Story 26.7: Route ELO writes to the correct bucket based on gameGenderType.
+  // 'male' or 'female' → eloRating (gender ELO)
+  // 'mix' or unknown   → mixEloRating (mix ELO)
+  // Null/undefined is treated as gender (legacy games created before Story 26.4).
+  const gameGenderType = gameData.gameGenderType ?? null;
+  const isMixGame = gameGenderType === "mix";
+  const eloField = isMixGame ? "mixEloRating" : "eloRating";
+  const defaultEloForGame = isMixGame ? DEFAULT_MIX_ELO : DEFAULT_ELO;
+  const historyGameType = isMixGame ? "mix" : "gender";
+
+  functions.logger.info(
+    `Game ${gameId} gameGenderType=${gameGenderType}, routing ELO writes to "${eloField}"`
+  );
+
   try {
     await db.runTransaction(async (transaction) => {
       // 1. Fetch all players
@@ -109,10 +124,11 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
       });
 
       // Track current ratings as we process each game (starts with stored ratings)
+      // Use the correct ELO bucket depending on game type (Story 26.7)
       const currentRatings = new Map<string, number>();
       playerIds.forEach(id => {
         const data = playerMap.get(id);
-        currentRatings.set(id, data?.eloRating || DEFAULT_ELO);
+        currentRatings.set(id, data?.[eloField] || defaultEloForGame);
       });
 
       // Track cumulative changes for each player
@@ -186,9 +202,10 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         const data = playerMap.get(playerId);
         if (!data) return;
 
-        const originalRating = data.eloRating || DEFAULT_ELO;
+        // Story 26.7: Read and write the correct ELO bucket
+        const originalRating = data[eloField] || defaultEloForGame;
         const cumulativeChange = cumulativeChanges.get(playerId) || 0;
-        const finalRating = currentRatings.get(playerId) || DEFAULT_ELO;
+        const finalRating = currentRatings.get(playerId) || defaultEloForGame;
         const won = isTeamA ? overallTeamAWon : overallTeamBWon;
         const opponentIds = isTeamA ? teamBPlayerIds : teamAPlayerIds;
 
@@ -206,10 +223,10 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         // Calculate best win tracking (Story 301.6)
         let bestWinUpdate: any = undefined;
         if (won && cumulativeChange > 0) {
-          // Get opponent team ratings at the time of the game
+          // Get opponent team ratings using the same ELO bucket (Story 26.7)
           const opponentRatings = opponentIds.map((oid: string) => {
             const oppData = playerMap.get(oid);
-            return oppData?.eloRating || DEFAULT_ELO;
+            return oppData?.[eloField] || defaultEloForGame;
           });
 
           // Calculate opponent team ELO (using same formula as team rating)
@@ -235,9 +252,10 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         }
 
         // Update User Doc
+        // Story 26.7: write to the correct ELO bucket (eloRating or mixEloRating)
         const userRef = db.collection("users").doc(playerId);
         const updateData: any = {
-          eloRating: finalRating,
+          [eloField]: finalRating,          // gender or mix ELO bucket
           eloLastUpdated: now,
           eloPeak: newPeak,
           eloPeakDate: newPeakDate,
@@ -267,6 +285,7 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
         };
 
         // Add to History (one entry per play session with cumulative change)
+        // Story 26.7: tag the entry with gameType so the chart can filter by bucket
         const opponentNames = opponentIds.map((oid: string) => displayNames.get(oid) || "Unknown").join(" & ");
         const historyRef = userRef.collection("ratingHistory").doc();
         transaction.set(historyRef, {
@@ -277,6 +296,7 @@ export async function processGameEloUpdates(gameId: string, gameData: any): Prom
             opponentTeam: opponentNames,
             won: won,
             timestamp: now,
+            gameType: historyGameType,  // 'gender' | 'mix'
         });
       };
 

--- a/functions/test/unit/elo.test.ts
+++ b/functions/test/unit/elo.test.ts
@@ -650,6 +650,213 @@ describe("processGameEloUpdates", () => {
     await expect(processGameEloUpdates(gameId, gameData)).resolves.not.toThrow();
   });
 
+  // ========================================================================
+  // Story 26.7: ELO routing by game type
+  // ========================================================================
+
+  /**
+   * Helper: builds a complete mock db suitable for Story 26.7 routing tests.
+   * playerMap maps player id → { eloRating, mixEloRating, displayName }
+   */
+  function buildMockDb(
+    localDb: any,
+    localTransaction: any,
+    gameId: string,
+    gameData: any,
+    playerMap: Record<string, any>
+  ): void {
+    const gameRef = { parent: { id: "games" } };
+    const gameDocMock = {
+      exists: true,
+      id: gameId,
+      ref: gameRef,
+      data: () => gameData,
+    };
+
+    const subCollectionMock = { doc: jest.fn(() => ({ id: "historyId" })) };
+    const docRefMock = { collection: jest.fn(() => subCollectionMock) };
+
+    const collectionMock = {
+      doc: jest.fn((id: string) => {
+        if (id === gameId) {
+          return { ...docRefMock, get: jest.fn().mockResolvedValue(gameDocMock) };
+        }
+        return {
+          ...docRefMock,
+          id,
+          exists: true,
+          data: () => playerMap[id] || {},
+        };
+      }),
+    };
+    localDb.collection.mockReturnValue(collectionMock);
+
+    localTransaction.get.mockImplementation((ref: any) =>
+      Promise.resolve({
+        exists: true,
+        id: ref.id,
+        data: () => playerMap[ref.id] || {},
+      })
+    );
+  }
+
+  test("gender game — updates eloRating, leaves mixEloRating unchanged", async () => {
+    const gameId = "g-gender";
+    const gameData = {
+      gameGenderType: "male",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, mixEloRating: 1000, displayName: "P1" },
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    const p1Call = transaction.update.mock.calls.find((c: any) => c[0]?.id === "p1");
+    expect(p1Call).toBeDefined();
+    // eloRating should be present and changed
+    expect(p1Call[1]).toHaveProperty("eloRating");
+    // mixEloRating must NOT be written
+    expect(p1Call[1]).not.toHaveProperty("mixEloRating");
+  });
+
+  test("female gender game — updates eloRating, leaves mixEloRating unchanged", async () => {
+    const gameId = "g-female";
+    const gameData = {
+      gameGenderType: "female",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1300, mixEloRating: 1050, displayName: "P1" },
+      p2: { eloRating: 1300, mixEloRating: 1050, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    const p1Call = transaction.update.mock.calls.find((c: any) => c[0]?.id === "p1");
+    expect(p1Call).toBeDefined();
+    expect(p1Call[1]).toHaveProperty("eloRating");
+    expect(p1Call[1]).not.toHaveProperty("mixEloRating");
+  });
+
+  test("mix game — updates mixEloRating, leaves eloRating unchanged", async () => {
+    const gameId = "g-mix";
+    const gameData = {
+      gameGenderType: "mix",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, mixEloRating: 1000, displayName: "P1" },
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    const p1Call = transaction.update.mock.calls.find((c: any) => c[0]?.id === "p1");
+    expect(p1Call).toBeDefined();
+    // mixEloRating should be present and changed
+    expect(p1Call[1]).toHaveProperty("mixEloRating");
+    // eloRating must NOT be written
+    expect(p1Call[1]).not.toHaveProperty("eloRating");
+  });
+
+  test("null gameGenderType — treated as gender game (legacy fallback)", async () => {
+    const gameId = "g-null";
+    const gameData = {
+      // gameGenderType absent (legacy game)
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, mixEloRating: 1000, displayName: "P1" },
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    const p1Call = transaction.update.mock.calls.find((c: any) => c[0]?.id === "p1");
+    expect(p1Call).toBeDefined();
+    expect(p1Call[1]).toHaveProperty("eloRating");
+    expect(p1Call[1]).not.toHaveProperty("mixEloRating");
+  });
+
+  test("gender game — history entry has gameType='gender'", async () => {
+    const gameId = "g-hist-gender";
+    const gameData = {
+      gameGenderType: "male",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, mixEloRating: 1000, displayName: "P1" },
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    // transaction.set is called for each history entry
+    expect(transaction.set).toHaveBeenCalled();
+    const historyCall = transaction.set.mock.calls[0];
+    expect(historyCall[1]).toHaveProperty("gameType", "gender");
+  });
+
+  test("mix game — history entry has gameType='mix'", async () => {
+    const gameId = "g-hist-mix";
+    const gameData = {
+      gameGenderType: "mix",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, mixEloRating: 1000, displayName: "P1" },
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    expect(transaction.set).toHaveBeenCalled();
+    const historyCall = transaction.set.mock.calls[0];
+    expect(historyCall[1]).toHaveProperty("gameType", "mix");
+  });
+
+  test("mix game — uses mixEloRating as starting rating (default 1000)", async () => {
+    const gameId = "g-default-mix";
+    const gameData = {
+      gameGenderType: "mix",
+      teams: { teamAPlayerIds: ["p1"], teamBPlayerIds: ["p2"] },
+      result: { games: [{ winner: "teamA" }] },
+    };
+    // p1 has no mixEloRating → should default to 1000
+    const playerMap: Record<string, any> = {
+      p1: { eloRating: 1200, displayName: "P1" }, // no mixEloRating
+      p2: { eloRating: 1200, mixEloRating: 1000, displayName: "P2" },
+    };
+    buildMockDb(db, transaction, gameId, gameData, playerMap);
+
+    await processGameEloUpdates(gameId, gameData);
+
+    // p1's history entry should show oldRating as 1000 (DEFAULT_MIX_ELO)
+    const p1HistCall = transaction.set.mock.calls.find((c: any) => {
+      // The set call's second arg has oldRating
+      return c[1]?.oldRating !== undefined;
+    });
+    expect(p1HistCall).toBeDefined();
+    // At least one history entry should have oldRating=1000 (the p1 entry)
+    const histEntries = transaction.set.mock.calls.map((c: any) => c[1]);
+    const p1Entry = histEntries.find((e: any) => e?.oldRating === 1000);
+    expect(p1Entry).toBeDefined();
+  });
+
   test("rejects when game document doesn't exist (Story 15.5)", async () => {
     const gameId = "nonexistent";
     const gameData = {


### PR DESCRIPTION
## Summary
- ELO writes now routed to `eloRating` (male/female games) or `mixEloRating` (mix games) based on `gameData.gameGenderType`
- `ratingHistory` entries tagged with `gameType: 'gender' | 'mix'` for the ELO chart to filter correctly (Story 26.6 depends on this)
- `null`/missing `gameGenderType` treated as gender (legacy fallback for pre-Story-26.4 games)
- `DEFAULT_MIX_ELO = 1000` constant added for mix ELO starting rating

## Routing table
| `gameGenderType` | Field written |
|---|---|
| `'male'` or `'female'` | `eloRating` |
| `'mix'` | `mixEloRating` |
| `null` / missing | `eloRating` (legacy) |

## Test plan
- [x] `npx tsc --noEmit` — 0 type errors
- [x] 7 new unit tests in `elo.test.ts` (Story 26.7):
  - Male game → `eloRating` updated, `mixEloRating` absent from write
  - Female game → `eloRating` updated, `mixEloRating` absent from write
  - Mix game → `mixEloRating` updated, `eloRating` absent from write
  - Null `gameGenderType` → falls back to `eloRating` (legacy)
  - Gender game history entry → `gameType = 'gender'`
  - Mix game history entry → `gameType = 'mix'`
  - Mix game with no stored `mixEloRating` → defaults to 1000
- [x] All 420 existing unit tests still pass