### PR TITLE
Story 28.5: Trigger — auto-expire game invitations on game status change

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -129,4 +129,5 @@ export {inviteGuestToGame} from "./inviteGuestToGame"; // Story 28.2
 export {getInvitablePlayersForGame} from "./getInvitablePlayersForGame"; // Story 28.3
 export {acceptGameGuestInvitation} from "./acceptGameGuestInvitation"; // Story 28.4
 export {declineGameGuestInvitation} from "./declineGameGuestInvitation"; // Story 28.4
+export {onGameStatusChangedExpireInvitations} from "./onGameStatusChangedExpireInvitations"; // Story 28.5
 

--- a/functions/src/onGameStatusChangedExpireInvitations.ts
+++ b/functions/src/onGameStatusChangedExpireInvitations.ts
@@ -1,0 +1,100 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/** Terminal game statuses that should expire all pending invitations */
+const TERMINAL_STATUSES = new Set(["completed", "cancelled", "aborted"]);
+
+/** Maximum documents per Firestore batch write */
+const BATCH_SIZE = 500;
+
+/**
+ * Handler for onGameStatusChangedExpireInvitations (exported for unit testing).
+ *
+ * Expires all pending gameInvitations for a game when it reaches a terminal
+ * status (completed / cancelled / aborted).
+ *
+ * Idempotent: only pending invitations are queried, so a second run produces
+ * zero writes.
+ */
+export async function onGameStatusChangedExpireInvitationsHandler(
+  change: functions.Change<functions.firestore.DocumentSnapshot>,
+  context: functions.EventContext
+): Promise<null> {
+  const before = change.before.data();
+  const after = change.after.data();
+  const gameId = context.params.gameId;
+
+  // ── 1. Guard: only act when status changes to a terminal value ────────────
+  if (!before || !after) return null;
+
+  const previousStatus: string = before.status ?? "";
+  const newStatus: string = after.status ?? "";
+
+  if (previousStatus === newStatus) return null;
+  if (!TERMINAL_STATUSES.has(newStatus)) return null;
+
+  functions.logger.info(
+    "[onGameStatusChangedExpireInvitations] Game reached terminal status — expiring pending invitations",
+    { gameId, previousStatus, newStatus }
+  );
+
+  const db = admin.firestore();
+
+  // ── 2. Query all pending invitations for this game ────────────────────────
+  const pendingSnapshot = await db
+    .collection("gameInvitations")
+    .where("gameId", "==", gameId)
+    .where("status", "==", "pending")
+    .get();
+
+  if (pendingSnapshot.empty) {
+    functions.logger.info(
+      "[onGameStatusChangedExpireInvitations] No pending invitations to expire",
+      { gameId }
+    );
+    return null;
+  }
+
+  const expiredAt = admin.firestore.FieldValue.serverTimestamp();
+  const totalDocs = pendingSnapshot.docs.length;
+
+  // ── 3. Batch-update in chunks of 500 (Firestore limit) ───────────────────
+  let expiredCount = 0;
+
+  for (let i = 0; i < pendingSnapshot.docs.length; i += BATCH_SIZE) {
+    const chunk = pendingSnapshot.docs.slice(i, i + BATCH_SIZE);
+    const batch = db.batch();
+
+    for (const doc of chunk) {
+      batch.update(doc.ref, {
+        status: "expired",
+        updatedAt: expiredAt,
+      });
+    }
+
+    await batch.commit();
+    expiredCount += chunk.length;
+  }
+
+  functions.logger.info(
+    "[onGameStatusChangedExpireInvitations] Done",
+    { gameId, expiredCount, totalDocs }
+  );
+
+  return null;
+}
+
+/**
+ * Firestore trigger — onGameStatusChangedExpireInvitations (Story 28.5)
+ *
+ * Fires on every update to a games/{gameId} document.
+ * When the status changes to "completed", "cancelled", or "aborted",
+ * all pending gameInvitations for that game are batch-updated to "expired".
+ *
+ * Idempotent: already-expired invitations are excluded by the query filter.
+ * Handles > 500 invitations via chunked batch writes.
+ */
+export const onGameStatusChangedExpireInvitations = functions
+  .region("europe-west6")
+  .firestore.document("games/{gameId}")
+  .onUpdate(onGameStatusChangedExpireInvitationsHandler);

