### PR TITLE
Story 28.1: Game data model — guestPlayerIds & gameInvitations collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -316,6 +316,32 @@ service cloud.firestore {
       }
     }
 
+    // ============================================
+    // Game Invitations (Epic 28 — Story 28.1)
+    // ============================================
+    // Cross-group game invitations. A user outside the game's group is invited
+    // by the game creator to join as a guest player.
+    //
+    // WRITE POLICY: All mutations go through Cloud Functions (Admin SDK) only.
+    //   - inviteGuestToGame (Story 28.2) — creates the invitation
+    //   - acceptGameGuestInvitation / declineGameGuestInvitation (Story 28.4) — update status
+    //   - auto-expire trigger (Story 28.5) — sets status to 'expired'
+    //
+    // READ POLICY: Only the invitee or the inviter may read a document.
+    match /gameInvitations/{invitationId} {
+      allow get: if isAuthenticated() &&
+                    (request.auth.uid == resource.data.inviteeId ||
+                     request.auth.uid == resource.data.inviterId);
+
+      // List queries must be scoped to the caller (invitee or inviter)
+      allow list: if isAuthenticated() &&
+                     (request.auth.uid == resource.data.inviteeId ||
+                      request.auth.uid == resource.data.inviterId);
+
+      // All writes are via Cloud Functions (Admin SDK bypasses these rules)
+      allow create, update, delete: if false;
+    }
+
     // Deny all other access
     match /{document=**} {
       allow read, write: if false;

--- a/lib/core/data/models/game_invitation_model.dart
+++ b/lib/core/data/models/game_invitation_model.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:play_with_me/core/data/models/game_model.dart';
+
+part 'game_invitation_model.freezed.dart';
+part 'game_invitation_model.g.dart';
+
+/// Status of a cross-group game invitation (Story 28.1)
+enum GameInvitationStatus {
+  @JsonValue('pending')
+  pending,
+  @JsonValue('accepted')
+  accepted,
+  @JsonValue('declined')
+  declined,
+  @JsonValue('expired')
+  expired,
+}
+
+/// Represents an invitation sent to a user outside the game's group (Story 28.1)
+/// Stored in the `gameInvitations` Firestore collection.
+/// Created and mutated exclusively via Cloud Functions (Admin SDK).
+@freezed
+class GameInvitationModel with _$GameInvitationModel {
+  const factory GameInvitationModel({
+    required String id,
+    required String gameId,
+    required String groupId,
+    required String inviteeId,
+    required String inviterId,
+    @Default(GameInvitationStatus.pending) GameInvitationStatus status,
+    @TimestampConverter() required DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    // Optional: when the invitation expires (set to game scheduledAt by CF)
+    @TimestampConverter() DateTime? expiresAt,
+  }) = _GameInvitationModel;
+
+  const GameInvitationModel._();
+
+  factory GameInvitationModel.fromJson(Map<String, dynamic> json) =>
+      _$GameInvitationModelFromJson(json);
+
+  /// Factory constructor for creating from Firestore DocumentSnapshot
+  factory GameInvitationModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    final jsonData = Map<String, dynamic>.from(data);
+
+    for (final field in ['createdAt', 'updatedAt', 'expiresAt']) {
+      if (data[field] is Timestamp) {
+        jsonData[field] = (data[field] as Timestamp).toDate().toIso8601String();
+      }
+    }
+
+    return GameInvitationModel.fromJson({...jsonData, 'id': doc.id});
+  }
+
+  /// Whether this invitation is still actionable
+  bool get isPending => status == GameInvitationStatus.pending;
+
+  /// Whether the invitee accepted and is now a guest player
+  bool get isAccepted => status == GameInvitationStatus.accepted;
+}

