### PR TITLE
Story 27.2: Upgrade iOS builds to Xcode 26 / iOS 26 SDK (ITMS-90725)

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -252,11 +252,27 @@ jobs:
   deploy_ios:
     name: 🍎 Build & Upload iOS (TestFlight)
     needs: test
-    runs-on: macos-15
+    runs-on: macos-latest  # macos-latest must include Xcode 26+ (iOS 26 SDK required from April 28 2026 — ITMS-90725)
 
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: 🔨 Select Xcode (latest stable — iOS 26 SDK required from April 28 2026)
+        # Explicitly selects the latest stable Xcode on the runner to ensure we
+        # build against the iOS 26 SDK. Using 'latest-stable' means this
+        # automatically picks up new Xcode versions as GitHub updates the runner.
+        # If the runner does not yet ship Xcode 26, pin runs-on to macos-26 once available.
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd  # v1.6.0
+        with:
+          xcode-version: 'latest-stable'
+
+      - name: 🔍 Log Xcode & SDK version
+        # Surfacing these early makes it obvious when the wrong SDK is in use.
+        run: |
+          echo "Xcode path: $(xcode-select -p)"
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-version
 
       - name: 🔧 Setup Flutter
         uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -171,11 +171,27 @@ jobs:
   deploy_ios:
     name: 🍎 Build & Upload iOS (App Store Connect)
     needs: test
-    runs-on: macos-latest
+    runs-on: macos-latest  # must include Xcode 26+ (iOS 26 SDK required from April 28 2026 — ITMS-90725)
 
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: 🔨 Select Xcode (latest stable — iOS 26 SDK required from April 28 2026)
+        # Explicitly selects the latest stable Xcode on the runner to ensure we
+        # build against the iOS 26 SDK. Using 'latest-stable' means this
+        # automatically picks up new Xcode versions as GitHub updates the runner.
+        # If the runner does not yet ship Xcode 26, pin runs-on to macos-26 once available.
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd  # v1.6.0
+        with:
+          xcode-version: 'latest-stable'
+
+      - name: 🔍 Log Xcode & SDK version
+        # Surfacing these early makes it obvious when the wrong SDK is in use.
+        run: |
+          echo "Xcode path: $(xcode-select -p)"
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-version
 
       - name: 🔧 Setup Flutter
         uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff  # v2.18.0


### PR DESCRIPTION
## Summary

- **Beta pipeline** (`cd-beta.yml`): switched `runs-on` from `macos-15` to `macos-latest` (aligns with production) and added explicit Xcode latest-stable selection
- **Production pipeline** (`cd-production.yml`): added the same explicit Xcode selection step
- Both iOS jobs now log the active Xcode path and iOS SDK version at the start of the job — making it immediately obvious if the wrong SDK is in use
- Both jobs are annotated with the ITMS-90725 context and April 28, 2026 deadline

## Context

Apple notified us on build 27 (v0.7.0):

> **ITMS-90725**: This app was built with the iOS 18.5 SDK. Starting **April 28, 2026**, all iOS and iPadOS apps must be built with the **iOS 26 SDK or later**.

The root cause: the beta job was pinned to `macos-15` (Xcode 16.x, iOS 18.x SDK) and production used `macos-latest` which also resolved to macOS 15 at build time.

## How the fix works

`maxim-lobanov/setup-xcode` with `xcode-version: 'latest-stable'` selects the highest stable Xcode pre-installed on the runner. Once GitHub updates `macos-latest` to include macOS with Xcode 26, both pipelines will automatically build against the iOS 26 SDK.

If GitHub has not updated `macos-latest` in time for the April 28 deadline, the next step is to pin `runs-on` to `macos-26` (or equivalent) once that runner label is confirmed available. The SDK logging step added here will surface any mismatch immediately.

## Test plan

- [ ] Trigger a beta build and verify the "Log Xcode & SDK version" step shows Xcode 26.x and iOS SDK 26.x
- [ ] Confirm upload to TestFlight completes without the ITMS-90725 warning
- [ ] Verify production pipeline passes the same check on next release

Closes #668

Authored-by: Babas10 <etienne.dubois91@gmail.com>