--- a/functions/test/unit/onGameStatusChangedExpireInvitations.test.ts
+++ b/functions/test/unit/onGameStatusChangedExpireInvitations.test.ts
@@ -1,0 +1,276 @@
+// Unit tests for onGameStatusChangedExpireInvitations Firestore trigger (Story 28.5)
+// Validates that pending game invitations are expired when a game reaches a terminal status.
+
+import * as admin from "firebase-admin";
+import { onGameStatusChangedExpireInvitationsHandler } from "../../src/onGameStatusChangedExpireInvitations";
+
+// ── Mock firebase-admin ──────────────────────────────────────────────────────
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
+const mockBatch = { update: mockBatchUpdate, commit: mockBatchCommit };
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+        batch: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+      }
+    ),
+  };
+});
+
+// ── Mock firebase-functions ──────────────────────────────────────────────────
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    firestore: {
+      document: jest.fn(() => ({
+        onUpdate: jest.fn((h: any) => h),
+      })),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    Change: class {},
+  };
+  fn.region = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal Firestore change object */
+function makeChange(beforeStatus: string | null, afterStatus: string | null) {
+  return {
+    before: { data: () => (beforeStatus !== null ? { status: beforeStatus } : undefined) },
+    after:  { data: () => (afterStatus  !== null ? { status: afterStatus }  : undefined) },
+  } as any;
+}
+
+/** Build a minimal EventContext with a gameId param */
+function makeContext(gameId = "game-1") {
+  return { params: { gameId } } as any;
+}
+
+/** Build pending invitation docs */
+function makePendingDocs(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `inv-${i}`,
+    ref: { id: `inv-${i}` },
+  }));
+}
+
+/** Build a mock Firestore db */
+function buildDb(pendingDocs: any[] = []) {
+  const db: any = {
+    collection: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({
+        empty: pendingDocs.length === 0,
+        docs: pendingDocs,
+      }),
+    })),
+    batch: jest.fn(() => mockBatch),
+  };
+  return db;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("onGameStatusChangedExpireInvitations", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Guard conditions — no writes expected ──────────────────────────────────
+
+  describe("no-op conditions", () => {
+    it("does nothing when status did not change", async () => {
+      const db = buildDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "scheduled"),
+        makeContext()
+      );
+
+      expect(result).toBeNull();
+      expect(db.collection).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when new status is not terminal (scheduled → in_progress)", async () => {
+      const db = buildDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "in_progress"),
+        makeContext()
+      );
+
+      expect(db.collection).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when new status is not terminal (scheduled → verification)", async () => {
+      const db = buildDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "verification"),
+        makeContext()
+      );
+
+      expect(db.collection).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when before data is missing", async () => {
+      const db = buildDb();
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange(null, "completed"),
+        makeContext()
+      );
+
+      expect(db.collection).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when there are no pending invitations", async () => {
+      const db = buildDb([]); // empty
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      const result = await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(result).toBeNull();
+      expect(mockBatchCommit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Terminal status triggers ───────────────────────────────────────────────
+
+  describe("terminal status → expires invitations", () => {
+    it.each([
+      ["completed"],
+      ["cancelled"],
+      ["aborted"],
+    ])("expires pending invitations when status changes to %s", async (terminalStatus) => {
+      const docs = makePendingDocs(2);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", terminalStatus),
+        makeContext()
+      );
+
+      expect(mockBatchUpdate).toHaveBeenCalledTimes(2);
+      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+
+      // Verify each doc was updated to expired
+      for (const doc of docs) {
+        expect(mockBatchUpdate).toHaveBeenCalledWith(
+          doc.ref,
+          expect.objectContaining({ status: "expired" })
+        );
+      }
+    });
+
+    it("expires invitations when transitioning from in_progress to cancelled", async () => {
+      const docs = makePendingDocs(1);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("in_progress", "cancelled"),
+        makeContext()
+      );
+
+      expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
+      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Batch chunking ────────────────────────────────────────────────────────
+
+  describe("batch chunking", () => {
+    it("uses a single batch for 500 or fewer invitations", async () => {
+      const docs = makePendingDocs(500);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+      expect(mockBatchUpdate).toHaveBeenCalledTimes(500);
+    });
+
+    it("uses two batches for 501 invitations", async () => {
+      const docs = makePendingDocs(501);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      expect(mockBatchUpdate).toHaveBeenCalledTimes(501);
+    });
+
+    it("uses three batches for 1001 invitations", async () => {
+      const docs = makePendingDocs(1001);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(mockBatchCommit).toHaveBeenCalledTimes(3);
+      expect(mockBatchUpdate).toHaveBeenCalledTimes(1001);
+    });
+  });
+
+  // ── Idempotency ───────────────────────────────────────────────────────────
+
+  describe("idempotency", () => {
+    it("queries only pending invitations so a second run produces zero writes", async () => {
+      // First run — 2 pending docs
+      const docs = makePendingDocs(2);
+      const db = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      jest.clearAllMocks();
+
+      // Second run — no pending docs left (they were expired by first run)
+      const emptyDb = buildDb([]);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(emptyDb);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(mockBatchCommit).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

New Firestore trigger `onGameStatusChangedExpireInvitations` on `games/{gameId}.onUpdate`.

- **Guard:** only acts when `before.status !== after.status` and the new status is in `{ completed, cancelled, aborted }` — all other transitions (e.g. `scheduled → in_progress`, `scheduled → verification`) are instant no-ops
- **Query:** fetches only `gameInvitations` where `gameId == gameId AND status == "pending"` — already-expired invitations are naturally excluded
- **Batch write:** updates matching docs to `status = "expired"` in chunks of 500 to stay within Firestore's batch limit; handles arbitrarily large invitation counts across multiple batches
- **Idempotent:** a second trigger fire finds zero pending docs and makes zero writes

## Test plan

- [ ] 13 unit tests — all passing:
  - No-op: status unchanged, non-terminal transition (→ in_progress, → verification), missing before data, no pending docs
  - Terminal triggers: `completed`, `cancelled`, `aborted`; also `in_progress → cancelled`
  - Batch chunking: 500 docs → 1 batch, 501 docs → 2 batches, 1001 docs → 3 batches
  - Idempotency: second run with empty query produces zero batch writes
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] CI passes

Closes #674