### PR TITLE
Story 28.2: CF inviteGuestToGame — creator-only, cross-group validation, deduplication

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -124,3 +124,6 @@ export {
   cleanupUnverifiedAccounts,
 } from "./scheduled";
 
+// Epic 28: Cross-Group Game Invitations
+export {inviteGuestToGame} from "./inviteGuestToGame"; // Story 28.2
+

--- a/functions/src/inviteGuestToGame.ts
+++ b/functions/src/inviteGuestToGame.ts
@@ -1,0 +1,223 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Request interface for inviteGuestToGame Cloud Function
+ */
+export interface InviteGuestToGameRequest {
+  gameId: string;
+  inviteeId: string;
+}
+
+/**
+ * Response interface for inviteGuestToGame Cloud Function
+ */
+export interface InviteGuestToGameResponse {
+  success: boolean;
+  invitationId: string;
+}
+
+/**
+ * Handler function for inviteGuestToGame (exported for unit testing).
+ *
+ * Lets a game creator invite a player from one of their other groups to join
+ * the game as a guest. The invitee must share at least one group with the
+ * caller (shared-group trust boundary).
+ *
+ * Logic:
+ * 1. Validate auth + inputs
+ * 2. Load game — verify caller is the creator
+ * 3. Verify invitee not already in playerIds or guestPlayerIds
+ * 4. Verify no pending invitation already exists for (gameId, inviteeId)
+ * 5. Load all groups where caller is a member
+ * 6. Verify invitee is a member of at least one of those groups
+ * 7. Atomically create the gameInvitations document
+ * 8. Return { success: true, invitationId }
+ */
+export async function inviteGuestToGameHandler(
+  data: InviteGuestToGameRequest,
+  context: functions.https.CallableContext
+): Promise<InviteGuestToGameResponse> {
+  // ── 1. Auth ──────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to invite guests to a game."
+    );
+  }
+
+  const callerId = context.auth.uid;
+  const { gameId, inviteeId } = data;
+
+  functions.logger.info("[inviteGuestToGame] Start", { callerId, gameId, inviteeId });
+
+  // ── 2. Input validation ──────────────────────────────────────────────────
+  if (!gameId || typeof gameId !== "string") {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'gameId' is required and must be a string."
+    );
+  }
+  if (!inviteeId || typeof inviteeId !== "string") {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'inviteeId' is required and must be a string."
+    );
+  }
+  if (inviteeId === callerId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "You cannot invite yourself to a game."
+    );
+  }
+
+  const db = admin.firestore();
+
+  try {
+    // ── 3. Load game — verify caller is creator ───────────────────────────
+    const gameDoc = await db.collection("games").doc(gameId).get();
+
+    if (!gameDoc.exists) {
+      functions.logger.warn("[inviteGuestToGame] Game not found", { callerId, gameId });
+      throw new functions.https.HttpsError("not-found", "Game not found.");
+    }
+
+    const game = gameDoc.data()!;
+
+    if (game.createdBy !== callerId) {
+      functions.logger.warn("[inviteGuestToGame] Caller is not game creator", {
+        callerId,
+        createdBy: game.createdBy,
+        gameId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "Only the game creator can invite guests."
+      );
+    }
+
+    // ── 4. Invitee not already a player or guest ──────────────────────────
+    const playerIds: string[] = game.playerIds ?? [];
+    const guestPlayerIds: string[] = game.guestPlayerIds ?? [];
+
+    if (playerIds.includes(inviteeId) || guestPlayerIds.includes(inviteeId)) {
+      functions.logger.warn("[inviteGuestToGame] Invitee already in game", {
+        callerId,
+        gameId,
+        inviteeId,
+      });
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "This player is already participating in the game."
+      );
+    }
+
+    // ── 5. No duplicate pending invitation ───────────────────────────────
+    const existingInvitation = await db
+      .collection("gameInvitations")
+      .where("gameId", "==", gameId)
+      .where("inviteeId", "==", inviteeId)
+      .where("status", "==", "pending")
+      .limit(1)
+      .get();
+
+    if (!existingInvitation.empty) {
+      functions.logger.warn("[inviteGuestToGame] Pending invitation already exists", {
+        callerId,
+        gameId,
+        inviteeId,
+      });
+      throw new functions.https.HttpsError(
+        "already-exists",
+        "A pending invitation already exists for this player and game."
+      );
+    }
+
+    // ── 6. Shared-group trust boundary ────────────────────────────────────
+    // Load all groups where the caller is a member, then check the invitee
+    // is a member of at least one of those groups.
+    const callerGroupsSnapshot = await db
+      .collection("groups")
+      .where("memberIds", "array-contains", callerId)
+      .get();
+
+    const sharedGroup = callerGroupsSnapshot.docs.find((doc) => {
+      const members: string[] = doc.data().memberIds ?? [];
+      return members.includes(inviteeId);
+    });
+
+    if (!sharedGroup) {
+      functions.logger.warn("[inviteGuestToGame] No shared group found", {
+        callerId,
+        inviteeId,
+        gameId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "You can only invite players who share at least one group with you."
+      );
+    }
+
+    functions.logger.info("[inviteGuestToGame] Shared group found, creating invitation", {
+      callerId,
+      inviteeId,
+      gameId,
+      sharedGroupId: sharedGroup.id,
+    });
+
+    // ── 7. Atomically create the gameInvitations document ─────────────────
+    const invitationRef = db.collection("gameInvitations").doc();
+
+    await invitationRef.set({
+      gameId,
+      groupId: game.groupId,
+      inviteeId,
+      inviterId: callerId,
+      status: "pending",
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      expiresAt: game.scheduledAt ?? null,
+    });
+
+    functions.logger.info("[inviteGuestToGame] Invitation created successfully", {
+      callerId,
+      inviteeId,
+      gameId,
+      invitationId: invitationRef.id,
+    });
+
+    // ── 8. Return ─────────────────────────────────────────────────────────
+    return { success: true, invitationId: invitationRef.id };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[inviteGuestToGame] Unexpected error", {
+      callerId,
+      gameId,
+      inviteeId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to send game invitation. Please try again."
+    );
+  }
+}
+
+/**
+ * Callable Cloud Function — inviteGuestToGame (Story 28.2)
+ *
+ * Lets the game creator invite a player from one of their other groups to
+ * join the game as a guest. Enforces:
+ *  - Creator-only access
+ *  - Shared-group trust boundary (no cold invites to strangers)
+ *  - No duplicate active invitations
+ *  - No re-invite of a player already in the game
+ */
+export const inviteGuestToGame = functions
+  .region("europe-west6")
+  .https.onCall(inviteGuestToGameHandler);

