### PR TITLE
feat(game-creation): remove manual game type selector

### DIFF
--- a/functions/scripts/setupGenderTestEnvironment.ts
+++ b/functions/scripts/setupGenderTestEnvironment.ts
@@ -47,7 +47,6 @@ const DEFAULT_PASSWORD = "test1010";
 // ---------------------------------------------------------------------------
 
 type Gender = "male" | "female" | "none";
-type GameGenderType = "male" | "female" | "mix";
 
 interface TestUser {
   uid: string;
@@ -259,7 +258,6 @@ async function createCompletedGame(
   teamB: string[],
   teamAWins: boolean,
   label: string,
-  gameGenderType: GameGenderType,
 ): Promise<string> {
   const ref = db.collection("games").doc();
 
@@ -267,7 +265,6 @@ async function createCompletedGame(
     title: label,
     description: "Gender test environment game",
     groupId,
-    gameGenderType,
     createdBy: teamA[0],
     createdAt:   admin.firestore.Timestamp.fromDate(gameDate),
     updatedAt:   admin.firestore.Timestamp.fromDate(gameDate),
@@ -320,7 +317,6 @@ async function createFutureGame(
   title: string,
   playerIds: string[],
   createdBy: string,
-  gameGenderType: GameGenderType,
 ): Promise<string> {
   const ref  = db.collection("games").doc();
   const date = new Date(Date.now() + daysFromNow * 24 * 60 * 60_000);
@@ -329,7 +325,6 @@ async function createFutureGame(
     title,
     description: "Join us for a great game!",
     groupId,
-    gameGenderType,
     createdBy,
     createdAt:   admin.firestore.Timestamp.now(),
     updatedAt:   admin.firestore.Timestamp.now(),
@@ -404,7 +399,7 @@ async function seedMaleGames(groupId: string, M: TestUser[]): Promise<string[]> 
     const id   = await createCompletedGame(
       groupId, date,
       tA.map((u) => u.uid), tB.map((u) => u.uid),
-      aWins, label, "male",
+      aWins, label,
     );
     ids.push(id);
     console.log(`  ✅ [male]   ${label} (${daysAgo}d ago) — ${aWins ? "Team A" : "Team B"} won`);
@@ -430,7 +425,7 @@ async function seedFemaleGames(groupId: string, F: TestUser[]): Promise<string[]
     const id   = await createCompletedGame(
       groupId, date,
       tA.map((u) => u.uid), tB.map((u) => u.uid),
-      aWins, label, "female",
+      aWins, label,
     );
     ids.push(id);
     console.log(`  ✅ [female] ${label} (${daysAgo}d ago) — ${aWins ? "Team A" : "Team B"} won`);
@@ -459,7 +454,7 @@ async function seedMixedGames(
     const id   = await createCompletedGame(
       groupId, date,
       tA.map((u) => u.uid), tB.map((u) => u.uid),
-      aWins, label, "mix",
+      aWins, label,
     );
     ids.push(id);
     console.log(`  ✅ [mix]    ${label} (${daysAgo}d ago) — ${aWins ? "Team A" : "Team B"} won  ← ELO skipped`);
@@ -475,19 +470,19 @@ async function seedFutureGames(
 
   ids.push(await createFutureGame(
     groupId, 1, "Men's Showdown",
-    [M[0].uid, M[1].uid, M[2].uid, M[3].uid], M[0].uid, "male",
+    [M[0].uid, M[1].uid, M[2].uid, M[3].uid], M[0].uid,
   ));
   console.log(`  ✅ [male]   Men's Showdown (tomorrow)`);
 
   ids.push(await createFutureGame(
     groupId, 5, "Women's Match",
-    [F[0].uid, F[1].uid, F[2].uid, F[3].uid], F[0].uid, "female",
+    [F[0].uid, F[1].uid, F[2].uid, F[3].uid], F[0].uid,
   ));
   console.log(`  ✅ [female] Women's Match (+5 days)`);
 
   ids.push(await createFutureGame(
     groupId, 14, "Mixed Open",
-    [M[0].uid, F[0].uid, N[0].uid, N[1].uid], M[0].uid, "mix",
+    [M[0].uid, F[0].uid, N[0].uid, N[1].uid], M[0].uid,
   ));
   console.log(`  ✅ [mix]    Mixed Open (+14 days)`);
 

--- a/lib/features/games/presentation/bloc/game_creation/game_creation_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_creation/game_creation_bloc.dart
@@ -28,7 +28,6 @@ class GameCreationBloc extends Bloc<GameCreationEvent, GameCreationState> {
     on<SetMinPlayers>(_onSetMinPlayers);
     on<SetGameType>(_onSetGameType);
     on<SetSkillLevel>(_onSetSkillLevel);
-    on<SetGameGenderType>(_onSetGameGenderType);
     on<ValidateForm>(_onValidateForm);
     on<SubmitGame>(_onSubmitGame);
     on<ResetForm>(_onResetForm);
@@ -120,33 +119,6 @@ class GameCreationBloc extends Bloc<GameCreationEvent, GameCreationState> {
     emit(formState);
   }
 
-  void _onSetGameGenderType(
-      SetGameGenderType event, Emitter<GameCreationState> emit) {
-    // copyWith cannot clear nullable fields (null ?? existing keeps the old value).
-    // Reconstruct the form state directly so gameGenderType can be set to null (Normal).
-    final current = _currentFormState;
-    emit(GameCreationFormState(
-      groupId: current.groupId,
-      groupName: current.groupName,
-      dateTime: current.dateTime,
-      locationName: current.locationName,
-      address: current.address,
-      title: current.title,
-      description: current.description,
-      maxPlayers: current.maxPlayers,
-      minPlayers: current.minPlayers,
-      gameType: current.gameType,
-      skillLevel: current.skillLevel,
-      gameGenderType: event.gameGenderType,
-      groupError: current.groupError,
-      dateTimeError: current.dateTimeError,
-      locationError: current.locationError,
-      titleError: current.titleError,
-      playersError: current.playersError,
-      isValid: current.isValid,
-    ));
-  }
-
   void _onValidateForm(ValidateForm event, Emitter<GameCreationState> emit) {
     emit(_validateAndEmit(_currentFormState));
   }
@@ -182,7 +154,6 @@ class GameCreationBloc extends Bloc<GameCreationEvent, GameCreationState> {
         minPlayers: formState.minPlayers,
         gameType: formState.gameType,
         skillLevel: formState.skillLevel,
-        gameGenderType: formState.gameGenderType, // Creator's intent (Story 26.8)
         playerIds: [event.createdBy], // Creator is automatically a player
       );
 

--- a/lib/features/games/presentation/bloc/game_creation/game_creation_event.dart
+++ b/lib/features/games/presentation/bloc/game_creation/game_creation_event.dart
@@ -105,16 +105,6 @@ class SetSkillLevel extends GameCreationEvent {
   List<Object?> get props => [skillLevel];
 }
 
-/// Event to set the gender type of the game (Story 26.8)
-class SetGameGenderType extends GameCreationEvent {
-  final GameGenderType? gameGenderType;
-
-  const SetGameGenderType({this.gameGenderType});
-
-  @override
-  List<Object?> get props => [gameGenderType];
-}
-
 /// Event to validate the form
 class ValidateForm extends GameCreationEvent {
   const ValidateForm();

--- a/lib/features/games/presentation/bloc/game_creation/game_creation_state.dart
+++ b/lib/features/games/presentation/bloc/game_creation/game_creation_state.dart
@@ -25,8 +25,6 @@ class GameCreationFormState extends GameCreationState {
   final int minPlayers;
   final GameType? gameType;
   final GameSkillLevel? skillLevel;
-  // Gender classification chosen at creation (Story 26.8)
-  final GameGenderType? gameGenderType;
 
   // Validation errors
   final String? groupError;
@@ -50,7 +48,6 @@ class GameCreationFormState extends GameCreationState {
     this.minPlayers = 2,
     this.gameType,
     this.skillLevel,
-    this.gameGenderType,
     this.groupError,
     this.dateTimeError,
     this.locationError,
@@ -71,7 +68,6 @@ class GameCreationFormState extends GameCreationState {
     int? minPlayers,
     GameType? gameType,
     GameSkillLevel? skillLevel,
-    GameGenderType? gameGenderType,
     String? groupError,
     String? dateTimeError,
     String? locationError,
@@ -91,7 +87,6 @@ class GameCreationFormState extends GameCreationState {
       minPlayers: minPlayers ?? this.minPlayers,
       gameType: gameType ?? this.gameType,
       skillLevel: skillLevel ?? this.skillLevel,
-      gameGenderType: gameGenderType ?? this.gameGenderType,
       groupError: groupError,
       dateTimeError: dateTimeError,
       locationError: locationError,
@@ -114,7 +109,6 @@ class GameCreationFormState extends GameCreationState {
         minPlayers,
         gameType,
         skillLevel,
-        gameGenderType,
         groupError,
         dateTimeError,
         locationError,

--- a/lib/features/games/presentation/pages/game_creation_page.dart
+++ b/lib/features/games/presentation/pages/game_creation_page.dart
@@ -7,12 +7,8 @@ import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
-import '../../../../core/data/models/game_model.dart';
-import '../../../../core/data/models/user_model.dart';
 import '../../../../core/domain/repositories/game_repository.dart';
 import '../../../../core/domain/repositories/group_repository.dart';
-import '../../../../core/domain/repositories/user_repository.dart';
-import '../../../../core/services/service_locator.dart';
 import '../../../auth/presentation/bloc/authentication/authentication_bloc.dart';
 import '../../../auth/presentation/bloc/authentication/authentication_state.dart';
 import '../bloc/game_creation/game_creation_bloc.dart';
@@ -24,8 +20,6 @@ class GameCreationPage extends StatefulWidget {
   final String groupName;
   final GameRepository? gameRepository;
   final GroupRepository? groupRepository;
-  /// Optional override for testing — production code uses the service locator.
-  final UserRepository? userRepository;
 
   const GameCreationPage({
     super.key,
@@ -33,7 +27,6 @@ class GameCreationPage extends StatefulWidget {
     required this.groupName,
     this.gameRepository,
     this.groupRepository,
-    this.userRepository,
   });
 
   @override
@@ -48,7 +41,6 @@ class _GameCreationPageState extends State<GameCreationPage> {
   final _addressController = TextEditingController();
 
   DateTime? _selectedDateTime;
-  UserModel? _currentUser;
 
   @override
   void initState() {
@@ -58,20 +50,6 @@ class _GameCreationPageState extends State<GameCreationPage> {
           groupId: widget.groupId,
           groupName: widget.groupName,
         ));
-    // Load the current user's profile to determine gender type (Story 26.8)
-    final repo = widget.userRepository ?? sl<UserRepository>();
-    repo.currentUser.first.then((user) {
-      if (!mounted) return;
-      setState(() => _currentUser = user);
-      // For mix-only users silently default to mix; for gendered users default to null (Normal)
-      if (user != null) {
-        final defaultType =
-            user.isMixOnly ? GameGenderType.mix : null;
-        context
-            .read<GameCreationBloc>()
-            .add(SetGameGenderType(gameGenderType: defaultType));
-      }
-    });
   }
 
   @override
@@ -267,84 +245,6 @@ class _GameCreationPageState extends State<GameCreationPage> {
     });
 
     bloc.add(SetDateTime(dateTime: dateTime));
-  }
-
-  /// Builds the game type selector (Normal / Mixed) for gendered users,
-  /// or an informational label for mix-only users (Story 26.8).
-  Widget _buildGameTypeSelector(
-    BuildContext context,
-    GameCreationState creationState,
-    AppLocalizations l10n,
-    bool isSubmitting,
-  ) {
-    final currentGameGenderType = creationState is GameCreationFormState
-        ? creationState.gameGenderType
-        : null;
-
-    final isMixOnly = _currentUser?.isMixOnly ?? true;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          l10n.gameCreationGameTypeSectionLabel,
-          style: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-            color: AppColors.textMuted,
-          ),
-        ),
-        const SizedBox(height: 8),
-        if (isMixOnly)
-          // Mix-only user: no choice — show info label
-          Row(
-            children: [
-              const Icon(Icons.info_outline, size: 16, color: AppColors.textMuted),
-              const SizedBox(width: 6),
-              Text(
-                l10n.gameCreationAlwaysMixed,
-                style: const TextStyle(
-                  fontSize: 13,
-                  color: AppColors.textMuted,
-                ),
-              ),
-            ],
-          )
-        else ...[
-          // Gendered user: show Normal / Mixed toggle
-          Row(
-            children: [
-              _GameTypeOption(
-                label: l10n.gameCreationGameTypeNormal,
-                isSelected: currentGameGenderType == null,
-                enabled: !isSubmitting,
-                onTap: () => context
-                    .read<GameCreationBloc>()
-                    .add(const SetGameGenderType(gameGenderType: null)),
-              ),
-              const SizedBox(width: 8),
-              _GameTypeOption(
-                label: l10n.gameCreationGameTypeMixed,
-                isSelected: currentGameGenderType == GameGenderType.mix,
-                enabled: !isSubmitting,
-                onTap: () => context
-                    .read<GameCreationBloc>()
-                    .add(const SetGameGenderType(
-                        gameGenderType: GameGenderType.mix)),
-              ),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Text(
-            l10n.gameCreationGameTypeDescription,
-            style: const TextStyle(
-              fontSize: 12,
-              color: AppColors.textMuted,
-            ),
-          ),
-        ],
-      ],
-    );
   }
 
   void _handleSubmit(BuildContext context, String userId) {
@@ -544,10 +444,6 @@ class _GameCreationPageState extends State<GameCreationPage> {
                       ),
                       const SizedBox(height: 16),
 
-                      // Game Type Selector (Story 26.8)
-                      _buildGameTypeSelector(context, creationState, l10n, isSubmitting),
-                      const SizedBox(height: 24),
-
                       // Submit Button
                       ElevatedButton(
                         onPressed: isSubmitting
@@ -579,47 +475,3 @@ class _GameCreationPageState extends State<GameCreationPage> {
   }
 }
 
-/// Pill-style toggle option for the game type selector (Story 26.8).
-class _GameTypeOption extends StatelessWidget {
-  final String label;
-  final bool isSelected;
-  final bool enabled;
-  final VoidCallback onTap;
-
-  const _GameTypeOption({
-    required this.label,
-    required this.isSelected,
-    required this.enabled,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: enabled ? onTap : null,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 150),
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-        decoration: BoxDecoration(
-          color: isSelected ? AppColors.primary : Colors.transparent,
-          borderRadius: BorderRadius.circular(24),
-          border: Border.all(
-            color: isSelected
-                ? AppColors.primary
-                : AppColors.textMuted.withValues(alpha: 0.4),
-          ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-            color: isSelected
-                ? Colors.white
-                : (enabled ? AppColors.textMuted : AppColors.textMuted.withValues(alpha: 0.5)),
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -611,26 +611,6 @@
   "deleteAccountConfirm": "Dauerhaft löschen",
   "deleteAccountSuccess": "Ihr Konto wurde gelöscht.",
   "deleteAccountError": "Konto konnte nicht gelöscht werden. Bitte erneut versuchen.",
-  "gameCreationGameTypeSectionLabel": "Spieltyp",
-  "@gameCreationGameTypeSectionLabel": {
-    "description": "Section label for the game type selector in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeNormal": "Normal",
-  "@gameCreationGameTypeNormal": {
-    "description": "Option label for gender-specific game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeMixed": "Gemischt",
-  "@gameCreationGameTypeMixed": {
-    "description": "Option label for mixed-gender game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeDescription": "Normale Spiele zählen für dein ELO. Gemischte Spiele sind freundschaftlich und beeinflussen dein Rating nicht.",
-  "@gameCreationGameTypeDescription": {
-    "description": "Explanatory text under the game type selector (Story 26.8)"
-  },
-  "gameCreationAlwaysMixed": "Ihre Spiele sind immer gemischt",
-  "@gameCreationAlwaysMixed": {
-    "description": "Info label shown to no-gender users instead of the selector (Story 26.8)"
-  },
   "registrationGenderRequired": "Bitte wählen Sie ein Geschlecht aus, um fortzufahren",
   "@registrationGenderRequired": {
     "description": "Validation error on registration when no gender is selected"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2828,26 +2828,6 @@
   "@deleteAccountError": {
     "description": "Snackbar message shown when account deletion fails"
   },
-  "gameCreationGameTypeSectionLabel": "Game Type",
-  "@gameCreationGameTypeSectionLabel": {
-    "description": "Section label for the game type selector in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeNormal": "Normal",
-  "@gameCreationGameTypeNormal": {
-    "description": "Option label for gender-specific game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeMixed": "Mixed",
-  "@gameCreationGameTypeMixed": {
-    "description": "Option label for mixed-gender game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeDescription": "Normal games count for your gender ELO. Mixed games are friendly and do not affect your rating.",
-  "@gameCreationGameTypeDescription": {
-    "description": "Explanatory text under the game type selector (Story 26.8)"
-  },
-  "gameCreationAlwaysMixed": "Your games are always mixed",
-  "@gameCreationAlwaysMixed": {
-    "description": "Info label shown to no-gender users instead of the selector (Story 26.8)"
-  },
   "registrationGenderRequired": "Please select a gender to continue",
   "@registrationGenderRequired": {
     "description": "Validation error on registration when no gender is selected"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -611,26 +611,6 @@
   "deleteAccountConfirm": "Eliminar permanentemente",
   "deleteAccountSuccess": "Tu cuenta ha sido eliminada.",
   "deleteAccountError": "No se pudo eliminar tu cuenta. Inténtalo de nuevo.",
-  "gameCreationGameTypeSectionLabel": "Tipo de juego",
-  "@gameCreationGameTypeSectionLabel": {
-    "description": "Section label for the game type selector in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeNormal": "Normal",
-  "@gameCreationGameTypeNormal": {
-    "description": "Option label for gender-specific game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeMixed": "Mixto",
-  "@gameCreationGameTypeMixed": {
-    "description": "Option label for mixed-gender game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeDescription": "Los juegos normales cuentan para tu ELO. Los juegos mixtos son amistosos y no afectan tu clasificación.",
-  "@gameCreationGameTypeDescription": {
-    "description": "Explanatory text under the game type selector (Story 26.8)"
-  },
-  "gameCreationAlwaysMixed": "Tus juegos son siempre mixtos",
-  "@gameCreationAlwaysMixed": {
-    "description": "Info label shown to no-gender users instead of the selector (Story 26.8)"
-  },
   "registrationGenderRequired": "Por favor selecciona un género para continuar",
   "@registrationGenderRequired": {
     "description": "Validation error on registration when no gender is selected"

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -611,26 +611,6 @@
   "deleteAccountConfirm": "Supprimer définitivement",
   "deleteAccountSuccess": "Votre compte a été supprimé.",
   "deleteAccountError": "Impossible de supprimer votre compte. Veuillez réessayer.",
-  "gameCreationGameTypeSectionLabel": "Type de partie",
-  "@gameCreationGameTypeSectionLabel": {
-    "description": "Section label for the game type selector in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeNormal": "Normal",
-  "@gameCreationGameTypeNormal": {
-    "description": "Option label for gender-specific game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeMixed": "Mixte",
-  "@gameCreationGameTypeMixed": {
-    "description": "Option label for mixed-gender game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeDescription": "Les parties normales comptent pour votre ELO. Les parties mixtes sont amicales et n'affectent pas votre classement.",
-  "@gameCreationGameTypeDescription": {
-    "description": "Explanatory text under the game type selector (Story 26.8)"
-  },
-  "gameCreationAlwaysMixed": "Vos parties sont toujours mixtes",
-  "@gameCreationAlwaysMixed": {
-    "description": "Info label shown to no-gender users instead of the selector (Story 26.8)"
-  },
   "registrationGenderRequired": "Veuillez sélectionner un genre pour continuer",
   "@registrationGenderRequired": {
     "description": "Validation error on registration when no gender is selected"

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -611,26 +611,6 @@
   "deleteAccountConfirm": "Elimina definitivamente",
   "deleteAccountSuccess": "Il tuo account è stato eliminato.",
   "deleteAccountError": "Impossibile eliminare l'account. Riprova.",
-  "gameCreationGameTypeSectionLabel": "Tipo di partita",
-  "@gameCreationGameTypeSectionLabel": {
-    "description": "Section label for the game type selector in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeNormal": "Normale",
-  "@gameCreationGameTypeNormal": {
-    "description": "Option label for gender-specific game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeMixed": "Misto",
-  "@gameCreationGameTypeMixed": {
-    "description": "Option label for mixed-gender game in game creation (Story 26.8)"
-  },
-  "gameCreationGameTypeDescription": "Le partite normali contano per il tuo ELO. Le partite miste sono amichevoli e non influenzano il tuo punteggio.",
-  "@gameCreationGameTypeDescription": {
-    "description": "Explanatory text under the game type selector (Story 26.8)"
-  },
-  "gameCreationAlwaysMixed": "Le tue partite sono sempre miste",
-  "@gameCreationAlwaysMixed": {
-    "description": "Info label shown to no-gender users instead of the selector (Story 26.8)"
-  },
   "registrationGenderRequired": "Seleziona un genere per continuare",
   "@registrationGenderRequired": {
     "description": "Validation error on registration when no gender is selected"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3596,36 +3596,6 @@ abstract class AppLocalizations {
   /// **'Failed to delete your account. Please try again.'**
   String get deleteAccountError;
 
-  /// Section label for the game type selector in game creation (Story 26.8)
-  ///
-  /// In en, this message translates to:
-  /// **'Game Type'**
-  String get gameCreationGameTypeSectionLabel;
-
-  /// Option label for gender-specific game in game creation (Story 26.8)
-  ///
-  /// In en, this message translates to:
-  /// **'Normal'**
-  String get gameCreationGameTypeNormal;
-
-  /// Option label for mixed-gender game in game creation (Story 26.8)
-  ///
-  /// In en, this message translates to:
-  /// **'Mixed'**
-  String get gameCreationGameTypeMixed;
-
-  /// Explanatory text under the game type selector (Story 26.8)
-  ///
-  /// In en, this message translates to:
-  /// **'Normal games count for your gender ELO. Mixed games are friendly and do not affect your rating.'**
-  String get gameCreationGameTypeDescription;
-
-  /// Info label shown to no-gender users instead of the selector (Story 26.8)
-  ///
-  /// In en, this message translates to:
-  /// **'Your games are always mixed'**
-  String get gameCreationAlwaysMixed;
-
   /// Validation error on registration when no gender is selected
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1965,22 +1965,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Konto konnte nicht gelöscht werden. Bitte erneut versuchen.';
 
   @override
-  String get gameCreationGameTypeSectionLabel => 'Spieltyp';
-
-  @override
-  String get gameCreationGameTypeNormal => 'Normal';
-
-  @override
-  String get gameCreationGameTypeMixed => 'Gemischt';
-
-  @override
-  String get gameCreationGameTypeDescription =>
-      'Normale Spiele zählen für dein ELO. Gemischte Spiele sind freundschaftlich und beeinflussen dein Rating nicht.';
-
-  @override
-  String get gameCreationAlwaysMixed => 'Ihre Spiele sind immer gemischt';
-
-  @override
   String get registrationGenderRequired =>
       'Bitte wählen Sie ein Geschlecht aus, um fortzufahren';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1930,22 +1930,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to delete your account. Please try again.';
 
   @override
-  String get gameCreationGameTypeSectionLabel => 'Game Type';
-
-  @override
-  String get gameCreationGameTypeNormal => 'Normal';
-
-  @override
-  String get gameCreationGameTypeMixed => 'Mixed';
-
-  @override
-  String get gameCreationGameTypeDescription =>
-      'Normal games count for your gender ELO. Mixed games are friendly and do not affect your rating.';
-
-  @override
-  String get gameCreationAlwaysMixed => 'Your games are always mixed';
-
-  @override
   String get registrationGenderRequired => 'Please select a gender to continue';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1955,22 +1955,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo eliminar tu cuenta. Inténtalo de nuevo.';
 
   @override
-  String get gameCreationGameTypeSectionLabel => 'Tipo de juego';
-
-  @override
-  String get gameCreationGameTypeNormal => 'Normal';
-
-  @override
-  String get gameCreationGameTypeMixed => 'Mixto';
-
-  @override
-  String get gameCreationGameTypeDescription =>
-      'Los juegos normales cuentan para tu ELO. Los juegos mixtos son amistosos y no afectan tu clasificación.';
-
-  @override
-  String get gameCreationAlwaysMixed => 'Tus juegos son siempre mixtos';
-
-  @override
   String get registrationGenderRequired =>
       'Por favor selecciona un género para continuar';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1968,22 +1968,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Impossible de supprimer votre compte. Veuillez réessayer.';
 
   @override
-  String get gameCreationGameTypeSectionLabel => 'Type de partie';
-
-  @override
-  String get gameCreationGameTypeNormal => 'Normal';
-
-  @override
-  String get gameCreationGameTypeMixed => 'Mixte';
-
-  @override
-  String get gameCreationGameTypeDescription =>
-      'Les parties normales comptent pour votre ELO. Les parties mixtes sont amicales et n\'affectent pas votre classement.';
-
-  @override
-  String get gameCreationAlwaysMixed => 'Vos parties sont toujours mixtes';
-
-  @override
   String get registrationGenderRequired =>
       'Veuillez sélectionner un genre pour continuer';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1949,22 +1949,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAccountError => 'Impossibile eliminare l\'account. Riprova.';
 
   @override
-  String get gameCreationGameTypeSectionLabel => 'Tipo di partita';
-
-  @override
-  String get gameCreationGameTypeNormal => 'Normale';
-
-  @override
-  String get gameCreationGameTypeMixed => 'Misto';
-
-  @override
-  String get gameCreationGameTypeDescription =>
-      'Le partite normali contano per il tuo ELO. Le partite miste sono amichevoli e non influenzano il tuo punteggio.';
-
-  @override
-  String get gameCreationAlwaysMixed => 'Le tue partite sono sempre miste';
-
-  @override
   String get registrationGenderRequired => 'Seleziona un genere per continuare';
 
   @override

--- a/test/unit/features/games/presentation/bloc/game_creation/game_creation_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/game_creation/game_creation_bloc_test.dart
@@ -283,60 +283,6 @@ void main() {
       );
     });
 
-    group('SetGameGenderType', () {
-      blocTest<GameCreationBloc, GameCreationState>(
-        'emits GameCreationFormState with mix gameGenderType',
-        build: () => gameCreationBloc,
-        act: (bloc) => bloc.add(const SetGameGenderType(
-          gameGenderType: GameGenderType.mix,
-        )),
-        expect: () => [
-          const GameCreationFormState(
-            gameGenderType: GameGenderType.mix,
-            isValid: false,
-          ),
-        ],
-      );
-
-      blocTest<GameCreationBloc, GameCreationState>(
-        'clears gameGenderType back to null (Normal) when dispatched with null',
-        build: () => gameCreationBloc,
-        seed: () => const GameCreationFormState(
-          gameGenderType: GameGenderType.mix,
-        ),
-        act: (bloc) => bloc.add(const SetGameGenderType(
-          gameGenderType: null,
-        )),
-        expect: () => [
-          const GameCreationFormState(
-            gameGenderType: null,
-            isValid: false,
-          ),
-        ],
-      );
-
-      blocTest<GameCreationBloc, GameCreationState>(
-        'preserves other form fields when gameGenderType changes',
-        build: () => gameCreationBloc,
-        seed: () => GameCreationFormState(
-          groupId: 'group1',
-          groupName: 'Test Group',
-          dateTime: DateTime(2030),
-          title: 'Beach Volleyball',
-          gameGenderType: null,
-        ),
-        act: (bloc) => bloc.add(const SetGameGenderType(
-          gameGenderType: GameGenderType.mix,
-        )),
-        expect: () => [
-          isA<GameCreationFormState>()
-              .having((s) => s.groupId, 'groupId', 'group1')
-              .having((s) => s.title, 'title', 'Beach Volleyball')
-              .having((s) => s.gameGenderType, 'gameGenderType', GameGenderType.mix),
-        ],
-      );
-    });
-
     group('SetSkillLevel', () {
       blocTest<GameCreationBloc, GameCreationState>(
         'emits GameCreationFormState with skillLevel',
@@ -603,67 +549,6 @@ void main() {
         ],
         verify: (_) {
           verifyNever(() => mockGameRepository.createGame(any()));
-        },
-      );
-
-      blocTest<GameCreationBloc, GameCreationState>(
-        'passes gameGenderType to repository when mix is selected',
-        build: () {
-          when(() => mockGameRepository.createGame(any())).thenAnswer(
-            (_) async => 'game456',
-          );
-          return gameCreationBloc;
-        },
-        seed: () => GameCreationFormState(
-          groupId: 'group1',
-          groupName: 'Test Group',
-          dateTime: futureDate,
-          locationName: 'Venice Beach',
-          title: 'Mixed Volleyball',
-          gameGenderType: GameGenderType.mix,
-          isValid: true,
-        ),
-        act: (bloc) => bloc.add(const SubmitGame(createdBy: 'user123')),
-        expect: () => [
-          const GameCreationSubmitting(),
-          isA<GameCreationSuccess>(),
-        ],
-        verify: (_) {
-          final captured = verify(
-            () => mockGameRepository.createGame(captureAny()),
-          ).captured;
-          final game = captured.first as GameModel;
-          expect(game.gameGenderType, equals(GameGenderType.mix));
-        },
-      );
-
-      blocTest<GameCreationBloc, GameCreationState>(
-        'passes null gameGenderType (Normal) to repository when not set',
-        build: () {
-          when(() => mockGameRepository.createGame(any())).thenAnswer(
-            (_) async => 'game789',
-          );
-          return gameCreationBloc;
-        },
-        seed: () => GameCreationFormState(
-          groupId: 'group1',
-          groupName: 'Test Group',
-          dateTime: futureDate,
-          locationName: 'Venice Beach',
-          title: 'Gender Volleyball',
-          isValid: true,
-        ),
-        act: (bloc) => bloc.add(const SubmitGame(createdBy: 'user123')),
-        expect: () => [
-          const GameCreationSubmitting(),
-          isA<GameCreationSuccess>(),
-        ],
-        verify: (_) {
-          final captured = verify(
-            () => mockGameRepository.createGame(captureAny()),
-          ).captured;
-          final game = captured.first as GameModel;
-          expect(game.gameGenderType, isNull);
         },
       );
 

--- a/test/widget/features/games/presentation/pages/game_creation_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_creation_page_test.dart
@@ -7,8 +7,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
-import 'package:play_with_me/core/data/models/user_model.dart';
-import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
@@ -30,8 +28,6 @@ class MockInvitationBloc
     extends MockBloc<InvitationEvent, InvitationState>
     implements InvitationBloc {}
 
-class MockUserRepository extends Mock implements UserRepository {}
-
 class FakeGameCreationEvent extends Fake implements GameCreationEvent {}
 
 class FakeGameCreationState extends Fake implements GameCreationState {}
@@ -40,31 +36,10 @@ void main() {
   late MockGameCreationBloc mockGameCreationBloc;
   late MockAuthenticationBloc mockAuthBloc;
   late MockInvitationBloc mockInvitationBloc;
-  late MockUserRepository mockUserRepository;
 
   const testUserId = 'test-user-123';
   const testGroupId = 'test-group-123';
   const testGroupName = 'Beach Volleyball Crew';
-
-  /// A gendered (male) user — should see Normal/Mixed selector.
-  final genderedUser = UserModel(
-    uid: testUserId,
-    email: 'test@example.com',
-    isEmailVerified: true,
-    isAnonymous: false,
-    gender: UserGender.male,
-    createdAt: DateTime(2024, 1, 1),
-  );
-
-  /// A no-gender user — should only see "always mixed" info label.
-  final noGenderUser = UserModel(
-    uid: testUserId,
-    email: 'test@example.com',
-    isEmailVerified: true,
-    isAnonymous: false,
-    gender: UserGender.none,
-    createdAt: DateTime(2024, 1, 1),
-  );
 
   setUpAll(() {
     registerFallbackValue(FakeGameCreationEvent());
@@ -75,7 +50,6 @@ void main() {
     mockGameCreationBloc = MockGameCreationBloc();
     mockAuthBloc = MockAuthenticationBloc();
     mockInvitationBloc = MockInvitationBloc();
-    mockUserRepository = MockUserRepository();
     when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
 
     when(() => mockGameCreationBloc.state)
@@ -94,18 +68,13 @@ void main() {
       ),
     );
     when(() => mockAuthBloc.stream).thenAnswer((_) => const Stream.empty());
-
-    // Default: gendered user (male) — tests that need a different user
-    // can override this stub before calling createTestWidget.
-    when(() => mockUserRepository.currentUser)
-        .thenAnswer((_) => Stream.value(genderedUser));
   });
 
   tearDown(() {
     mockGameCreationBloc.close();
   });
 
-  Widget createTestWidget({UserRepository? userRepository}) {
+  Widget createTestWidget() {
     return MaterialApp(
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -123,7 +92,6 @@ void main() {
         child: GameCreationPage(
           groupId: testGroupId,
           groupName: testGroupName,
-          userRepository: userRepository ?? mockUserRepository,
         ),
       ),
     );
@@ -640,133 +608,5 @@ void main() {
       });
     });
 
-    // Story 26.8 — Game type selector visibility based on user gender
-    group('Game Type Selector (Story 26.8)', () {
-      testWidgets(
-          'shows Normal/Mixed selector for a gendered (male) user',
-          (tester) async {
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(genderedUser));
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump(); // allow Future from currentUser.first to resolve
-
-        // Section label must be visible
-        expect(find.text('Game Type'), findsOneWidget);
-        // Both toggle options must be visible
-        expect(find.text('Normal'), findsOneWidget);
-        expect(find.text('Mixed'), findsOneWidget);
-        // Info label for mix-only users must NOT appear
-        expect(find.text('Your games are always mixed'), findsNothing);
-      });
-
-      testWidgets(
-          'shows Normal/Mixed selector for a gendered (female) user',
-          (tester) async {
-        final femaleUser = UserModel(
-          uid: testUserId,
-          email: 'test@example.com',
-          isEmailVerified: true,
-          isAnonymous: false,
-          gender: UserGender.female,
-          createdAt: DateTime(2024, 1, 1),
-        );
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(femaleUser));
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump();
-
-        expect(find.text('Normal'), findsOneWidget);
-        expect(find.text('Mixed'), findsOneWidget);
-        expect(find.text('Your games are always mixed'), findsNothing);
-      });
-
-      testWidgets(
-          'hides selector and shows info label for a no-gender user',
-          (tester) async {
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(noGenderUser));
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump();
-
-        // No toggle options
-        expect(find.text('Normal'), findsNothing);
-        expect(find.text('Mixed'), findsNothing);
-        // Info label must be shown
-        expect(find.text('Your games are always mixed'), findsOneWidget);
-      });
-
-      testWidgets(
-          'tapping Mixed option dispatches SetGameGenderType(mix)',
-          (tester) async {
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(genderedUser));
-        // Seed a form state so the BLoC emits a state that renders the selector
-        when(() => mockGameCreationBloc.state).thenReturn(
-          const GameCreationFormState(isValid: false),
-        );
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump();
-
-        // Scroll to selector if needed, then tap Mixed
-        await tester.ensureVisible(find.text('Mixed'));
-        await tester.tap(find.text('Mixed'));
-        await tester.pump();
-
-        verify(
-          () => mockGameCreationBloc.add(
-            const SetGameGenderType(gameGenderType: GameGenderType.mix),
-          ),
-        ).called(1);
-      });
-
-      testWidgets(
-          'tapping Normal option dispatches SetGameGenderType(null)',
-          (tester) async {
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(genderedUser));
-        when(() => mockGameCreationBloc.state).thenReturn(
-          const GameCreationFormState(
-            gameGenderType: GameGenderType.mix,
-            isValid: false,
-          ),
-        );
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump();
-
-        // Clear recorded calls from initState (which also dispatches null for gendered users).
-        clearInteractions(mockGameCreationBloc);
-
-        await tester.ensureVisible(find.text('Normal'));
-        await tester.tap(find.text('Normal'));
-        await tester.pump();
-
-        verify(
-          () => mockGameCreationBloc.add(
-            const SetGameGenderType(gameGenderType: null),
-          ),
-        ).called(1);
-      });
-
-      testWidgets(
-          'no-gender user silently dispatches SetGameGenderType(mix) on load',
-          (tester) async {
-        when(() => mockUserRepository.currentUser)
-            .thenAnswer((_) => Stream.value(noGenderUser));
-
-        await tester.pumpWidget(createTestWidget());
-        await tester.pump();
-
-        verify(
-          () => mockGameCreationBloc.add(
-            const SetGameGenderType(gameGenderType: GameGenderType.mix),
-          ),
-        ).called(1);
-      });
-    });
   });
 }


### PR DESCRIPTION
## Summary

- Removes the manual "Game Type" (Normal / Mixed) selector from the game creation form
- The `gameGenderType` field is now set exclusively by Cloud Functions (`onGameCreatedClassifyGender`, `onGamePlayersChangedClassifyGender`) based on the genders of players who actually join the game
- Removes `SetGameGenderType` event, `_onSetGameGenderType` BLoC handler, and `gameGenderType` from `GameCreationFormState`
- Removes 5 unused l10n strings across all 5 languages (EN/FR/DE/ES/IT) and regenerates localizations
- Removes 13 related tests (8 bloc + 5 widget) that tested the now-deleted selector

## Test plan

- [x] All existing unit and widget tests pass (`flutter test test/unit/ test/widget/`)
- [x] `flutter analyze` reports no issues
- [x] Game creation form no longer shows a Game Type field
- [x] Existing `MixGameBadge` display in game list and game details is unaffected
- [x] Cloud Functions still auto-classify game gender when players join