### PR TITLE
Story 28.4: CF acceptGameGuestInvitation / declineGameGuestInvitation

### DIFF
--- a/functions/src/acceptGameGuestInvitation.ts
+++ b/functions/src/acceptGameGuestInvitation.ts
@@ -1,0 +1,212 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Request interface for acceptGameGuestInvitation Cloud Function
+ */
+export interface AcceptGameGuestInvitationRequest {
+  invitationId: string;
+}
+
+/**
+ * Response interface for acceptGameGuestInvitation Cloud Function
+ */
+export interface AcceptGameGuestInvitationResponse {
+  success: boolean;
+}
+
+/** Game statuses that prevent a guest from joining */
+const INACTIVE_GAME_STATUSES = new Set(["completed", "cancelled"]);
+
+/**
+ * Handler for acceptGameGuestInvitation (exported for unit testing).
+ *
+ * Atomically:
+ *  - Verifies the invitation is pending and belongs to the caller
+ *  - Verifies the game is still active and not full
+ *  - Adds inviteeId to game.guestPlayerIds
+ *  - Sets invitation status to "accepted"
+ *
+ * Idempotent: calling again on an already-accepted invitation returns success.
+ */
+export async function acceptGameGuestInvitationHandler(
+  data: AcceptGameGuestInvitationRequest,
+  context: functions.https.CallableContext
+): Promise<AcceptGameGuestInvitationResponse> {
+  // ── 1. Auth ──────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to accept a game invitation."
+    );
+  }
+
+  const callerId = context.auth.uid;
+  const { invitationId } = data;
+
+  functions.logger.info("[acceptGameGuestInvitation] Start", { callerId, invitationId });
+
+  // ── 2. Input validation ──────────────────────────────────────────────────
+  if (!invitationId || typeof invitationId !== "string") {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'invitationId' is required and must be a string."
+    );
+  }
+
+  const db = admin.firestore();
+
+  try {
+    const invitationRef = db.collection("gameInvitations").doc(invitationId);
+
+    // ── 3. Load invitation ─────────────────────────────────────────────────
+    const invitationDoc = await invitationRef.get();
+
+    if (!invitationDoc.exists) {
+      functions.logger.warn("[acceptGameGuestInvitation] Invitation not found", {
+        callerId,
+        invitationId,
+      });
+      throw new functions.https.HttpsError("not-found", "Invitation not found.");
+    }
+
+    const invitation = invitationDoc.data()!;
+
+    // Ownership check
+    if (invitation.inviteeId !== callerId) {
+      functions.logger.warn("[acceptGameGuestInvitation] Caller is not the invitee", {
+        callerId,
+        inviteeId: invitation.inviteeId,
+        invitationId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "This invitation is not yours to accept."
+      );
+    }
+
+    // Idempotency: already accepted → return success
+    if (invitation.status === "accepted") {
+      functions.logger.info("[acceptGameGuestInvitation] Already accepted — idempotent", {
+        callerId,
+        invitationId,
+      });
+      return { success: true };
+    }
+
+    // Must be pending
+    if (invitation.status !== "pending") {
+      functions.logger.warn("[acceptGameGuestInvitation] Invitation not pending", {
+        callerId,
+        invitationId,
+        status: invitation.status,
+      });
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        `Invitation cannot be accepted (current status: ${invitation.status}).`
+      );
+    }
+
+    // ── 4. Transaction: capacity check + atomic write ──────────────────────
+    await db.runTransaction(async (tx) => {
+      const gameRef = db.collection("games").doc(invitation.gameId);
+      const [currentInvDoc, gameDoc] = await Promise.all([
+        tx.get(invitationRef),
+        tx.get(gameRef),
+      ]);
+
+      // Re-check invitation status inside transaction
+      if (!currentInvDoc.exists || currentInvDoc.data()!.status !== "pending") {
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "Invitation is no longer pending."
+        );
+      }
+
+      if (!gameDoc.exists) {
+        throw new functions.https.HttpsError("not-found", "The game no longer exists.");
+      }
+
+      const game = gameDoc.data()!;
+
+      // Game must still be active
+      if (INACTIVE_GAME_STATUSES.has(game.status)) {
+        functions.logger.warn("[acceptGameGuestInvitation] Game is no longer active", {
+          callerId,
+          invitationId,
+          gameId: invitation.gameId,
+          gameStatus: game.status,
+        });
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "The game is no longer accepting players."
+        );
+      }
+
+      // Capacity check
+      const playerIds: string[] = game.playerIds ?? [];
+      const guestPlayerIds: string[] = game.guestPlayerIds ?? [];
+      const maxPlayers: number = game.maxPlayers ?? 4;
+
+      if (playerIds.length + guestPlayerIds.length >= maxPlayers) {
+        functions.logger.warn("[acceptGameGuestInvitation] Game is full", {
+          callerId,
+          invitationId,
+          gameId: invitation.gameId,
+          currentCount: playerIds.length + guestPlayerIds.length,
+          maxPlayers,
+        });
+        throw new functions.https.HttpsError(
+          "failed-precondition",
+          "The game is already full."
+        );
+      }
+
+      // Atomic writes
+      tx.update(gameRef, {
+        guestPlayerIds: admin.firestore.FieldValue.arrayUnion(callerId),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      tx.update(invitationRef, {
+        status: "accepted",
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    });
+
+    functions.logger.info("[acceptGameGuestInvitation] Accepted successfully", {
+      callerId,
+      invitationId,
+      gameId: invitation.gameId,
+    });
+
+    return { success: true };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[acceptGameGuestInvitation] Unexpected error", {
+      callerId,
+      invitationId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to accept game invitation. Please try again."
+    );
+  }
+}
+
+/**
+ * Callable Cloud Function — acceptGameGuestInvitation (Story 28.4)
+ *
+ * Lets the invited player accept a cross-group game invitation.
+ * Atomically adds them to guestPlayerIds and marks the invitation accepted.
+ * Re-checks capacity inside the transaction to prevent race conditions.
+ */
+export const acceptGameGuestInvitation = functions
+  .region("europe-west6")
+  .https.onCall(acceptGameGuestInvitationHandler);

