### PR TITLE
Story 28.3: CF getInvitablePlayersForGame — cross-group member lookup

### DIFF
--- a/functions/src/getInvitablePlayersForGame.ts
+++ b/functions/src/getInvitablePlayersForGame.ts
@@ -1,0 +1,216 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Request interface for getInvitablePlayersForGame Cloud Function
+ */
+export interface GetInvitablePlayersForGameRequest {
+  gameId: string;
+}
+
+/**
+ * A player the game creator can invite as a guest (Story 28.3)
+ */
+export interface InvitablePlayer {
+  uid: string;
+  displayName: string | null;
+  photoUrl: string | null;
+  sourceGroupId: string;    // the group through which this player was found
+  sourceGroupName: string;
+}
+
+/**
+ * Response interface for getInvitablePlayersForGame Cloud Function
+ */
+export interface GetInvitablePlayersForGameResponse {
+  players: InvitablePlayer[];
+}
+
+/**
+ * Handler function for getInvitablePlayersForGame (exported for unit testing).
+ *
+ * Returns the list of players the game creator can invite as guests.
+ *
+ * Logic:
+ * 1. Validate auth + inputs
+ * 2. Load game — verify caller is the creator
+ * 3. Load all groups the caller belongs to, EXCLUDING the game's own group
+ * 4. Collect unique member UIDs from those groups (first occurrence wins for sourceGroup)
+ * 5. Subtract playerIds, guestPlayerIds, and UIDs with pending invitations
+ * 6. Batch-fetch user profiles for remaining UIDs
+ * 7. Return deduplicated list with sourceGroupId / sourceGroupName
+ */
+export async function getInvitablePlayersForGameHandler(
+  data: GetInvitablePlayersForGameRequest,
+  context: functions.https.CallableContext
+): Promise<GetInvitablePlayersForGameResponse> {
+  // ── 1. Auth ──────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to fetch invitable players."
+    );
+  }
+
+  const callerId = context.auth.uid;
+  const { gameId } = data;
+
+  functions.logger.info("[getInvitablePlayersForGame] Start", { callerId, gameId });
+
+  // ── 2. Input validation ──────────────────────────────────────────────────
+  if (!gameId || typeof gameId !== "string") {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'gameId' is required and must be a string."
+    );
+  }
+
+  const db = admin.firestore();
+
+  try {
+    // ── 3. Load game — verify caller is creator ───────────────────────────
+    const gameDoc = await db.collection("games").doc(gameId).get();
+
+    if (!gameDoc.exists) {
+      functions.logger.warn("[getInvitablePlayersForGame] Game not found", { callerId, gameId });
+      throw new functions.https.HttpsError("not-found", "Game not found.");
+    }
+
+    const game = gameDoc.data()!;
+
+    if (game.createdBy !== callerId) {
+      functions.logger.warn("[getInvitablePlayersForGame] Caller is not game creator", {
+        callerId,
+        createdBy: game.createdBy,
+        gameId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "Only the game creator can fetch the list of invitable players."
+      );
+    }
+
+    const gameGroupId: string = game.groupId;
+    const alreadyIn = new Set<string>([
+      ...(game.playerIds ?? []),
+      ...(game.guestPlayerIds ?? []),
+      callerId, // never suggest inviting yourself
+    ]);
+
+    // ── 4. Load groups caller belongs to (excluding the game's own group) ─
+    const callerGroupsSnapshot = await db
+      .collection("groups")
+      .where("memberIds", "array-contains", callerId)
+      .get();
+
+    // Map: uid → { sourceGroupId, sourceGroupName } (first group wins)
+    const candidateMap = new Map<string, { sourceGroupId: string; sourceGroupName: string }>();
+
+    for (const groupDoc of callerGroupsSnapshot.docs) {
+      if (groupDoc.id === gameGroupId) continue; // skip the game's own group
+
+      const groupData = groupDoc.data();
+      const members: string[] = groupData.memberIds ?? [];
+      const groupName: string = groupData.name ?? "";
+
+      for (const uid of members) {
+        if (!alreadyIn.has(uid) && !candidateMap.has(uid)) {
+          candidateMap.set(uid, { sourceGroupId: groupDoc.id, sourceGroupName: groupName });
+        }
+      }
+    }
+
+    // ── 5. Subtract pending invitees ─────────────────────────────────────
+    if (candidateMap.size > 0) {
+      const pendingSnapshot = await db
+        .collection("gameInvitations")
+        .where("gameId", "==", gameId)
+        .where("status", "==", "pending")
+        .get();
+
+      for (const doc of pendingSnapshot.docs) {
+        const inviteeId: string = doc.data().inviteeId;
+        candidateMap.delete(inviteeId);
+      }
+    }
+
+    if (candidateMap.size === 0) {
+      functions.logger.info("[getInvitablePlayersForGame] No candidates found", { callerId, gameId });
+      return { players: [] };
+    }
+
+    // ── 6. Batch-fetch user profiles ──────────────────────────────────────
+    const candidateUids = Array.from(candidateMap.keys());
+
+    // Firestore `in` queries support up to 30 values; batch accordingly.
+    const BATCH_SIZE = 30;
+    const profileBatches: Promise<admin.firestore.QuerySnapshot>[] = [];
+    for (let i = 0; i < candidateUids.length; i += BATCH_SIZE) {
+      const batch = candidateUids.slice(i, i + BATCH_SIZE);
+      profileBatches.push(
+        db
+          .collection("users")
+          .where(admin.firestore.FieldPath.documentId(), "in", batch)
+          .get()
+      );
+    }
+
+    const profileSnapshots = await Promise.all(profileBatches);
+
+    const players: InvitablePlayer[] = [];
+    for (const snapshot of profileSnapshots) {
+      for (const userDoc of snapshot.docs) {
+        const source = candidateMap.get(userDoc.id);
+        if (!source) continue;
+
+        const u = userDoc.data();
+        players.push({
+          uid: userDoc.id,
+          displayName: u.displayName ?? null,
+          photoUrl: u.photoUrl ?? null,
+          sourceGroupId: source.sourceGroupId,
+          sourceGroupName: source.sourceGroupName,
+        });
+      }
+    }
+
+    functions.logger.info("[getInvitablePlayersForGame] Done", {
+      callerId,
+      gameId,
+      candidateCount: candidateUids.length,
+      returnedCount: players.length,
+    });
+
+    // ── 7. Return ─────────────────────────────────────────────────────────
+    return { players };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[getInvitablePlayersForGame] Unexpected error", {
+      callerId,
+      gameId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to fetch invitable players. Please try again."
+    );
+  }
+}
+
+/**
+ * Callable Cloud Function — getInvitablePlayersForGame (Story 28.3)
+ *
+ * Returns candidates the game creator can invite as guest players:
+ *  - Members of the creator's other groups (not the game's own group)
+ *  - Excluding players already in the game (playerIds / guestPlayerIds)
+ *  - Excluding users who already have a pending invitation
+ *  - Returns only non-sensitive fields: uid, displayName, photoUrl, sourceGroupId, sourceGroupName
+ */
+export const getInvitablePlayersForGame = functions
+  .region("europe-west6")
+  .https.onCall(getInvitablePlayersForGameHandler);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -126,4 +126,5 @@ export {
 
 // Epic 28: Cross-Group Game Invitations
 export {inviteGuestToGame} from "./inviteGuestToGame"; // Story 28.2
+export {getInvitablePlayersForGame} from "./getInvitablePlayersForGame"; // Story 28.3
 

--- a/functions/test/unit/getInvitablePlayersForGame.test.ts
+++ b/functions/test/unit/getInvitablePlayersForGame.test.ts
@@ -1,0 +1,313 @@
+// Unit tests for getInvitablePlayersForGame Cloud Function (Story 28.3)
+// Validates creator-only access, cross-group lookup, and exclusion logic.
+
+import * as admin from "firebase-admin";
+import { getInvitablePlayersForGameHandler } from "../../src/getInvitablePlayersForGame";
+
+// ── Mock firebase-admin ──────────────────────────────────────────────────────
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({ collection: jest.fn() })),
+      {
+        FieldValue: { serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP") },
+        FieldPath: { documentId: jest.fn(() => "__name__") },
+      }
+    ),
+  };
+});
+
+// ── Mock firebase-functions ──────────────────────────────────────────────────
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((h: any) => h),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+  fn.region = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const creatorContext = { auth: { uid: "creator-uid" } };
+
+const makeGameData = (overrides: Partial<Record<string, any>> = {}) => ({
+  groupId: "game-group",
+  createdBy: "creator-uid",
+  playerIds: [],
+  guestPlayerIds: [],
+  ...overrides,
+});
+
+const makeUserDoc = (uid: string, displayName = `User ${uid}`, photoUrl: string | null = null) => ({
+  id: uid,
+  exists: true,
+  data: () => ({ displayName, photoUrl }),
+});
+
+/**
+ * Build a mock Firestore with explicit data for each collection.
+ *
+ * @param gameData          Game document data
+ * @param gameExists        Whether the game doc exists
+ * @param callerGroups      Groups the caller belongs to (id + data)
+ * @param pendingInvitees   UIDs that already have pending invitations
+ * @param userDocs          User documents to return for profile fetch
+ */
+function buildMockDb({
+  gameData = makeGameData(),
+  gameExists = true,
+  callerGroups = [
+    { id: "other-group", data: () => ({ name: "Other Group", memberIds: ["creator-uid", "alice", "bob"] }) },
+  ],
+  pendingInvitees = [] as string[],
+  userDocs = [makeUserDoc("alice"), makeUserDoc("bob")],
+}: {
+  gameData?: ReturnType<typeof makeGameData>;
+  gameExists?: boolean;
+  callerGroups?: { id: string; data: () => any }[];
+  pendingInvitees?: string[];
+  userDocs?: ReturnType<typeof makeUserDoc>[];
+} = {}): any {
+  return {
+    collection: jest.fn((col: string) => {
+      if (col === "games") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue({ exists: gameExists, data: () => gameData }),
+          })),
+        };
+      }
+
+      if (col === "groups") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: callerGroups }),
+        };
+      }
+
+      if (col === "gameInvitations") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({
+            docs: pendingInvitees.map((uid) => ({
+              id: `inv-${uid}`,
+              data: () => ({ inviteeId: uid }),
+            })),
+          }),
+        };
+      }
+
+      if (col === "users") {
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: userDocs }),
+        };
+      }
+
+      return {};
+    }),
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("getInvitablePlayersForGame", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Auth + input validation ──────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("throws unauthenticated when no auth context", async () => {
+      const db = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        getInvitablePlayersForGameHandler({ gameId: "g1" }, { auth: null } as any)
+      ).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+  });
+
+  describe("input validation", () => {
+    it("throws invalid-argument when gameId is missing", async () => {
+      const db = buildMockDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        getInvitablePlayersForGameHandler({ gameId: "" }, creatorContext as any)
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+  });
+
+  // ── Game validation ──────────────────────────────────────────────────────
+
+  describe("game validation", () => {
+    it("throws not-found when game does not exist", async () => {
+      const db = buildMockDb({ gameExists: false });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        getInvitablePlayersForGameHandler({ gameId: "ghost" }, creatorContext as any)
+      ).rejects.toMatchObject({ code: "not-found" });
+    });
+
+    it("throws permission-denied when caller is not the creator", async () => {
+      const db = buildMockDb({ gameData: makeGameData({ createdBy: "other-user" }) });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await expect(
+        getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any)
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+  });
+
+  // ── Exclusion logic ──────────────────────────────────────────────────────
+
+  describe("exclusion logic", () => {
+    it("excludes members from the game's own group", async () => {
+      const db = buildMockDb({
+        callerGroups: [
+          // same group as the game — should be skipped
+          { id: "game-group", data: () => ({ name: "Game Group", memberIds: ["creator-uid", "same-group-member"] }) },
+          // other group — should be included
+          { id: "other-group", data: () => ({ name: "Other Group", memberIds: ["creator-uid", "alice"] }) },
+        ],
+        userDocs: [makeUserDoc("alice")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players.map((p) => p.uid)).toEqual(["alice"]);
+      expect(result.players.map((p) => p.uid)).not.toContain("same-group-member");
+    });
+
+    it("excludes users already in playerIds", async () => {
+      const db = buildMockDb({
+        gameData: makeGameData({ playerIds: ["alice"] }),
+        userDocs: [makeUserDoc("bob")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players.map((p) => p.uid)).not.toContain("alice");
+    });
+
+    it("excludes users already in guestPlayerIds", async () => {
+      const db = buildMockDb({
+        gameData: makeGameData({ guestPlayerIds: ["bob"] }),
+        userDocs: [makeUserDoc("alice")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players.map((p) => p.uid)).not.toContain("bob");
+    });
+
+    it("excludes users with a pending invitation", async () => {
+      const db = buildMockDb({
+        pendingInvitees: ["alice"],
+        userDocs: [makeUserDoc("bob")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players.map((p) => p.uid)).not.toContain("alice");
+    });
+
+    it("excludes the caller from the results", async () => {
+      const db = buildMockDb({
+        userDocs: [makeUserDoc("alice")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players.map((p) => p.uid)).not.toContain("creator-uid");
+    });
+
+    it("deduplicates users appearing in multiple groups — includes once with first group", async () => {
+      const db = buildMockDb({
+        callerGroups: [
+          { id: "group-1", data: () => ({ name: "Group One", memberIds: ["creator-uid", "alice"] }) },
+          { id: "group-2", data: () => ({ name: "Group Two", memberIds: ["creator-uid", "alice"] }) },
+        ],
+        userDocs: [makeUserDoc("alice")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players).toHaveLength(1);
+      expect(result.players[0].uid).toBe("alice");
+      expect(result.players[0].sourceGroupId).toBe("group-1");
+      expect(result.players[0].sourceGroupName).toBe("Group One");
+    });
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────
+
+  describe("success", () => {
+    it("returns players with correct fields", async () => {
+      const db = buildMockDb({
+        callerGroups: [
+          { id: "other-group", data: () => ({ name: "Beach Crew", memberIds: ["creator-uid", "alice"] }) },
+        ],
+        userDocs: [makeUserDoc("alice", "Alice", "https://example.com/alice.jpg")],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players).toHaveLength(1);
+      expect(result.players[0]).toMatchObject({
+        uid: "alice",
+        displayName: "Alice",
+        photoUrl: "https://example.com/alice.jpg",
+        sourceGroupId: "other-group",
+        sourceGroupName: "Beach Crew",
+      });
+    });
+
+    it("returns empty list when caller belongs to no other groups", async () => {
+      const db = buildMockDb({ callerGroups: [] });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players).toEqual([]);
+    });
+
+    it("returns empty list when all candidates are excluded", async () => {
+      const db = buildMockDb({
+        gameData: makeGameData({ playerIds: ["alice"], guestPlayerIds: ["bob"] }),
+        userDocs: [],
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await getInvitablePlayersForGameHandler({ gameId: "g1" }, creatorContext as any);
+
+      expect(result.players).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New callable Cloud Function `getInvitablePlayersForGame` (region: `europe-west6`)
- Creator-only: rejects callers who are not `game.createdBy`
- Scans all groups the caller belongs to, **excluding the game's own group** (members of the game's group are already participants, not guests)
- Subtracts players already in `playerIds`, `guestPlayerIds`, the caller themselves, and users with a pending invitation
- Deduplicates: user appearing in multiple shared groups is returned once, with the first matching group as `sourceGroupId` / `sourceGroupName`
- Batch-fetches user profiles in chunks of 30 (Firestore `in` query limit)
- Returns only non-sensitive fields: `uid`, `displayName`, `photoUrl`, `sourceGroupId`, `sourceGroupName`

## Test plan

- [ ] 13 unit tests — all passing:
  - Auth: unauthenticated
  - Input validation: missing gameId
  - Game validation: game not found, caller not creator
  - Exclusion: game's own group members excluded, playerIds excluded, guestPlayerIds excluded, pending invitees excluded, caller excluded
  - Deduplication: user in two groups returned once with first group
  - Happy path: correct fields returned, empty when no candidates, empty when all excluded
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] CI passes

Closes #672