--- a/lib/core/data/models/game_invitation_model.freezed.dart
+++ b/lib/core/data/models/game_invitation_model.freezed.dart
@@ -1,0 +1,370 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'game_invitation_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+GameInvitationModel _$GameInvitationModelFromJson(Map<String, dynamic> json) {
+  return _GameInvitationModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GameInvitationModel {
+  String get id => throw _privateConstructorUsedError;
+  String get gameId => throw _privateConstructorUsedError;
+  String get groupId => throw _privateConstructorUsedError;
+  String get inviteeId => throw _privateConstructorUsedError;
+  String get inviterId => throw _privateConstructorUsedError;
+  GameInvitationStatus get status => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  DateTime? get updatedAt => throw _privateConstructorUsedError; // Optional: when the invitation expires (set to game scheduledAt by CF)
+  @TimestampConverter()
+  DateTime? get expiresAt => throw _privateConstructorUsedError;
+
+  /// Serializes this GameInvitationModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of GameInvitationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $GameInvitationModelCopyWith<GameInvitationModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GameInvitationModelCopyWith<$Res> {
+  factory $GameInvitationModelCopyWith(
+    GameInvitationModel value,
+    $Res Function(GameInvitationModel) then,
+  ) = _$GameInvitationModelCopyWithImpl<$Res, GameInvitationModel>;
+  @useResult
+  $Res call({
+    String id,
+    String gameId,
+    String groupId,
+    String inviteeId,
+    String inviterId,
+    GameInvitationStatus status,
+    @TimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    @TimestampConverter() DateTime? expiresAt,
+  });
+}
+
+/// @nodoc
+class _$GameInvitationModelCopyWithImpl<$Res, $Val extends GameInvitationModel>
+    implements $GameInvitationModelCopyWith<$Res> {
+  _$GameInvitationModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GameInvitationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? gameId = null,
+    Object? groupId = null,
+    Object? inviteeId = null,
+    Object? inviterId = null,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = freezed,
+    Object? expiresAt = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            gameId: null == gameId
+                ? _value.gameId
+                : gameId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            groupId: null == groupId
+                ? _value.groupId
+                : groupId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            inviteeId: null == inviteeId
+                ? _value.inviteeId
+                : inviteeId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            inviterId: null == inviterId
+                ? _value.inviterId
+                : inviterId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as GameInvitationStatus,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            updatedAt: freezed == updatedAt
+                ? _value.updatedAt
+                : updatedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            expiresAt: freezed == expiresAt
+                ? _value.expiresAt
+                : expiresAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$GameInvitationModelImplCopyWith<$Res>
+    implements $GameInvitationModelCopyWith<$Res> {
+  factory _$$GameInvitationModelImplCopyWith(
+    _$GameInvitationModelImpl value,
+    $Res Function(_$GameInvitationModelImpl) then,
+  ) = __$$GameInvitationModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String gameId,
+    String groupId,
+    String inviteeId,
+    String inviterId,
+    GameInvitationStatus status,
+    @TimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime? updatedAt,
+    @TimestampConverter() DateTime? expiresAt,
+  });
+}
+
+/// @nodoc
+class __$$GameInvitationModelImplCopyWithImpl<$Res>
+    extends _$GameInvitationModelCopyWithImpl<$Res, _$GameInvitationModelImpl>
+    implements _$$GameInvitationModelImplCopyWith<$Res> {
+  __$$GameInvitationModelImplCopyWithImpl(
+    _$GameInvitationModelImpl _value,
+    $Res Function(_$GameInvitationModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GameInvitationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? gameId = null,
+    Object? groupId = null,
+    Object? inviteeId = null,
+    Object? inviterId = null,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = freezed,
+    Object? expiresAt = freezed,
+  }) {
+    return _then(
+      _$GameInvitationModelImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        gameId: null == gameId
+            ? _value.gameId
+            : gameId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        groupId: null == groupId
+            ? _value.groupId
+            : groupId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        inviteeId: null == inviteeId
+            ? _value.inviteeId
+            : inviteeId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        inviterId: null == inviterId
+            ? _value.inviterId
+            : inviterId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as GameInvitationStatus,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        updatedAt: freezed == updatedAt
+            ? _value.updatedAt
+            : updatedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        expiresAt: freezed == expiresAt
+            ? _value.expiresAt
+            : expiresAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GameInvitationModelImpl extends _GameInvitationModel {
+  const _$GameInvitationModelImpl({
+    required this.id,
+    required this.gameId,
+    required this.groupId,
+    required this.inviteeId,
+    required this.inviterId,
+    this.status = GameInvitationStatus.pending,
+    @TimestampConverter() required this.createdAt,
+    @TimestampConverter() this.updatedAt,
+    @TimestampConverter() this.expiresAt,
+  }) : super._();
+
+  factory _$GameInvitationModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GameInvitationModelImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String gameId;
+  @override
+  final String groupId;
+  @override
+  final String inviteeId;
+  @override
+  final String inviterId;
+  @override
+  @JsonKey()
+  final GameInvitationStatus status;
+  @override
+  @TimestampConverter()
+  final DateTime createdAt;
+  @override
+  @TimestampConverter()
+  final DateTime? updatedAt;
+  // Optional: when the invitation expires (set to game scheduledAt by CF)
+  @override
+  @TimestampConverter()
+  final DateTime? expiresAt;
+
+  @override
+  String toString() {
+    return 'GameInvitationModel(id: $id, gameId: $gameId, groupId: $groupId, inviteeId: $inviteeId, inviterId: $inviterId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, expiresAt: $expiresAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GameInvitationModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.gameId, gameId) || other.gameId == gameId) &&
+            (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.inviteeId, inviteeId) ||
+                other.inviteeId == inviteeId) &&
+            (identical(other.inviterId, inviterId) ||
+                other.inviterId == inviterId) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.expiresAt, expiresAt) ||
+                other.expiresAt == expiresAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    gameId,
+    groupId,
+    inviteeId,
+    inviterId,
+    status,
+    createdAt,
+    updatedAt,
+    expiresAt,
+  );
+
+  /// Create a copy of GameInvitationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GameInvitationModelImplCopyWith<_$GameInvitationModelImpl> get copyWith =>
+      __$$GameInvitationModelImplCopyWithImpl<_$GameInvitationModelImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GameInvitationModelImplToJson(this);
+  }
+}
+
+abstract class _GameInvitationModel extends GameInvitationModel {
+  const factory _GameInvitationModel({
+    required final String id,
+    required final String gameId,
+    required final String groupId,
+    required final String inviteeId,
+    required final String inviterId,
+    final GameInvitationStatus status,
+    @TimestampConverter() required final DateTime createdAt,
+    @TimestampConverter() final DateTime? updatedAt,
+    @TimestampConverter() final DateTime? expiresAt,
+  }) = _$GameInvitationModelImpl;
+  const _GameInvitationModel._() : super._();
+
+  factory _GameInvitationModel.fromJson(Map<String, dynamic> json) =
+      _$GameInvitationModelImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get gameId;
+  @override
+  String get groupId;
+  @override
+  String get inviteeId;
+  @override
+  String get inviterId;
+  @override
+  GameInvitationStatus get status;
+  @override
+  @TimestampConverter()
+  DateTime get createdAt;
+  @override
+  @TimestampConverter()
+  DateTime? get updatedAt; // Optional: when the invitation expires (set to game scheduledAt by CF)
+  @override
+  @TimestampConverter()
+  DateTime? get expiresAt;
+
+  /// Create a copy of GameInvitationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GameInvitationModelImplCopyWith<_$GameInvitationModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/data/models/game_invitation_model.g.dart
+++ b/lib/core/data/models/game_invitation_model.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'game_invitation_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GameInvitationModelImpl _$$GameInvitationModelImplFromJson(
+  Map<String, dynamic> json,
+) => _$GameInvitationModelImpl(
+  id: json['id'] as String,
+  gameId: json['gameId'] as String,
+  groupId: json['groupId'] as String,
+  inviteeId: json['inviteeId'] as String,
+  inviterId: json['inviterId'] as String,
+  status:
+      $enumDecodeNullable(_$GameInvitationStatusEnumMap, json['status']) ??
+      GameInvitationStatus.pending,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: const TimestampConverter().fromJson(json['updatedAt']),
+  expiresAt: const TimestampConverter().fromJson(json['expiresAt']),
+);
+
+Map<String, dynamic> _$$GameInvitationModelImplToJson(
+  _$GameInvitationModelImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'gameId': instance.gameId,
+  'groupId': instance.groupId,
+  'inviteeId': instance.inviteeId,
+  'inviterId': instance.inviterId,
+  'status': _$GameInvitationStatusEnumMap[instance.status]!,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'updatedAt': const TimestampConverter().toJson(instance.updatedAt),
+  'expiresAt': const TimestampConverter().toJson(instance.expiresAt),
+};
+
+const _$GameInvitationStatusEnumMap = {
+  GameInvitationStatus.pending: 'pending',
+  GameInvitationStatus.accepted: 'accepted',
+  GameInvitationStatus.declined: 'declined',
+  GameInvitationStatus.expired: 'expired',
+};

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -23,6 +23,8 @@ class GameModel with _$GameModel {
     @Default(2) int minPlayers,
     @Default([]) List<String> playerIds,
     @Default([]) List<String> waitlistIds,
+    // Guest players — cross-group invitees who accepted a game invitation (Story 28.1)
+    @Default([]) List<String> guestPlayerIds,
     // Game settings
     @Default(true) bool allowWaitlist,
     @Default(true) bool allowPlayerInvites,
@@ -157,8 +159,14 @@ class GameModel with _$GameModel {
 
   /// Business logic methods
 
-  /// Check if user is participating in the game
+  /// Check if user is a regular group player in the game
   bool isPlayer(String userId) => playerIds.contains(userId);
+
+  /// Check if user is a guest player (cross-group invitee who accepted)
+  bool isGuestPlayer(String userId) => guestPlayerIds.contains(userId);
+
+  /// Check if user is any kind of participant (regular or guest)
+  bool isParticipant(String userId) => isPlayer(userId) || isGuestPlayer(userId);
 
   /// Check if user is on the waitlist
   bool isOnWaitlist(String userId) => waitlistIds.contains(userId);
@@ -169,17 +177,17 @@ class GameModel with _$GameModel {
   /// Check if user can manage the game
   bool canManage(String userId) => createdBy == userId;
 
-  /// Check if game is full
-  bool get isFull => playerIds.length >= maxPlayers;
+  /// Check if game is full (counts both regular players and accepted guests)
+  bool get isFull => playerIds.length + guestPlayerIds.length >= maxPlayers;
 
-  /// Check if game has minimum players
-  bool get hasMinimumPlayers => playerIds.length >= minPlayers;
+  /// Check if game has minimum players (counts both regular players and accepted guests)
+  bool get hasMinimumPlayers => playerIds.length + guestPlayerIds.length >= minPlayers;
 
-  /// Get available spots
-  int get availableSpots => maxPlayers - playerIds.length;
+  /// Get available spots (accounts for accepted guests filling spots)
+  int get availableSpots => maxPlayers - (playerIds.length + guestPlayerIds.length);
 
-  /// Get current player count
-  int get currentPlayerCount => playerIds.length;
+  /// Get current player count (regular players + accepted guests)
+  int get currentPlayerCount => playerIds.length + guestPlayerIds.length;
 
   /// Get waitlist count
   int get waitlistCount => waitlistIds.length;
@@ -220,7 +228,7 @@ class GameModel with _$GameModel {
 
   /// Check if user can join the game
   bool canUserJoin(String userId) {
-    if (isPlayer(userId) || isOnWaitlist(userId)) return false;
+    if (isPlayer(userId) || isGuestPlayer(userId) || isOnWaitlist(userId)) return false;
     if (status != GameStatus.scheduled) return false;
     if (isPast) return false;
     return !isFull || allowWaitlist;
@@ -236,7 +244,7 @@ class GameModel with _$GameModel {
   /// Allows participants (or creator) to enter results if the game is ready
   /// (completed, in-progress, or past scheduled time) and has enough players
   bool canUserEnterResults(String userId) {
-    final isParticipant = isPlayer(userId) || isCreator(userId);
+    final isParticipant = isPlayer(userId) || isGuestPlayer(userId) || isCreator(userId);
     final hasExistingResult = result != null;
     final isCancelled = status == GameStatus.cancelled;
     final isVerification = status == GameStatus.verification;

--- a/lib/core/data/models/game_model.freezed.dart
+++ b/lib/core/data/models/game_model.freezed.dart
@@ -42,6 +42,8 @@ mixin _$GameModel {
   int get minPlayers => throw _privateConstructorUsedError;
   List<String> get playerIds => throw _privateConstructorUsedError;
   List<String> get waitlistIds =>
+      throw _privateConstructorUsedError; // Guest players — cross-group invitees who accepted a game invitation (Story 28.1)
+  List<String> get guestPlayerIds =>
       throw _privateConstructorUsedError; // Game settings
   bool get allowWaitlist => throw _privateConstructorUsedError;
   bool get allowPlayerInvites => throw _privateConstructorUsedError;
@@ -111,6 +113,7 @@ abstract class $GameModelCopyWith<$Res> {
     int minPlayers,
     List<String> playerIds,
     List<String> waitlistIds,
+    List<String> guestPlayerIds,
     bool allowWaitlist,
     bool allowPlayerInvites,
     GameVisibility visibility,
@@ -170,6 +173,7 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
     Object? minPlayers = null,
     Object? playerIds = null,
     Object? waitlistIds = null,
+    Object? guestPlayerIds = null,
     Object? allowWaitlist = null,
     Object? allowPlayerInvites = null,
     Object? visibility = null,
@@ -257,6 +261,10 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
             waitlistIds: null == waitlistIds
                 ? _value.waitlistIds
                 : waitlistIds // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            guestPlayerIds: null == guestPlayerIds
+                ? _value.guestPlayerIds
+                : guestPlayerIds // ignore: cast_nullable_to_non_nullable
                       as List<String>,
             allowWaitlist: null == allowWaitlist
                 ? _value.allowWaitlist
@@ -412,6 +420,7 @@ abstract class _$$GameModelImplCopyWith<$Res>
     int minPlayers,
     List<String> playerIds,
     List<String> waitlistIds,
+    List<String> guestPlayerIds,
     bool allowWaitlist,
     bool allowPlayerInvites,
     GameVisibility visibility,
@@ -473,6 +482,7 @@ class __$$GameModelImplCopyWithImpl<$Res>
     Object? minPlayers = null,
     Object? playerIds = null,
     Object? waitlistIds = null,
+    Object? guestPlayerIds = null,
     Object? allowWaitlist = null,
     Object? allowPlayerInvites = null,
     Object? visibility = null,
@@ -560,6 +570,10 @@ class __$$GameModelImplCopyWithImpl<$Res>
         waitlistIds: null == waitlistIds
             ? _value._waitlistIds
             : waitlistIds // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        guestPlayerIds: null == guestPlayerIds
+            ? _value._guestPlayerIds
+            : guestPlayerIds // ignore: cast_nullable_to_non_nullable
                   as List<String>,
         allowWaitlist: null == allowWaitlist
             ? _value.allowWaitlist
@@ -670,6 +684,7 @@ class _$GameModelImpl extends _GameModel {
     this.minPlayers = 2,
     final List<String> playerIds = const [],
     final List<String> waitlistIds = const [],
+    final List<String> guestPlayerIds = const [],
     this.allowWaitlist = true,
     this.allowPlayerInvites = true,
     this.visibility = GameVisibility.group,
@@ -693,6 +708,7 @@ class _$GameModelImpl extends _GameModel {
     this.gameGenderType,
   }) : _playerIds = playerIds,
        _waitlistIds = waitlistIds,
+       _guestPlayerIds = guestPlayerIds,
        _equipment = equipment,
        _scores = scores,
        _confirmedBy = confirmedBy,
@@ -754,6 +770,17 @@ class _$GameModelImpl extends _GameModel {
     if (_waitlistIds is EqualUnmodifiableListView) return _waitlistIds;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_waitlistIds);
+  }
+
+  // Guest players — cross-group invitees who accepted a game invitation (Story 28.1)
+  final List<String> _guestPlayerIds;
+  // Guest players — cross-group invitees who accepted a game invitation (Story 28.1)
+  @override
+  @JsonKey()
+  List<String> get guestPlayerIds {
+    if (_guestPlayerIds is EqualUnmodifiableListView) return _guestPlayerIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_guestPlayerIds);
   }
 
   // Game settings
@@ -855,7 +882,7 @@ class _$GameModelImpl extends _GameModel {
 
   @override
   String toString() {
-    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, eloUpdates: $eloUpdates, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes, gameGenderType: $gameGenderType)';
+    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, guestPlayerIds: $guestPlayerIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, eloUpdates: $eloUpdates, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes, gameGenderType: $gameGenderType)';
   }
 
   @override
@@ -893,6 +920,10 @@ class _$GameModelImpl extends _GameModel {
             const DeepCollectionEquality().equals(
               other._waitlistIds,
               _waitlistIds,
+            ) &&
+            const DeepCollectionEquality().equals(
+              other._guestPlayerIds,
+              _guestPlayerIds,
             ) &&
             (identical(other.allowWaitlist, allowWaitlist) ||
                 other.allowWaitlist == allowWaitlist) &&
@@ -960,6 +991,7 @@ class _$GameModelImpl extends _GameModel {
     minPlayers,
     const DeepCollectionEquality().hash(_playerIds),
     const DeepCollectionEquality().hash(_waitlistIds),
+    const DeepCollectionEquality().hash(_guestPlayerIds),
     allowWaitlist,
     allowPlayerInvites,
     visibility,
@@ -1015,6 +1047,7 @@ abstract class _GameModel extends GameModel {
     final int minPlayers,
     final List<String> playerIds,
     final List<String> waitlistIds,
+    final List<String> guestPlayerIds,
     final bool allowWaitlist,
     final bool allowPlayerInvites,
     final GameVisibility visibility,
@@ -1078,7 +1111,9 @@ abstract class _GameModel extends GameModel {
   @override
   List<String> get playerIds;
   @override
-  List<String> get waitlistIds; // Game settings
+  List<String> get waitlistIds; // Guest players — cross-group invitees who accepted a game invitation (Story 28.1)
+  @override
+  List<String> get guestPlayerIds; // Game settings
   @override
   bool get allowWaitlist;
   @override

--- a/lib/core/data/models/game_model.g.dart
+++ b/lib/core/data/models/game_model.g.dart
@@ -33,6 +33,11 @@ _$GameModelImpl _$$GameModelImplFromJson(
           ?.map((e) => e as String)
           .toList() ??
       const [],
+  guestPlayerIds:
+      (json['guestPlayerIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const [],
   allowWaitlist: json['allowWaitlist'] as bool? ?? true,
   allowPlayerInvites: json['allowPlayerInvites'] as bool? ?? true,
   visibility:
@@ -48,10 +53,6 @@ _$GameModelImpl _$$GameModelImplFromJson(
   courtInfo: json['courtInfo'] as String?,
   gameType: $enumDecodeNullable(_$GameTypeEnumMap, json['gameType']),
   skillLevel: $enumDecodeNullable(_$GameSkillLevelEnumMap, json['skillLevel']),
-  gameGenderType: $enumDecodeNullable(
-    _$GameGenderTypeEnumMap,
-    json['gameGenderType'],
-  ),
   scores:
       (json['scores'] as List<dynamic>?)
           ?.map((e) => GameScore.fromJson(e as Map<String, dynamic>))
@@ -75,6 +76,10 @@ _$GameModelImpl _$$GameModelImplFromJson(
   completedAt: const TimestampConverter().fromJson(json['completedAt']),
   weatherDependent: json['weatherDependent'] as bool? ?? true,
   weatherNotes: json['weatherNotes'] as String?,
+  gameGenderType: $enumDecodeNullable(
+    _$GameGenderTypeEnumMap,
+    json['gameGenderType'],
+  ),
 );
 
 Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
@@ -95,6 +100,7 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
       'minPlayers': instance.minPlayers,
       'playerIds': instance.playerIds,
       'waitlistIds': instance.waitlistIds,
+      'guestPlayerIds': instance.guestPlayerIds,
       'allowWaitlist': instance.allowWaitlist,
       'allowPlayerInvites': instance.allowPlayerInvites,
       'visibility': _$GameVisibilityEnumMap[instance.visibility]!,
@@ -104,7 +110,6 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
       'courtInfo': instance.courtInfo,
       'gameType': _$GameTypeEnumMap[instance.gameType],
       'skillLevel': _$GameSkillLevelEnumMap[instance.skillLevel],
-      'gameGenderType': _$GameGenderTypeEnumMap[instance.gameGenderType],
       'scores': instance.scores,
       'winnerId': instance.winnerId,
       'teams': instance.teams,
@@ -116,6 +121,7 @@ Map<String, dynamic> _$$GameModelImplToJson(_$GameModelImpl instance) =>
       'completedAt': const TimestampConverter().toJson(instance.completedAt),
       'weatherDependent': instance.weatherDependent,
       'weatherNotes': instance.weatherNotes,
+      'gameGenderType': _$GameGenderTypeEnumMap[instance.gameGenderType],
     };
 
 const _$GameStatusEnumMap = {

--- a/lib/core/domain/exceptions/repository_exceptions.dart
+++ b/lib/core/domain/exceptions/repository_exceptions.dart
@@ -88,3 +88,14 @@ class GroupInviteLinkException implements Exception {
   @override
   String toString() => message;
 }
+
+/// Exception thrown by GameInvitationRepository operations (Story 28.1).
+class GameInvitationException implements Exception {
+  final String message;
+  final String? code;
+
+  GameInvitationException(this.message, {this.code});
+
+  @override
+  String toString() => message;
+}

--- a/test/unit/core/data/models/game_invitation_model_test.dart
+++ b/test/unit/core/data/models/game_invitation_model_test.dart
@@ -1,0 +1,126 @@
+// Tests GameInvitationModel serialization and business logic (Story 28.1)
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/game_invitation_model.dart';
+
+void main() {
+  group('GameInvitationModel', () {
+    GameInvitationModel createTestInvitation({
+      String id = 'inv-123',
+      String gameId = 'game-123',
+      String groupId = 'group-123',
+      String inviteeId = 'invitee-user',
+      String inviterId = 'inviter-user',
+      GameInvitationStatus status = GameInvitationStatus.pending,
+      DateTime? createdAt,
+      DateTime? updatedAt,
+      DateTime? expiresAt,
+    }) {
+      return GameInvitationModel(
+        id: id,
+        gameId: gameId,
+        groupId: groupId,
+        inviteeId: inviteeId,
+        inviterId: inviterId,
+        status: status,
+        createdAt: createdAt ?? DateTime(2025),
+        updatedAt: updatedAt,
+        expiresAt: expiresAt,
+      );
+    }
+
+    group('defaults', () {
+      test('status defaults to pending', () {
+        final inv = GameInvitationModel(
+          id: 'i',
+          gameId: 'g',
+          groupId: 'grp',
+          inviteeId: 'invitee',
+          inviterId: 'inviter',
+          createdAt: DateTime(2025),
+        );
+        expect(inv.status, GameInvitationStatus.pending);
+      });
+    });
+
+    group('isPending', () {
+      test('returns true for pending status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.pending);
+        expect(inv.isPending, isTrue);
+      });
+
+      test('returns false for accepted status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.accepted);
+        expect(inv.isPending, isFalse);
+      });
+
+      test('returns false for declined status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.declined);
+        expect(inv.isPending, isFalse);
+      });
+
+      test('returns false for expired status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.expired);
+        expect(inv.isPending, isFalse);
+      });
+    });
+
+    group('isAccepted', () {
+      test('returns true for accepted status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.accepted);
+        expect(inv.isAccepted, isTrue);
+      });
+
+      test('returns false for pending status', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.pending);
+        expect(inv.isAccepted, isFalse);
+      });
+    });
+
+    group('JSON serialization', () {
+      test('serializes and deserializes all required fields', () {
+        final inv = createTestInvitation();
+        final json = inv.toJson();
+
+        expect(json['gameId'], 'game-123');
+        expect(json['groupId'], 'group-123');
+        expect(json['inviteeId'], 'invitee-user');
+        expect(json['inviterId'], 'inviter-user');
+        expect(json['status'], 'pending');
+
+        final restored = GameInvitationModel.fromJson(json);
+        expect(restored.gameId, inv.gameId);
+        expect(restored.inviteeId, inv.inviteeId);
+        expect(restored.inviterId, inv.inviterId);
+        expect(restored.status, inv.status);
+      });
+
+      test('serializes accepted status correctly', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.accepted);
+        expect(inv.toJson()['status'], 'accepted');
+      });
+
+      test('serializes declined status correctly', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.declined);
+        expect(inv.toJson()['status'], 'declined');
+      });
+
+      test('serializes expired status correctly', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.expired);
+        expect(inv.toJson()['status'], 'expired');
+      });
+    });
+
+    group('copyWith', () {
+      test('updates status while preserving other fields', () {
+        final inv = createTestInvitation(status: GameInvitationStatus.pending);
+        final accepted = inv.copyWith(
+          status: GameInvitationStatus.accepted,
+          updatedAt: DateTime(2025, 6),
+        );
+        expect(accepted.status, GameInvitationStatus.accepted);
+        expect(accepted.gameId, inv.gameId);
+        expect(accepted.inviteeId, inv.inviteeId);
+      });
+    });
+  });
+}

--- a/test/unit/core/data/models/game_model_test.dart
+++ b/test/unit/core/data/models/game_model_test.dart
@@ -1688,4 +1688,212 @@ void main() {
       expect(updated.gameGenderType, GameGenderType.mix);
     });
   });
