### PR TITLE
fix(l10n): rename gender "None of them" to "Other"

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -592,7 +592,7 @@
   "@genderFemale": {
     "description": "Gender option: Female"
   },
-  "genderPreferNotToSay": "Keines davon",
+  "genderPreferNotToSay": "Andere",
   "@genderPreferNotToSay": {
     "description": "Gender option: Prefer not to say"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2791,7 +2791,7 @@
   "@genderFemale": {
     "description": "Gender option: Female"
   },
-  "genderPreferNotToSay": "None of them",
+  "genderPreferNotToSay": "Other",
   "@genderPreferNotToSay": {
     "description": "Gender option: Prefer not to say (maps to UserGender.none)"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -592,7 +592,7 @@
   "@genderFemale": {
     "description": "Gender option: Female"
   },
-  "genderPreferNotToSay": "Ninguno",
+  "genderPreferNotToSay": "Otro",
   "@genderPreferNotToSay": {
     "description": "Gender option: Prefer not to say"
   },

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -592,7 +592,7 @@
   "@genderFemale": {
     "description": "Gender option: Female"
   },
-  "genderPreferNotToSay": "Aucun des deux",
+  "genderPreferNotToSay": "Autre",
   "@genderPreferNotToSay": {
     "description": "Gender option: Prefer not to say"
   },

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -592,7 +592,7 @@
   "@genderFemale": {
     "description": "Gender option: Female"
   },
-  "genderPreferNotToSay": "Nessuno dei due",
+  "genderPreferNotToSay": "Altro",
   "@genderPreferNotToSay": {
     "description": "Gender option: Prefer not to say"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3545,7 +3545,7 @@ abstract class AppLocalizations {
   /// Gender option: Prefer not to say (maps to UserGender.none)
   ///
   /// In en, this message translates to:
-  /// **'None of them'**
+  /// **'Other'**
   String get genderPreferNotToSay;
 
   /// Continue button label on gender selection screen

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1935,7 +1935,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get genderFemale => 'Weiblich';
 
   @override
-  String get genderPreferNotToSay => 'Keines davon';
+  String get genderPreferNotToSay => 'Andere';
 
   @override
   String get genderSelectionContinue => 'Weiter';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1900,7 +1900,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get genderFemale => 'Female';
 
   @override
-  String get genderPreferNotToSay => 'None of them';
+  String get genderPreferNotToSay => 'Other';
 
   @override
   String get genderSelectionContinue => 'Continue';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1925,7 +1925,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get genderFemale => 'Mujer';
 
   @override
-  String get genderPreferNotToSay => 'Ninguno';
+  String get genderPreferNotToSay => 'Otro';
 
   @override
   String get genderSelectionContinue => 'Continuar';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1938,7 +1938,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get genderFemale => 'Femme';
 
   @override
-  String get genderPreferNotToSay => 'Aucun des deux';
+  String get genderPreferNotToSay => 'Autre';
 
   @override
   String get genderSelectionContinue => 'Continuer';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1921,7 +1921,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get genderFemale => 'Donna';
 
   @override
-  String get genderPreferNotToSay => 'Nessuno dei due';
+  String get genderPreferNotToSay => 'Altro';
 
   @override
   String get genderSelectionContinue => 'Continua';


### PR DESCRIPTION
## Summary

Renames the third gender option on the sign-up page from "None of them" to "Other" across all 5 supported languages.

| Language | Before | After |
|----------|--------|-------|
| EN | None of them | Other |
| FR | Aucun des deux | Autre |
| DE | Keines davon | Andere |
| ES | Ninguno | Otro |
| IT | Nessuno dei due | Altro |

Only the display label changes — the underlying stored value (`none`) and the `UserGender.none` enum are unchanged.

## Test plan

- [x] Sign-up gender selector shows "Other" in English
- [x] `flutter analyze` reports no issues
- [x] Localizations regenerated via `flutter gen-l10n`