--- a/functions/test/unit/inviteGuestToGame.test.ts
+++ b/functions/test/unit/inviteGuestToGame.test.ts
@@ -1,0 +1,327 @@
+// Unit tests for inviteGuestToGame Cloud Function (Story 28.2)
+// Validates creator-only access, shared-group boundary, and deduplication logic.
+
+import * as admin from "firebase-admin";
+import { inviteGuestToGameHandler } from "../../src/inviteGuestToGame";
+
+// ── Mock firebase-admin ──────────────────────────────────────────────────────
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// ── Mock firebase-functions ──────────────────────────────────────────────────
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((handler: any) => handler),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+  fn.region = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Minimal game doc data */
+const makeGameData = (overrides: Partial<Record<string, any>> = {}) => ({
+  groupId: "group-abc",
+  createdBy: "creator-uid",
+  playerIds: [],
+  guestPlayerIds: [],
+  scheduledAt: new Date("2026-06-01"),
+  ...overrides,
+});
+
+/** Auth context for the game creator */
+const creatorContext = { auth: { uid: "creator-uid" } };
+
+/** Build a mock Firestore that satisfies the CF's read pattern */
+function buildMockDb({
+  gameExists = true,
+  gameData = makeGameData(),
+  pendingInvitationExists = false,
+  callerGroupDocs = [
+    { id: "group-abc", data: () => ({ memberIds: ["creator-uid", "invitee-uid"] }) },
+  ],
+  invitationDocId = "new-inv-id",
+}: {
+  gameExists?: boolean;
+  gameData?: ReturnType<typeof makeGameData>;
+  pendingInvitationExists?: boolean;
+  callerGroupDocs?: { id: string; data: () => any }[];
+  invitationDocId?: string;
+} = {}): { db: any; invitationSetMock: jest.Mock } {
+  const invitationSetMock = jest.fn().mockResolvedValue(undefined);
+  const mockInvitationRef = { id: invitationDocId, set: invitationSetMock };
+
+  const db = {
+    collection: jest.fn((col: string) => {
+      if (col === "games") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue({
+              exists: gameExists,
+              data: () => gameData,
+            }),
+          })),
+        };
+      }
+
+      if (col === "gameInvitations") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            empty: !pendingInvitationExists,
+            docs: pendingInvitationExists ? [{ id: "existing-inv" }] : [],
+          }),
+          doc: jest.fn(() => mockInvitationRef),
+        };
+      }
+
+      if (col === "groups") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: callerGroupDocs }),
+        };
+      }
+
+      return {};
+    }),
+  };
+
+  return { db, invitationSetMock };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("inviteGuestToGame", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Authentication ───────────────────���──────────────────────────────────
+
+  describe("authentication", () => {
+    it("throws unauthenticated when no auth context", async () => {
+      const { db } = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler({ gameId: "g1", inviteeId: "u1" }, { auth: null } as any)
+      ).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────
+
+  describe("input validation", () => {
+    it("throws invalid-argument when gameId is missing", async () => {
+      const { db } = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler({ gameId: "", inviteeId: "u1" }, creatorContext as any)
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when inviteeId is missing", async () => {
+      const { db } = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler({ gameId: "g1", inviteeId: "" }, creatorContext as any)
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when caller invites themselves", async () => {
+      const { db } = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "creator-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+  });
+
+  // ── Game validation ─────────────────────────────────────────────────────
+
+  describe("game validation", () => {
+    it("throws not-found when game does not exist", async () => {
+      const { db } = buildMockDb({ gameExists: false });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "ghost-game", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "not-found" });
+    });
+
+    it("throws permission-denied when caller is not the creator", async () => {
+      const { db } = buildMockDb({ gameData: makeGameData({ createdBy: "other-user" }) });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+  });
+
+  // ── Deduplication ───────────────────────────────────────────────────────
+
+  describe("deduplication", () => {
+    it("throws already-exists when invitee is already a regular player", async () => {
+      const { db } = buildMockDb({
+        gameData: makeGameData({ playerIds: ["invitee-uid"] }),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "already-exists" });
+    });
+
+    it("throws already-exists when invitee is already a guest player", async () => {
+      const { db } = buildMockDb({
+        gameData: makeGameData({ guestPlayerIds: ["invitee-uid"] }),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "already-exists" });
+    });
+
+    it("throws already-exists when a pending invitation already exists", async () => {
+      const { db } = buildMockDb({ pendingInvitationExists: true });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "already-exists" });
+    });
+  });
+
+  // ── Shared-group trust boundary ─────────────────────────────────────────
+
+  describe("shared-group trust boundary", () => {
+    it("throws permission-denied when invitee shares no group with caller", async () => {
+      const { db } = buildMockDb({
+        callerGroupDocs: [
+          { id: "group-x", data: () => ({ memberIds: ["creator-uid", "other-person"] }) },
+        ],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+
+    it("throws permission-denied when caller belongs to no groups", async () => {
+      const { db } = buildMockDb({ callerGroupDocs: [] });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        inviteGuestToGameHandler(
+          { gameId: "g1", inviteeId: "invitee-uid" },
+          creatorContext as any
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+
+    it("succeeds when invitee is in a different group that the caller also belongs to", async () => {
+      const { db } = buildMockDb({
+        callerGroupDocs: [
+          // game's own group — invitee not in it
+          { id: "group-abc", data: () => ({ memberIds: ["creator-uid"] }) },
+          // second group — shared with invitee
+          { id: "group-xyz", data: () => ({ memberIds: ["creator-uid", "invitee-uid"] }) },
+        ],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await inviteGuestToGameHandler(
+        { gameId: "g1", inviteeId: "invitee-uid" },
+        creatorContext as any
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.invitationId).toBe("new-inv-id");
+    });
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────────
+
+  describe("success", () => {
+    it("creates an invitation document and returns invitationId", async () => {
+      const { db, invitationSetMock } = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await inviteGuestToGameHandler(
+        { gameId: "game-1", inviteeId: "invitee-uid" },
+        creatorContext as any
+      );
+
+      expect(result).toEqual({ success: true, invitationId: "new-inv-id" });
+
+      // Verify the document was written with the correct shape
+      expect(invitationSetMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gameId: "game-1",
+          groupId: "group-abc",
+          inviteeId: "invitee-uid",
+          inviterId: "creator-uid",
+          status: "pending",
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New callable Cloud Function `inviteGuestToGame` (region: `europe-west6`)
- Creator-only: only `game.createdBy` can call this function
- Shared-group trust boundary: invitee must be a member of at least one group the caller also belongs to — no cold invites to strangers
- Deduplication: rejects if invitee is already in `playerIds`, `guestPlayerIds`, or has an existing `pending` invitation for the same game
- Atomically creates a `gameInvitations` document (`status: 'pending'`, `expiresAt` = `game.scheduledAt`)
- Returns `{ success: true, invitationId }` on success; structured `HttpsError` on all failure paths

## Test plan

- [ ] 13 unit tests — all passing, no coverage gaps:
  - Auth: unauthenticated
  - Input validation: missing gameId, missing inviteeId, self-invite
  - Game validation: game not found, caller not creator
  - Deduplication: already a player, already a guest, pending invitation exists
  - Trust boundary: no shared group, caller has no groups, succeeds via second shared group
  - Happy path: correct document shape written, correct invitationId returned
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] CI passes

Closes #671