### PR TITLE
Story 28.10: UI — game invitations badge and direct game navigation

### DIFF
--- a/lib/app/play_with_me_app.dart
+++ b/lib/app/play_with_me_app.dart
@@ -92,6 +92,9 @@ class PlayWithMeApp extends StatelessWidget {
         BlocProvider<InviteJoinBloc>(
           create: (context) => sl<InviteJoinBloc>(),
         ),
+        BlocProvider<GameInvitationsBloc>(
+          create: (context) => sl<GameInvitationsBloc>(),
+        ),
         BlocProvider<LocalePreferencesBloc>(
           create: (context) => LocalePreferencesBloc(
             repository: sl<LocalePreferencesRepository>(),
@@ -106,6 +109,9 @@ class PlayWithMeApp extends StatelessWidget {
                 context.read<InvitationBloc>().add(
                   LoadPendingInvitations(userId: state.user.uid),
                 );
+                context
+                    .read<GameInvitationsBloc>()
+                    .add(const LoadGameInvitations());
                 // Check for pending invite token (from "I Have an Account" flow).
                 // If found, navigate to join confirmation and clear the stack.
                 final deepLinkState = context.read<DeepLinkBloc>().state;
@@ -383,8 +389,8 @@ class _HomePageState extends State<HomePage> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => BlocProvider(
-              create: (ctx) => sl<GameInvitationsBloc>(),
+            builder: (_) => BlocProvider.value(
+              value: context.read<GameInvitationsBloc>(),
               child: const PendingGameInvitationsPage(),
             ),
           ),

--- a/lib/core/data/models/game_invitation_details.dart
+++ b/lib/core/data/models/game_invitation_details.dart
@@ -46,7 +46,7 @@ class GameInvitationDetails {
       gameScheduledAt: DateTime.parse(map['gameScheduledAt'] as String),
       gameLocationName: map['gameLocationName'] as String,
       groupName: map['groupName'] as String,
-      inviterDisplayName: map['inviterDisplayName'] as String,
+      inviterDisplayName: map['inviterDisplayName'] as String? ?? '',
     );
   }
 }

--- a/lib/core/data/models/invitable_player_model.dart
+++ b/lib/core/data/models/invitable_player_model.dart
@@ -19,7 +19,7 @@ class InvitablePlayerModel {
   factory InvitablePlayerModel.fromMap(Map<String, dynamic> map) {
     return InvitablePlayerModel(
       uid: map['uid'] as String,
-      displayName: map['displayName'] as String,
+      displayName: map['displayName'] as String? ?? '',
       photoUrl: map['photoUrl'] as String?,
       sourceGroupId: map['sourceGroupId'] as String,
       sourceGroupName: map['sourceGroupName'] as String,

--- a/lib/core/data/repositories/firestore_game_guest_invitation_repository.dart
+++ b/lib/core/data/repositories/firestore_game_guest_invitation_repository.dart
@@ -22,9 +22,9 @@ class FirestoreGameGuestInvitationRepository
           _functions.httpsCallable('getInvitablePlayersForGame');
       final result = await callable.call({'gameId': gameId});
 
-      final data = result.data as Map<String, dynamic>;
+      final data = Map<String, dynamic>.from(result.data as Map);
       final players = (data['players'] as List<dynamic>? ?? [])
-          .cast<Map<String, dynamic>>()
+          .map((e) => Map<String, dynamic>.from(e as Map))
           .map(InvitablePlayerModel.fromMap)
           .toList();
       return players;
@@ -51,7 +51,7 @@ class FirestoreGameGuestInvitationRepository
         'inviteeId': inviteeId,
       });
 
-      final data = result.data as Map<String, dynamic>;
+      final data = Map<String, dynamic>.from(result.data as Map);
       return data['invitationId'] as String;
     } on FirebaseFunctionsException catch (e) {
       throw GameInvitationException(

--- a/lib/core/data/repositories/firestore_game_invitations_repository.dart
+++ b/lib/core/data/repositories/firestore_game_invitations_repository.dart
@@ -19,9 +19,10 @@ class FirestoreGameInvitationsRepository implements GameInvitationsRepository {
       final callable =
           _functions.httpsCallable('getGameInvitationsForUser');
       final result = await callable.call<Map<String, dynamic>>();
-      final raw = result.data['invitations'] as List<dynamic>;
+      final data = Map<String, dynamic>.from(result.data as Map);
+      final raw = data['invitations'] as List<dynamic>;
       return raw
-          .cast<Map<String, dynamic>>()
+          .map((e) => Map<String, dynamic>.from(e as Map))
           .map(GameInvitationDetails.fromMap)
           .toList();
     } on FirebaseFunctionsException catch (e) {

--- a/lib/core/theme/play_with_me_app_bar.dart
+++ b/lib/core/theme/play_with_me_app_bar.dart
@@ -6,6 +6,8 @@ import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart';
+import 'package:play_with_me/features/games/presentation/pages/pending_game_invitations_page.dart';
 import 'package:play_with_me/features/invitations/presentation/pages/pending_invitations_page.dart';
 import 'package:play_with_me/features/profile/presentation/pages/profile_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -83,7 +85,7 @@ class PlayWithMeAppBar {
     final l10n = AppLocalizations.of(context)!;
 
     return [
-      // Invitation badge
+      // Invitation badge (group invitations)
       BlocBuilder<InvitationBloc, InvitationState>(
         builder: (context, state) {
           int pendingCount = 0;
@@ -131,6 +133,78 @@ class PlayWithMeAppBar {
                   ),
                 ),
             ],
+          );
+        },
+      ),
+      // Game invitation badge — only rendered when GameInvitationsBloc is in scope
+      Builder(
+        builder: (context) {
+          GameInvitationsBloc? gameInvBloc;
+          try {
+            gameInvBloc = context.read<GameInvitationsBloc>();
+          } catch (_) {}
+          if (gameInvBloc == null) return const SizedBox.shrink();
+
+          return BlocBuilder<GameInvitationsBloc, GameInvitationsState>(
+            bloc: gameInvBloc,
+            builder: (context, state) {
+              int pendingCount = 0;
+              if (state is GameInvitationsLoaded) {
+                pendingCount = state.invitations.length;
+              } else if (state is GameInvitationActionInFlight) {
+                pendingCount = state.invitations.length;
+              } else if (state is GameInvitationActionSuccess) {
+                pendingCount = state.invitations.length;
+              } else if (state is GameInvitationActionError) {
+                pendingCount = state.invitations.length;
+              }
+
+              return Stack(
+                children: [
+                  IconButton(
+                    icon:
+                        const Icon(Icons.sports_volleyball_outlined, size: 22),
+                    tooltip: l10n.gameInvitations,
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => BlocProvider.value(
+                            value: gameInvBloc!,
+                            child: const PendingGameInvitationsPage(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  if (pendingCount > 0)
+                    Positioned(
+                      right: 8,
+                      top: 8,
+                      child: Container(
+                        padding: const EdgeInsets.all(3),
+                        decoration: BoxDecoration(
+                          color: Colors.red,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        constraints: const BoxConstraints(
+                          minWidth: 16,
+                          minHeight: 16,
+                        ),
+                        child: Text(
+                          pendingCount > 9 ? '9+' : '$pendingCount',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 9,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                ],
+              );
+            },
           );
         },
       ),

--- a/lib/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart
@@ -45,11 +45,15 @@ class GameInvitationsBloc
 
     emit(GameInvitationActionInFlight(current, event.invitationId));
     try {
+      final accepted = current.firstWhere(
+        (i) => i.invitationId == event.invitationId,
+        orElse: () => current.first,
+      );
       await _repository.acceptGameInvitation(event.invitationId);
       final updated =
           current.where((i) => i.invitationId != event.invitationId).toList();
       emit(GameInvitationActionSuccess(updated, event.invitationId,
-          accepted: true));
+          accepted: true, gameId: accepted.gameId));
     } on GameInvitationException catch (e) {
       emit(GameInvitationActionError(current, e.message, errorCode: e.code));
     } catch (e) {

--- a/lib/features/games/presentation/bloc/game_invitations/game_invitations_state.dart
+++ b/lib/features/games/presentation/bloc/game_invitations/game_invitations_state.dart
@@ -36,11 +36,18 @@ class GameInvitationActionInFlight extends GameInvitationsState {
 
 /// An accept/decline call succeeded; [invitationId] has been removed from [invitations].
 /// [accepted] distinguishes which action was taken (for snackbar copy).
+/// [gameId] is set when accepted=true so the UI can navigate to game details.
 class GameInvitationActionSuccess extends GameInvitationsState {
   final List<GameInvitationDetails> invitations;
   final String invitationId;
   final bool accepted;
-  const GameInvitationActionSuccess(this.invitations, this.invitationId, {required this.accepted});
+  final String? gameId;
+  const GameInvitationActionSuccess(
+    this.invitations,
+    this.invitationId, {
+    required this.accepted,
+    this.gameId,
+  });
 }
 
 /// An accept/decline call failed; the original [invitations] list is preserved.

--- a/lib/features/games/presentation/pages/game_details_page.dart
+++ b/lib/features/games/presentation/pages/game_details_page.dart
@@ -396,18 +396,12 @@ class _PlayersCard extends StatelessWidget {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (isCreator)
-                          TextButton.icon(
+                          IconButton(
                             onPressed: () => showInviteGuestPlayersSheet(
                                 context, game.id),
-                            icon: const Icon(Icons.person_add_outlined,
-                                size: 18),
-                            label: Text(l10n.inviteGuestPlayers),
-                            style: TextButton.styleFrom(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 4),
-                              tapTargetSize:
-                                  MaterialTapTargetSize.shrinkWrap,
-                            ),
+                            icon: const Icon(Icons.person_add_outlined),
+                            tooltip: l10n.inviteGuestPlayers,
+                            visualDensity: VisualDensity.compact,
                           ),
                         Chip(
                           label: Text(

--- a/lib/features/games/presentation/pages/pending_game_invitations_page.dart
+++ b/lib/features/games/presentation/pages/pending_game_invitations_page.dart
@@ -7,6 +7,7 @@ import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:play_with_me/core/data/models/game_invitation_details.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart';
+import 'package:play_with_me/features/games/presentation/pages/game_details_page.dart';
 import 'package:play_with_me/features/games/presentation/widgets/game_invitation_card.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
@@ -75,10 +76,13 @@ class _PendingGameInvitationsViewState
         ),
       );
       // Navigate to game details after accept
-      if (state.accepted) {
-        // Find the invitation that was processed (already removed from list —
-        // we can't navigate since we only have the id, not the gameId anymore).
-        // No-op: user can find the game in their upcoming games list.
+      if (state.accepted && state.gameId != null) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => GameDetailsPage(gameId: state.gameId!),
+          ),
+        );
       }
     }
 
@@ -175,6 +179,12 @@ class _PendingGameInvitationsViewState
             onDecline: () => context
                 .read<GameInvitationsBloc>()
                 .add(DeclineGameInvitation(inv.invitationId)),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => GameDetailsPage(gameId: inv.gameId),
+              ),
+            ),
           );
         },
       ),

--- a/lib/features/games/presentation/widgets/game_invitation_card.dart
+++ b/lib/features/games/presentation/widgets/game_invitation_card.dart
@@ -16,12 +16,16 @@ class GameInvitationCard extends StatelessWidget {
   final VoidCallback onAccept;
   final VoidCallback onDecline;
 
+  /// Optional tap handler — navigates to game details when set.
+  final VoidCallback? onTap;
+
   const GameInvitationCard({
     super.key,
     required this.invitation,
     required this.isProcessing,
     required this.onAccept,
     required this.onDecline,
+    this.onTap,
   });
 
   @override
@@ -33,8 +37,11 @@ class GameInvitationCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       elevation: 2,
+      clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Padding(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -115,6 +122,7 @@ class GameInvitationCard extends StatelessWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/test/unit/app/play_with_me_app_test.dart
+++ b/test/unit/app/play_with_me_app_test.dart
@@ -10,6 +10,7 @@ import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/features/profile/domain/entities/locale_preferences_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import '../helpers/test_helpers.dart';
 import '../features/auth/data/mock_auth_repository.dart';
@@ -170,6 +171,9 @@ void main() {
             BlocProvider<InvitationBloc>(
               create: (context) => sl<InvitationBloc>(),
             ),
+            BlocProvider<GameInvitationsBloc>(
+              create: (context) => sl<GameInvitationsBloc>(),
+            ),
           ],
           child: const MaterialApp(
             localizationsDelegates: [
@@ -211,6 +215,9 @@ void main() {
             ),
             BlocProvider<InvitationBloc>(
               create: (context) => sl<InvitationBloc>(),
+            ),
+            BlocProvider<GameInvitationsBloc>(
+              create: (context) => sl<GameInvitationsBloc>(),
             ),
           ],
           child: const MaterialApp(

--- a/test/unit/features/games/bloc/game_invitations_bloc_test.dart
+++ b/test/unit/features/games/bloc/game_invitations_bloc_test.dart
@@ -117,7 +117,8 @@ void main() {
             .having((s) => s.processingInvitationId, 'processingId', 'inv-1'),
         isA<GameInvitationActionSuccess>()
             .having((s) => s.accepted, 'accepted', true)
-            .having((s) => s.invitations, 'invitations', isEmpty),
+            .having((s) => s.invitations, 'invitations', isEmpty)
+            .having((s) => s.gameId, 'gameId', 'game-1'),
       ],
     );
 

--- a/test/unit/helpers/test_helpers.dart
+++ b/test/unit/helpers/test_helpers.dart
@@ -23,6 +23,8 @@ import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_bloc.dar
 import 'package:play_with_me/core/services/deep_link_service.dart';
 import 'package:play_with_me/core/services/pending_invite_storage.dart';
 import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/core/domain/repositories/game_invitations_repository.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_join/invite_join_bloc.dart';
 import '../features/auth/data/mock_auth_repository.dart';
 import '../core/data/repositories/mock_group_repository.dart';
@@ -51,6 +53,10 @@ class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 // Mock for GroupInviteLinkRepository
 class MockGroupInviteLinkRepository extends Mock
     implements GroupInviteLinkRepository {}
+
+// Mock for GameInvitationsRepository
+class MockGameInvitationsRepository extends Mock
+    implements GameInvitationsRepository {}
 
 // Fake for UserModel (required for mocktail's any() matcher)
 class FakeUserModel extends Fake implements UserModel {}
@@ -236,6 +242,17 @@ Future<void> initializeTestDependencies({
   // Register AccountStatusBloc factory that uses the mock auth repository
   sl.registerFactory<AccountStatusBloc>(
     () => AccountStatusBloc(authRepository: sl<AuthRepository>()),
+  );
+
+  // Register GameInvitationsBloc with a mock repository (Story 28.10)
+  final mockGameInvitationsRepo = MockGameInvitationsRepository();
+  when(() => mockGameInvitationsRepo.getGameInvitations())
+      .thenAnswer((_) async => []);
+  sl.registerLazySingleton<GameInvitationsRepository>(
+    () => mockGameInvitationsRepo,
+  );
+  sl.registerFactory<GameInvitationsBloc>(
+    () => GameInvitationsBloc(repository: sl<GameInvitationsRepository>()),
   );
 
 }

--- a/test/widget/features/games/presentation/pages/game_creation_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_creation_page_test.dart
@@ -16,6 +16,7 @@ import 'package:play_with_me/features/auth/presentation/bloc/authentication/auth
 import 'package:play_with_me/features/games/presentation/bloc/game_creation/game_creation_bloc.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_creation/game_creation_event.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_creation/game_creation_state.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_invitations/game_invitations_bloc.dart';
 import 'package:play_with_me/features/games/presentation/pages/game_creation_page.dart';
 
 class MockGameCreationBloc
@@ -28,6 +29,10 @@ class MockInvitationBloc
     extends MockBloc<InvitationEvent, InvitationState>
     implements InvitationBloc {}
 
+class MockGameInvitationsBloc
+    extends MockBloc<GameInvitationsEvent, GameInvitationsState>
+    implements GameInvitationsBloc {}
+
 class FakeGameCreationEvent extends Fake implements GameCreationEvent {}
 
 class FakeGameCreationState extends Fake implements GameCreationState {}
@@ -36,6 +41,7 @@ void main() {
   late MockGameCreationBloc mockGameCreationBloc;
   late MockAuthenticationBloc mockAuthBloc;
   late MockInvitationBloc mockInvitationBloc;
+  late MockGameInvitationsBloc mockGameInvitationsBloc;
 
   const testUserId = 'test-user-123';
   const testGroupId = 'test-group-123';
@@ -50,7 +56,10 @@ void main() {
     mockGameCreationBloc = MockGameCreationBloc();
     mockAuthBloc = MockAuthenticationBloc();
     mockInvitationBloc = MockInvitationBloc();
+    mockGameInvitationsBloc = MockGameInvitationsBloc();
     when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
+    when(() => mockGameInvitationsBloc.state)
+        .thenReturn(const GameInvitationsInitial());
 
     when(() => mockGameCreationBloc.state)
         .thenReturn(const GameCreationInitial());
@@ -88,6 +97,8 @@ void main() {
           BlocProvider<GameCreationBloc>.value(value: mockGameCreationBloc),
           BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
           BlocProvider<InvitationBloc>.value(value: mockInvitationBloc),
+          BlocProvider<GameInvitationsBloc>.value(
+              value: mockGameInvitationsBloc),
         ],
         child: GameCreationPage(
           groupId: testGroupId,

--- a/test/widget/features/games/presentation/pages/pending_game_invitations_page_test.dart
+++ b/test/widget/features/games/presentation/pages/pending_game_invitations_page_test.dart
@@ -1,5 +1,6 @@
-// Widget tests for PendingGameInvitationsPage (Story 28.7).
-// Validates loading, empty state, invitation list, accept/decline, and error handling.
+// Widget tests for PendingGameInvitationsPage (Stories 28.7 & 28.10).
+// Validates loading, empty state, invitation list, accept/decline, error handling,
+// and card tap → game details navigation (Story 28.10).
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
@@ -42,6 +43,7 @@ class FakeInvitationState extends Fake implements InvitationState {}
 class FakeAuthenticationEvent extends Fake implements AuthenticationEvent {}
 
 class FakeAuthenticationState extends Fake implements AuthenticationState {}
+
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -234,6 +236,22 @@ void main() {
     await tester.pump();
 
     expect(find.text('Failed to process invitation'), findsOneWidget);
+  });
+
+  // ── Card tap navigation (Story 28.10) ───────────────────────────────────────
+
+  testWidgets('invitation card has tap handler wired to game navigation',
+      (tester) async {
+    when(() => mockBloc.state)
+        .thenReturn(GameInvitationsLoaded([_makeInvitation()]));
+
+    await tester.pumpWidget(buildPage());
+    await tester.pump();
+
+    // Verify the card is wrapped in an InkWell with a non-null onTap.
+    final inkWells = tester.widgetList<InkWell>(find.byType(InkWell));
+    expect(inkWells.any((w) => w.onTap != null), isTrue,
+        reason: 'At least one InkWell on the card must have onTap set');
   });
 
   // ── Error state ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Ball icon with pending count badge in AppBar next to the group invitation envelope — shows pending game invitation count sourced from `GameInvitationsBloc`
- Tapping the ball icon opens `PendingGameInvitationsPage`
- Tapping any invitation card navigates directly to `GameDetailsPage(gameId)`, bypassing the group
- Accepting an invitation auto-navigates to the game details page
- Includes overflow fix: invite guests `TextButton.icon` replaced with compact `IconButton`

## Changes

- `play_with_me_app.dart` — `GameInvitationsBloc` added to global `MultiBlocProvider`; `LoadGameInvitations` triggered on auth
- `play_with_me_app_bar.dart` — game invitations badge with graceful fallback when bloc not in scope
- `game_invitations_state.dart` — `GameInvitationActionSuccess` carries optional `gameId`
- `game_invitations_bloc.dart` — accept action captures and emits `gameId`
- `pending_game_invitations_page.dart` — `onTap` on cards → `GameDetailsPage`; auto-navigate after accept
- `game_invitation_card.dart` — `onTap` parameter + `InkWell` wrapper
- `game_details_page.dart` — invite guests button replaced with compact `IconButton`

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/unit/ test/widget/` — all 3537 tests pass
- [x] Bloc test: `AcceptGameInvitation` asserts `gameId` is set in success state
- [x] Widget test: `GameInvitationCard` has `InkWell` with non-null `onTap`

Closes #693