+
+  // ── Story 28.1: guestPlayerIds field ─────────────────────────────────────
+
+  group('guestPlayerIds (Story 28.1)', () {
+    GameModel baseGame({
+      List<String> playerIds = const [],
+      List<String> guestPlayerIds = const [],
+      int maxPlayers = 4,
+      int minPlayers = 2,
+    }) {
+      final now = DateTime.now();
+      return GameModel(
+        id: 'game-28',
+        title: 'Guest Game',
+        groupId: 'group-1',
+        createdBy: 'creator-1',
+        createdAt: now,
+        scheduledAt: now.add(const Duration(days: 1)),
+        location: const GameLocation(name: 'Court'),
+        maxPlayers: maxPlayers,
+        minPlayers: minPlayers,
+        playerIds: playerIds,
+        guestPlayerIds: guestPlayerIds,
+      );
+    }
+
+    test('defaults to empty list', () {
+      final game = baseGame();
+      expect(game.guestPlayerIds, isEmpty);
+    });
+
+    group('isGuestPlayer', () {
+      test('returns true for user in guestPlayerIds', () {
+        final game = baseGame(guestPlayerIds: ['guest-1']);
+        expect(game.isGuestPlayer('guest-1'), isTrue);
+      });
+
+      test('returns false for user not in guestPlayerIds', () {
+        final game = baseGame(guestPlayerIds: ['guest-1']);
+        expect(game.isGuestPlayer('other-user'), isFalse);
+      });
+    });
+
+    group('isParticipant', () {
+      test('returns true for regular player', () {
+        final game = baseGame(playerIds: ['player-1']);
+        expect(game.isParticipant('player-1'), isTrue);
+      });
+
+      test('returns true for guest player', () {
+        final game = baseGame(guestPlayerIds: ['guest-1']);
+        expect(game.isParticipant('guest-1'), isTrue);
+      });
+
+      test('returns false for non-participant', () {
+        final game = baseGame(playerIds: ['player-1'], guestPlayerIds: ['guest-1']);
+        expect(game.isParticipant('stranger'), isFalse);
+      });
+    });
+
+    group('currentPlayerCount', () {
+      test('counts regular players only when no guests', () {
+        final game = baseGame(playerIds: ['p1', 'p2']);
+        expect(game.currentPlayerCount, 2);
+      });
+
+      test('counts both regular and guest players', () {
+        final game = baseGame(playerIds: ['p1', 'p2'], guestPlayerIds: ['g1']);
+        expect(game.currentPlayerCount, 3);
+      });
+    });
+
+    group('availableSpots', () {
+      test('subtracts both regular and guest players', () {
+        final game = baseGame(
+          maxPlayers: 4,
+          playerIds: ['p1', 'p2'],
+          guestPlayerIds: ['g1'],
+        );
+        expect(game.availableSpots, 1);
+      });
+
+      test('returns 0 when all spots filled by guests', () {
+        final game = baseGame(
+          maxPlayers: 2,
+          playerIds: [],
+          guestPlayerIds: ['g1', 'g2'],
+        );
+        expect(game.availableSpots, 0);
+      });
+    });
+
+    group('isFull', () {
+      test('is true when regular + guest players fill all spots', () {
+        final game = baseGame(
+          maxPlayers: 3,
+          playerIds: ['p1'],
+          guestPlayerIds: ['g1', 'g2'],
+        );
+        expect(game.isFull, isTrue);
+      });
+
+      test('is false when there are still open spots', () {
+        final game = baseGame(
+          maxPlayers: 4,
+          playerIds: ['p1'],
+          guestPlayerIds: ['g1'],
+        );
+        expect(game.isFull, isFalse);
+      });
+
+      test('is true when only guests fill all spots', () {
+        final game = baseGame(
+          maxPlayers: 2,
+          playerIds: [],
+          guestPlayerIds: ['g1', 'g2'],
+        );
+        expect(game.isFull, isTrue);
+      });
+    });
+
+    group('hasMinimumPlayers', () {
+      test('counts guests toward minimum', () {
+        final game = baseGame(
+          minPlayers: 2,
+          playerIds: ['p1'],
+          guestPlayerIds: ['g1'],
+        );
+        expect(game.hasMinimumPlayers, isTrue);
+      });
+
+      test('is false when combined count is below minimum', () {
+        final game = baseGame(
+          minPlayers: 3,
+          playerIds: ['p1'],
+          guestPlayerIds: ['g1'],
+        );
+        expect(game.hasMinimumPlayers, isFalse);
+      });
+    });
+
+    group('canUserJoin', () {
+      test('returns false for existing guest player', () {
+        final now = DateTime.now();
+        final game = GameModel(
+          id: 'g',
+          title: 'T',
+          groupId: 'grp',
+          createdBy: 'c',
+          createdAt: now,
+          scheduledAt: now.add(const Duration(days: 1)),
+          location: const GameLocation(name: 'Court'),
+          guestPlayerIds: ['guest-1'],
+        );
+        expect(game.canUserJoin('guest-1'), isFalse);
+      });
+    });
+
+    group('canUserEnterResults', () {
+      test('guest player can enter results for past completed game', () {
+        final past = DateTime.now().subtract(const Duration(hours: 1));
+        final game = GameModel(
+          id: 'g',
+          title: 'T',
+          groupId: 'grp',
+          createdBy: 'creator',
+          createdAt: past,
+          scheduledAt: past,
+          location: const GameLocation(name: 'Court'),
+          status: GameStatus.completed,
+          playerIds: ['p1', 'p2'],
+          guestPlayerIds: ['guest-1'],
+        );
+        expect(game.canUserEnterResults('guest-1'), isTrue);
+      });
+    });
+
+    test('guestPlayerIds is included in toJson output', () {
+      final now = DateTime.now();
+      final game = GameModel(
+        id: 'g',
+        title: 'T',
+        groupId: 'grp',
+        createdBy: 'u',
+        createdAt: now,
+        scheduledAt: now.add(const Duration(days: 1)),
+        location: const GameLocation(name: 'Court'),
+        guestPlayerIds: ['guest-1', 'guest-2'],
+      );
+      final json = game.toJson();
+      expect(json['guestPlayerIds'], ['guest-1', 'guest-2']);
+    });
+
+    test('guestPlayerIds is deserialized from JSON map', () {
+      final now = DateTime.now();
+      final game = GameModel.fromJson({
+        'id': 'g',
+        'title': 'T',
+        'groupId': 'grp',
+        'createdBy': 'u',
+        'createdAt': now.toIso8601String(),
+        'scheduledAt': now.add(const Duration(days: 1)).toIso8601String(),
+        'location': {'name': 'Court'},
+        'guestPlayerIds': ['guest-1', 'guest-2'],
+      });
+      expect(game.guestPlayerIds, ['guest-1', 'guest-2']);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Add `guestPlayerIds: List<String>` to `GameModel` — stores UIDs of cross-group invitees who accepted a game invitation
- Update all player-count business logic (`isFull`, `availableSpots`, `currentPlayerCount`, `hasMinimumPlayers`) to count both regular players and accepted guests
- Add `isGuestPlayer()`, `isParticipant()` helpers; update `canUserJoin()` and `canUserEnterResults()` to handle guests correctly
- Create `GameInvitationModel` freezed class with `GameInvitationStatus` enum (`pending` / `accepted` / `declined` / `expired`)
- Add `GameInvitationException` to `repository_exceptions.dart`
- Add `gameInvitations` Firestore collection security rules: readable only by `inviteeId` or `inviterId`; all writes locked to Cloud Functions (Admin SDK)

## Test plan

- [ ] All existing `GameModel` unit tests still pass
- [ ] New `guestPlayerIds` unit tests: defaults empty, `isFull`/`availableSpots`/`currentPlayerCount` include guests, `isGuestPlayer`, `isParticipant`, `canUserJoin` blocks existing guests, `canUserEnterResults` allows guests, JSON serialization
- [ ] New `GameInvitationModel` unit tests: status defaults, `isPending`/`isAccepted`, JSON round-trip for all statuses, `copyWith`
- [ ] `flutter analyze` — no issues
- [ ] CI passes

Closes #670