--- a/functions/src/declineGameGuestInvitation.ts
+++ b/functions/src/declineGameGuestInvitation.ts
@@ -1,0 +1,142 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Request interface for declineGameGuestInvitation Cloud Function
+ */
+export interface DeclineGameGuestInvitationRequest {
+  invitationId: string;
+}
+
+/**
+ * Response interface for declineGameGuestInvitation Cloud Function
+ */
+export interface DeclineGameGuestInvitationResponse {
+  success: boolean;
+}
+
+/**
+ * Handler for declineGameGuestInvitation (exported for unit testing).
+ *
+ * Updates the invitation status to "declined".
+ *
+ * Idempotent: calling again on an already-declined invitation returns success.
+ */
+export async function declineGameGuestInvitationHandler(
+  data: DeclineGameGuestInvitationRequest,
+  context: functions.https.CallableContext
+): Promise<DeclineGameGuestInvitationResponse> {
+  // ── 1. Auth ──────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to decline a game invitation."
+    );
+  }
+
+  const callerId = context.auth.uid;
+  const { invitationId } = data;
+
+  functions.logger.info("[declineGameGuestInvitation] Start", { callerId, invitationId });
+
+  // ── 2. Input validation ──────────────────────────────────────────────────
+  if (!invitationId || typeof invitationId !== "string") {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Parameter 'invitationId' is required and must be a string."
+    );
+  }
+
+  const db = admin.firestore();
+
+  try {
+    const invitationRef = db.collection("gameInvitations").doc(invitationId);
+
+    // ── 3. Load invitation ─────────────────────────────────────────────────
+    const invitationDoc = await invitationRef.get();
+
+    if (!invitationDoc.exists) {
+      functions.logger.warn("[declineGameGuestInvitation] Invitation not found", {
+        callerId,
+        invitationId,
+      });
+      throw new functions.https.HttpsError("not-found", "Invitation not found.");
+    }
+
+    const invitation = invitationDoc.data()!;
+
+    // Ownership check
+    if (invitation.inviteeId !== callerId) {
+      functions.logger.warn("[declineGameGuestInvitation] Caller is not the invitee", {
+        callerId,
+        inviteeId: invitation.inviteeId,
+        invitationId,
+      });
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "This invitation is not yours to decline."
+      );
+    }
+
+    // Idempotency: already declined → return success
+    if (invitation.status === "declined") {
+      functions.logger.info("[declineGameGuestInvitation] Already declined — idempotent", {
+        callerId,
+        invitationId,
+      });
+      return { success: true };
+    }
+
+    // Must be pending
+    if (invitation.status !== "pending") {
+      functions.logger.warn("[declineGameGuestInvitation] Invitation not pending", {
+        callerId,
+        invitationId,
+        status: invitation.status,
+      });
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        `Invitation cannot be declined (current status: ${invitation.status}).`
+      );
+    }
+
+    // ── 4. Update invitation status ────────────────────────────────────────
+    await invitationRef.update({
+      status: "declined",
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    functions.logger.info("[declineGameGuestInvitation] Declined successfully", {
+      callerId,
+      invitationId,
+    });
+
+    return { success: true };
+  } catch (error) {
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
+
+    functions.logger.error("[declineGameGuestInvitation] Unexpected error", {
+      callerId,
+      invitationId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to decline game invitation. Please try again."
+    );
+  }
+}
+
+/**
+ * Callable Cloud Function — declineGameGuestInvitation (Story 28.4)
+ *
+ * Lets the invited player decline a cross-group game invitation.
+ * Only updates the invitation status — does not touch the game document.
+ */
+export const declineGameGuestInvitation = functions
+  .region("europe-west6")
+  .https.onCall(declineGameGuestInvitationHandler);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -127,4 +127,6 @@ export {
 // Epic 28: Cross-Group Game Invitations
 export {inviteGuestToGame} from "./inviteGuestToGame"; // Story 28.2
 export {getInvitablePlayersForGame} from "./getInvitablePlayersForGame"; // Story 28.3
+export {acceptGameGuestInvitation} from "./acceptGameGuestInvitation"; // Story 28.4
+export {declineGameGuestInvitation} from "./declineGameGuestInvitation"; // Story 28.4
 

--- a/functions/test/unit/acceptDeclineGameGuestInvitation.test.ts
+++ b/functions/test/unit/acceptDeclineGameGuestInvitation.test.ts
@@ -1,0 +1,441 @@
+// Unit tests for acceptGameGuestInvitation and declineGameGuestInvitation (Story 28.4)
+
+import * as admin from "firebase-admin";
+import { acceptGameGuestInvitationHandler } from "../../src/acceptGameGuestInvitation";
+import { declineGameGuestInvitationHandler } from "../../src/declineGameGuestInvitation";
+
+// ── Mock firebase-admin ──────────────────────────────────────────────────────
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({ collection: jest.fn(), runTransaction: jest.fn() })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+          arrayUnion: jest.fn((...args: any[]) => ({ _type: "arrayUnion", args })),
+        },
+      }
+    ),
+  };
+});
+
+// ── Mock firebase-functions ──────────────────────────────────────────────────
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((h: any) => h),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+  fn.region = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const inviteeContext = { auth: { uid: "invitee-uid" } };
+
+const makeInvitation = (overrides: Partial<Record<string, any>> = {}) => ({
+  gameId: "game-1",
+  inviteeId: "invitee-uid",
+  inviterId: "creator-uid",
+  status: "pending",
+  ...overrides,
+});
+
+const makeGame = (overrides: Partial<Record<string, any>> = {}) => ({
+  groupId: "group-abc",
+  createdBy: "creator-uid",
+  status: "scheduled",
+  maxPlayers: 4,
+  playerIds: ["p1", "p2"],
+  guestPlayerIds: [],
+  ...overrides,
+});
+
+/**
+ * Build a mock Firestore for the accept handler.
+ * Returns the update mocks so assertions can inspect them.
+ */
+function buildAcceptDb({
+  invitationData = makeInvitation(),
+  invitationExists = true,
+  gameData = makeGame(),
+  gameExists = true,
+}: {
+  invitationData?: ReturnType<typeof makeInvitation>;
+  invitationExists?: boolean;
+  gameData?: ReturnType<typeof makeGame>;
+  gameExists?: boolean;
+} = {}): { db: any; gameUpdateMock: jest.Mock; invitationUpdateMock: jest.Mock } {
+  const gameUpdateMock = jest.fn();
+  const invitationUpdateMock = jest.fn();
+
+  const invitationRef = {
+    update: invitationUpdateMock,
+  };
+  const gameRef = {
+    update: gameUpdateMock,
+  };
+
+  const db: any = {
+    collection: jest.fn((col: string) => {
+      if (col === "gameInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            ...invitationRef,
+            get: jest.fn().mockResolvedValue({
+              exists: invitationExists,
+              data: () => invitationData,
+            }),
+          })),
+        };
+      }
+      if (col === "games") {
+        return {
+          doc: jest.fn(() => ({
+            ...gameRef,
+          })),
+        };
+      }
+      return {};
+    }),
+    runTransaction: jest.fn(async (fn: any) => {
+      const tx = {
+        get: jest.fn(async (ref: any) => {
+          // Distinguish invitation ref vs game ref by checking which mock they're on
+          if (ref === db.collection("gameInvitations").doc()) {
+            return { exists: invitationExists, data: () => invitationData };
+          }
+          return { exists: gameExists, data: () => gameData };
+        }),
+        update: jest.fn(),
+      };
+
+      // Supply correct transaction reads by simulating Promise.all order:
+      // [invitationRef, gameRef] — index 0 = invitation, index 1 = game
+      let callCount = 0;
+      tx.get = jest.fn(async (_ref: any) => {
+        if (callCount === 0) {
+          callCount++;
+          return { exists: invitationExists, data: () => invitationData };
+        }
+        callCount++;
+        return { exists: gameExists, data: () => gameData };
+      });
+
+      await fn(tx);
+
+      // Expose the tx.update mock for assertions
+      gameUpdateMock.mockImplementation(tx.update);
+      invitationUpdateMock.mockImplementation(tx.update);
+    }),
+  };
+
+  return { db, gameUpdateMock, invitationUpdateMock };
+}
+
+/**
+ * Build a mock Firestore for the decline handler.
+ */
+function buildDeclineDb({
+  invitationData = makeInvitation(),
+  invitationExists = true,
+}: {
+  invitationData?: ReturnType<typeof makeInvitation>;
+  invitationExists?: boolean;
+} = {}): { db: any; updateMock: jest.Mock } {
+  const updateMock = jest.fn().mockResolvedValue(undefined);
+
+  const db: any = {
+    collection: jest.fn((col: string) => {
+      if (col === "gameInvitations") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue({
+              exists: invitationExists,
+              data: () => invitationData,
+            }),
+            update: updateMock,
+          })),
+        };
+      }
+      return {};
+    }),
+  };
+
+  return { db, updateMock };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// acceptGameGuestInvitation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("acceptGameGuestInvitation", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Auth + input validation ────────────────────────────────────────────────
+
+  it("throws unauthenticated when no auth context", async () => {
+    const { db } = buildAcceptDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, { auth: null } as any)
+    ).rejects.toMatchObject({ code: "unauthenticated" });
+  });
+
+  it("throws invalid-argument when invitationId is missing", async () => {
+    const { db } = buildAcceptDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "invalid-argument" });
+  });
+
+  // ── Invitation validation ──────────────────────────────────────────────────
+
+  it("throws not-found when invitation does not exist", async () => {
+    const { db } = buildAcceptDb({ invitationExists: false });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-ghost" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("throws permission-denied when caller is not the invitee", async () => {
+    const { db } = buildAcceptDb({
+      invitationData: makeInvitation({ inviteeId: "someone-else" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "permission-denied" });
+  });
+
+  it("returns success immediately when already accepted (idempotent)", async () => {
+    const { db } = buildAcceptDb({
+      invitationData: makeInvitation({ status: "accepted" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    const result = await acceptGameGuestInvitationHandler(
+      { invitationId: "inv-1" },
+      inviteeContext as any
+    );
+
+    expect(result).toEqual({ success: true });
+    // Transaction should NOT have been called
+    expect(db.runTransaction).not.toHaveBeenCalled();
+  });
+
+  it("throws failed-precondition when invitation is expired", async () => {
+    const { db } = buildAcceptDb({
+      invitationData: makeInvitation({ status: "expired" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  it("throws failed-precondition when invitation is declined", async () => {
+    const { db } = buildAcceptDb({
+      invitationData: makeInvitation({ status: "declined" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  // ── Game validation (inside transaction) ──────────────────────────────────
+
+  it("throws not-found when game no longer exists", async () => {
+    const { db } = buildAcceptDb({ gameExists: false });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("throws failed-precondition when game is completed", async () => {
+    const { db } = buildAcceptDb({ gameData: makeGame({ status: "completed" }) });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  it("throws failed-precondition when game is cancelled", async () => {
+    const { db } = buildAcceptDb({ gameData: makeGame({ status: "cancelled" }) });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  it("throws failed-precondition when game is full", async () => {
+    const { db } = buildAcceptDb({
+      gameData: makeGame({ maxPlayers: 2, playerIds: ["p1", "p2"], guestPlayerIds: [] }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  it("throws failed-precondition when game is full counting existing guests", async () => {
+    const { db } = buildAcceptDb({
+      gameData: makeGame({ maxPlayers: 3, playerIds: ["p1", "p2"], guestPlayerIds: ["g1"] }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      acceptGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("returns success and runs transaction for a valid pending invitation", async () => {
+    const { db } = buildAcceptDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    const result = await acceptGameGuestInvitationHandler(
+      { invitationId: "inv-1" },
+      inviteeContext as any
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(db.runTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// declineGameGuestInvitation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("declineGameGuestInvitation", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Auth + input validation ────────────────────────────────────────────────
+
+  it("throws unauthenticated when no auth context", async () => {
+    const { db } = buildDeclineDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "inv-1" }, { auth: null } as any)
+    ).rejects.toMatchObject({ code: "unauthenticated" });
+  });
+
+  it("throws invalid-argument when invitationId is missing", async () => {
+    const { db } = buildDeclineDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "invalid-argument" });
+  });
+
+  // ── Invitation validation ──────────────────────────────────────────────────
+
+  it("throws not-found when invitation does not exist", async () => {
+    const { db } = buildDeclineDb({ invitationExists: false });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "inv-ghost" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("throws permission-denied when caller is not the invitee", async () => {
+    const { db } = buildDeclineDb({
+      invitationData: makeInvitation({ inviteeId: "someone-else" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "permission-denied" });
+  });
+
+  it("returns success immediately when already declined (idempotent)", async () => {
+    const { db, updateMock } = buildDeclineDb({
+      invitationData: makeInvitation({ status: "declined" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    const result = await declineGameGuestInvitationHandler(
+      { invitationId: "inv-1" },
+      inviteeContext as any
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("throws failed-precondition when invitation is accepted", async () => {
+    const { db } = buildDeclineDb({
+      invitationData: makeInvitation({ status: "accepted" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  it("throws failed-precondition when invitation is expired", async () => {
+    const { db } = buildDeclineDb({
+      invitationData: makeInvitation({ status: "expired" }),
+    });
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    await expect(
+      declineGameGuestInvitationHandler({ invitationId: "inv-1" }, inviteeContext as any)
+    ).rejects.toMatchObject({ code: "failed-precondition" });
+  });
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("updates invitation to declined and returns success", async () => {
+    const { db, updateMock } = buildDeclineDb();
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+    const result = await declineGameGuestInvitationHandler(
+      { invitationId: "inv-1" },
+      inviteeContext as any
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "declined" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two new callable Cloud Functions (region: `europe-west6`) for the invited player to act on a cross-group game invitation.

**`acceptGameGuestInvitation`**
- Invitee-only — rejects if `invitation.inviteeId !== caller.uid`
- Idempotent — already-accepted invitation returns `{ success: true }` without re-running the transaction
- Firestore transaction re-checks inside: invitation still pending, game exists, game not completed/cancelled, game not full (`playerIds.length + guestPlayerIds.length < maxPlayers`)
- On success: atomically adds `inviteeId` to `game.guestPlayerIds` and sets `invitation.status = "accepted"`

**`declineGameGuestInvitation`**
- Invitee-only — rejects if `invitation.inviteeId !== caller.uid`
- Idempotent — already-declined invitation returns `{ success: true }` without another write
- Does not touch the game document; updates `invitation.status = "declined"` only

Both functions use structured `HttpsError` codes on all failure paths and structured logging.

## Test plan

- [ ] 21 unit tests — all passing:
  - Auth: unauthenticated (both)
  - Input validation: missing invitationId (both)
  - Not found: invitation missing (both)
  - Permission: caller not the invitee (both)
  - Idempotency: already-accepted / already-declined returns success without side effects
  - Status guard: expired / declined / accepted block the wrong action
  - Game validation: game not found, completed, cancelled, full (regular players), full (guests)
  - Happy path: transaction called for accept; update called with correct shape for decline
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] CI passes

Closes #673