### PR TITLE
fix(game-gender): treat gender=none as mix in classification

### DIFF
--- a/functions/src/helpers/classifyGameGenderType.ts
+++ b/functions/src/helpers/classifyGameGenderType.ts
@@ -29,8 +29,8 @@ export async function classifyGameGenderType(
     const userData = userDoc.data();
     const gender: string | undefined = userData?.gender;
 
-    if (!gender || gender === "prefer_not_to_say") {
-      // Unknown or non-binary preference → treat as mixed
+    if (!gender || gender === "none" || gender === "prefer_not_to_say") {
+      // Unknown, none, or non-binary preference → treat as mixed
       functions.logger.debug("[classifyGameGenderType] Player has no classifiable gender", {
         playerId,
         gender: gender ?? "undefined",


### PR DESCRIPTION
## Summary

- Users with `gender = "none"` were not triggering the mix badge on games they created
- The `classifyGameGenderType` helper only checked for `!gender` and `"prefer_not_to_say"`, but `"none"` is a non-empty string that passed both conditions
- A solo creator with `gender="none"` fell through to `genders.size === 1` and incorrectly returned `"female"`
- Fix: add `|| gender === "none"` to the early-return mix condition

## Root cause

```typescript
// Before — "none" passed this check (non-empty string)
if (!gender || gender === "prefer_not_to_say") { return "mix"; }

// After
if (!gender || gender === "none" || gender === "prefer_not_to_say") { return "mix"; }
```

## Test plan

- [x] Deployed fix to gatherli-dev
- [x] User with no gender creates a game → MixGameBadge appears
- [x] User with gender=male creates a game alone → no mix badge
- [x] Mixed team (male + none) → mix badge appears