### PR TITLE
Story 28.8: Gender reclassification — include guestPlayerIds in trigger

### DIFF
--- a/functions/src/gameGenderClassification.ts
+++ b/functions/src/gameGenderClassification.ts
@@ -53,7 +53,8 @@ export const onGameCreatedClassifyGender = functions
 
 /**
  * Reclassifies the game gender type whenever the player list changes.
- * Fires on any game document update, but only writes when playerIds changed.
+ * Fires on any game document update, but only writes when playerIds or
+ * guestPlayerIds changed (Story 28.8: guest players included in classification).
  */
 export const onGamePlayersChangedClassifyGender = functions
   .region("europe-west6")
@@ -65,24 +66,33 @@ export const onGamePlayersChangedClassifyGender = functions
 
     const beforePlayers: string[] = before.playerIds || [];
     const afterPlayers: string[] = after.playerIds || [];
+    const beforeGuests: string[] = before.guestPlayerIds || [];
+    const afterGuests: string[] = after.guestPlayerIds || [];
 
-    // Only reclassify when playerIds actually changed
-    const playersChanged =
-      beforePlayers.length !== afterPlayers.length ||
-      afterPlayers.some((id: string) => !beforePlayers.includes(id)) ||
-      beforePlayers.some((id: string) => !afterPlayers.includes(id));
+    // Reclassify when playerIds or guestPlayerIds changed
+    const listChanged = (a: string[], b: string[]) =>
+      a.length !== b.length ||
+      b.some((id: string) => !a.includes(id)) ||
+      a.some((id: string) => !b.includes(id));
 
-    if (!playersChanged) {
+    if (!listChanged(beforePlayers, afterPlayers) && !listChanged(beforeGuests, afterGuests)) {
       return null;
     }
 
+    const allPlayerIds = [...afterPlayers, ...afterGuests];
+
     functions.logger.info(
       "[onGamePlayersChangedClassifyGender] Player list changed, reclassifying",
-      { gameId, before: beforePlayers.length, after: afterPlayers.length }
+      {
+        gameId,
+        regularPlayers: afterPlayers.length,
+        guestPlayers: afterGuests.length,
+        total: allPlayerIds.length,
+      }
     );
 
     try {
-      const gameGenderType = await classifyGameGenderType(afterPlayers);
+      const gameGenderType = await classifyGameGenderType(allPlayerIds);
 
       if (gameGenderType === null) {
         // All players left — remove the field

--- a/functions/test/unit/gameGenderClassification.test.ts
+++ b/functions/test/unit/gameGenderClassification.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for gameGenderClassification Cloud Functions (Story 26.4)
+// Unit tests for gameGenderClassification Cloud Functions (Stories 26.4, 28.8)
 // Validates onCreate and onUpdate triggers that classify game gender type
 
 import * as admin from "firebase-admin";
@@ -174,10 +174,25 @@ describe("onGamePlayersChangedClassifyGender", () => {
     jest.clearAllMocks();
   });
 
-  function makeChange(beforePlayers: string[], afterPlayers: string[]) {
+  function makeChange(
+    beforePlayers: string[],
+    afterPlayers: string[],
+    beforeGuests: string[] = [],
+    afterGuests: string[] = []
+  ) {
     return {
-      before: { data: jest.fn().mockReturnValue({ playerIds: beforePlayers }) },
-      after: { data: jest.fn().mockReturnValue({ playerIds: afterPlayers }) },
+      before: {
+        data: jest.fn().mockReturnValue({
+          playerIds: beforePlayers,
+          guestPlayerIds: beforeGuests,
+        }),
+      },
+      after: {
+        data: jest.fn().mockReturnValue({
+          playerIds: afterPlayers,
+          guestPlayerIds: afterGuests,
+        }),
+      },
     };
   }
 
@@ -255,5 +270,55 @@ describe("onGamePlayersChangedClassifyGender", () => {
         makeContext()
       )
     ).resolves.toBeNull();
+  });
+
+  // Story 28.8: guestPlayerIds included in classification
+
+  test("returns null when neither playerIds nor guestPlayerIds changed", async () => {
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(makeDb({}));
+    const result = await (onGamePlayersChangedClassifyGender as any)(
+      makeChange(["u1"], ["u1"], ["g1"], ["g1"]),
+      makeContext()
+    );
+    expect(result).toBeNull();
+  });
+
+  test("reclassifies when guestPlayerIds changes (guest accepts invitation)", async () => {
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(
+      makeDb({ u1: "male", u2: "male", g1: "female" })
+    );
+    await (onGamePlayersChangedClassifyGender as any)(
+      makeChange(["u1", "u2"], ["u1", "u2"], [], ["g1"]),
+      makeContext()
+    );
+    expect(mockGameRef.update).toHaveBeenCalledWith(
+      expect.objectContaining({ gameGenderType: "mix" })
+    );
+  });
+
+  test("classifies as 'mix' when regular players are male and guest is female", async () => {
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(
+      makeDb({ u1: "male", u2: "male", g1: "female" })
+    );
+    await (onGamePlayersChangedClassifyGender as any)(
+      makeChange(["u1"], ["u1", "u2"], [], ["g1"]),
+      makeContext()
+    );
+    expect(mockGameRef.update).toHaveBeenCalledWith(
+      expect.objectContaining({ gameGenderType: "mix" })
+    );
+  });
+
+  test("reclassifies back to 'male' when female guest declines (guestPlayerIds shrinks)", async () => {
+    (admin.firestore as unknown as jest.Mock).mockReturnValue(
+      makeDb({ u1: "male", u2: "male" })
+    );
+    await (onGamePlayersChangedClassifyGender as any)(
+      makeChange(["u1", "u2"], ["u1", "u2"], ["g1"], []),
+      makeContext()
+    );
+    expect(mockGameRef.update).toHaveBeenCalledWith(
+      expect.objectContaining({ gameGenderType: "male" })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `onGamePlayersChangedClassifyGender` now combines `playerIds + guestPlayerIds` before calling `classifyGameGenderType`, so guest players are factored into the game's gender classification
- Trigger now also fires when `guestPlayerIds` changes (guest accepts or declines), not only when `playerIds` changes
- No changes to `classifyGameGenderType.ts` itself — purely a change to how the trigger assembles its input

## Test plan

- [x] All 10 existing gender classification tests still pass
- [x] New: returns null when neither `playerIds` nor `guestPlayerIds` changed
- [x] New: reclassifies when `guestPlayerIds` changes (guest accepts invitation)
- [x] New: game with male regular players + female guest classified as `"mix"`
- [x] New: reclassifies back to `"male"` when female guest declines (`guestPlayerIds` shrinks)

Closes #677