### PR TITLE
fix(functions): improve account deletion cascade

### DIFF
--- a/functions/src/deleteUserAccount.ts
+++ b/functions/src/deleteUserAccount.ts
@@ -8,10 +8,15 @@ import * as admin from "firebase-admin";
  * Triggered by the authenticated user themselves (user-initiated deletion).
  *
  * Cascade order:
- * 1. Remove user from all groups (memberIds array)
- * 2. Delete all friendship documents (sent and received)
- * 3. Delete the Firestore user document
- * 4. Delete the Firebase Auth user (last — triggers deleteUserDocument Auth trigger)
+ * 1. Load all groups the user belongs to
+ * 2. Handle admin orphaning: promote another member or delete empty groups
+ * 3. Delete group invite links created by the user (+ invite_tokens lookup docs)
+ * 4. Remove user from all groups (memberIds + adminIds)
+ * 5. Delete all game invitations sent or received by the user
+ * 6. Delete all friendship documents (sent and received)
+ * 7. Delete avatar from Cloud Storage (non-fatal if missing)
+ * 8. Delete the Firestore user document
+ * 9. Delete the Firebase Auth user (point of no return)
  *
  * Story 27.1 — Apple Guideline 5.1.1(v) compliance
  */
@@ -28,34 +33,160 @@ export const deleteUserAccount = functions
     const uid = context.auth.uid;
     const db = admin.firestore();
 
-    functions.logger.info(`[deleteUserAccount] Starting account deletion for uid=${uid}`);
+    functions.logger.info(
+      `[deleteUserAccount] Starting account deletion for uid=${uid}`
+    );
 
-    // 1. Remove user from all groups
+    // ── 1. Load all groups where user is a member ──────────────────────────
     const groupsSnap = await db
       .collection("groups")
       .where("memberIds", "array-contains", uid)
       .get();
 
-    if (!groupsSnap.empty) {
+    // ── 2. Handle admin orphaning ──────────────────────────────────────────
+    // For each group where the user is the sole admin:
+    //   • If other members exist → promote the first non-admin member to admin
+    //   • If no other members remain → delete the group entirely
+    const groupsToDelete: FirebaseFirestore.DocumentReference[] = [];
+    const promotionBatch = db.batch();
+    let promotionBatchHasOps = false;
+
+    for (const groupDoc of groupsSnap.docs) {
+      const data = groupDoc.data();
+      const adminIds: string[] = data.adminIds ?? [];
+      const memberIds: string[] = data.memberIds ?? [];
+      const createdBy: string = data.createdBy;
+
+      const isOnlyAdmin =
+        adminIds.includes(uid) &&
+        adminIds.filter((id) => id !== uid).length === 0;
+      const isCreator = createdBy === uid;
+
+      if (!isOnlyAdmin && !isCreator) continue;
+
+      const otherMembers = memberIds.filter((id) => id !== uid);
+
+      if (otherMembers.length === 0) {
+        // Nobody left — schedule group for deletion
+        groupsToDelete.push(groupDoc.ref);
+        functions.logger.info(
+          `[deleteUserAccount] Group ${groupDoc.id} will be deleted (no remaining members)`
+        );
+      } else {
+        // Promote first available member
+        const newAdmin = otherMembers[0];
+        promotionBatch.update(groupDoc.ref, {
+          adminIds: admin.firestore.FieldValue.arrayUnion(newAdmin),
+          ...(isCreator ? { createdBy: newAdmin } : {}),
+        });
+        promotionBatchHasOps = true;
+        functions.logger.info(
+          `[deleteUserAccount] Promoting uid=${newAdmin} to admin in group ${groupDoc.id}`
+        );
+      }
+    }
+
+    if (promotionBatchHasOps) {
+      await promotionBatch.commit();
+    }
+
+    for (const groupRef of groupsToDelete) {
+      await groupRef.delete();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted empty group ${groupRef.id}`
+      );
+    }
+
+    // ── 3. Delete group invite links created by this user ─────────────────
+    // Uses collectionGroup to query across all groups' "invites" subcollections.
+    // For each invite, also delete the corresponding invite_tokens lookup doc.
+    const inviteLinksSnap = await db
+      .collectionGroup("invites")
+      .where("createdBy", "==", uid)
+      .get();
+
+    if (!inviteLinksSnap.empty) {
+      const inviteBatch = db.batch();
+      for (const inviteDoc of inviteLinksSnap.docs) {
+        const token: string | undefined = inviteDoc.data().token;
+        inviteBatch.delete(inviteDoc.ref);
+        if (token) {
+          inviteBatch.delete(db.collection("invite_tokens").doc(token));
+        }
+      }
+      await inviteBatch.commit();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted ${inviteLinksSnap.size} group invite link(s)`
+      );
+    }
+
+    // ── 4. Remove user from all groups (memberIds + adminIds) ──────────────
+    const survivingGroups = groupsSnap.docs.filter(
+      (doc) => !groupsToDelete.some((ref) => ref.id === doc.id)
+    );
+
+    if (survivingGroups.length > 0) {
       const groupBatch = db.batch();
-      groupsSnap.docs.forEach((doc) => {
+      survivingGroups.forEach((doc) => {
         groupBatch.update(doc.ref, {
           memberIds: admin.firestore.FieldValue.arrayRemove(uid),
+          adminIds: admin.firestore.FieldValue.arrayRemove(uid),
         });
       });
       await groupBatch.commit();
       functions.logger.info(
-        `[deleteUserAccount] Removed user from ${groupsSnap.size} group(s)`
+        `[deleteUserAccount] Removed user from ${survivingGroups.length} group(s)`
       );
     }
 
-    // 2. Delete all friendship documents
-    const [sentSnap, receivedSnap] = await Promise.all([
+    // ── 5. Delete game invitations ─────────────────────────────────────────
+    // Delete invitations where the user is the inviter or the invitee.
+    // When the user is the invitee, also remove them from pendingInviteeIds
+    // on the game document so the game stays consistent.
+    const [sentGameInvites, receivedGameInvites] = await Promise.all([
+      db.collection("gameInvitations").where("inviterId", "==", uid).get(),
+      db.collection("gameInvitations").where("inviteeId", "==", uid).get(),
+    ]);
+
+    const allGameInvites = [
+      ...sentGameInvites.docs,
+      ...receivedGameInvites.docs,
+    ];
+
+    if (allGameInvites.length > 0) {
+      const gameInviteBatch = db.batch();
+      const gameIdsToClean = new Set<string>();
+
+      allGameInvites.forEach((doc) => {
+        gameInviteBatch.delete(doc.ref);
+        // Track games where the deleted user was a pending invitee
+        if (doc.data().inviteeId === uid) {
+          const gameId: string = doc.data().gameId;
+          if (gameId) gameIdsToClean.add(gameId);
+        }
+      });
+
+      // Remove uid from pendingInviteeIds on affected game documents
+      gameIdsToClean.forEach((gameId) => {
+        gameInviteBatch.update(db.collection("games").doc(gameId), {
+          pendingInviteeIds: admin.firestore.FieldValue.arrayRemove(uid),
+        });
+      });
+
+      await gameInviteBatch.commit();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted ${allGameInvites.length} game invitation(s), ` +
+          `cleaned pendingInviteeIds on ${gameIdsToClean.size} game(s)`
+      );
+    }
+
+    // ── 6. Delete all friendship documents ────────────────────────────────
+    const [sentFriendships, receivedFriendships] = await Promise.all([
       db.collection("friendships").where("requesterId", "==", uid).get(),
       db.collection("friendships").where("receiverId", "==", uid).get(),
     ]);
 
-    const allFriendshipDocs = [...sentSnap.docs, ...receivedSnap.docs];
+    const allFriendshipDocs = [...sentFriendships.docs, ...receivedFriendships.docs];
     if (allFriendshipDocs.length > 0) {
       const friendBatch = db.batch();
       allFriendshipDocs.forEach((doc) => friendBatch.delete(doc.ref));
@@ -65,13 +196,33 @@ export const deleteUserAccount = functions
       );
     }
 
-    // 3. Delete Firestore user document
-    await db.collection("users").doc(uid).delete();
-    functions.logger.info(`[deleteUserAccount] Deleted Firestore user document`);
+    // ── 7. Delete avatar from Cloud Storage ───────────────────────────────
+    // Storage path: avatars/{uid}/
+    // Non-fatal: a missing avatar must not block account deletion.
+    try {
+      const bucket = admin.storage().bucket();
+      await bucket.deleteFiles({ prefix: `avatars/${uid}/` });
+      functions.logger.info(
+        `[deleteUserAccount] Deleted avatar files from Storage`
+      );
+    } catch (storageError) {
+      functions.logger.warn(
+        `[deleteUserAccount] Could not delete avatar files (non-fatal)`,
+        { storageError }
+      );
+    }
 
-    // 4. Delete Firebase Auth user (this is the point of no return)
+    // ── 8. Delete Firestore user document ─────────────────────────────────
+    await db.collection("users").doc(uid).delete();
+    functions.logger.info(
+      `[deleteUserAccount] Deleted Firestore user document`
+    );
+
+    // ── 9. Delete Firebase Auth user (point of no return) ─────────────────
     await admin.auth().deleteUser(uid);
-    functions.logger.info(`[deleteUserAccount] Firebase Auth user deleted — account fully removed`);
+    functions.logger.info(
+      `[deleteUserAccount] Firebase Auth user deleted — account fully removed`
+    );
 
     return { success: true };
   });


### PR DESCRIPTION
## Summary

- **Admin orphaning**: when the deleting user is the sole admin, promotes the first other member to admin (and updates `createdBy` if they were the creator); if no other members remain, the group is deleted entirely
- **Group invite links**: deletes all `invites` subcollection docs created by the user (via `collectionGroup` query) and their corresponding `invite_tokens` lookup documents
- **Admin removal**: removes the user from both `adminIds` and `memberIds` in surviving groups (previously only `memberIds` was cleaned)
- **Game invitations**: deletes all `gameInvitations` where the user is inviter or invitee; removes the user from `pendingInviteeIds` on affected game documents
- **Avatar cleanup**: deletes Cloud Storage files at `avatars/{uid}/` (non-fatal — missing avatar does not block deletion)

Completed games and training sessions are intentionally preserved as they involve other players' records.

## Test plan

- [ ] Delete account as sole admin of a group with other members → another member is promoted to admin
- [ ] Delete account as sole admin of a group with no other members → group is deleted
- [ ] Delete account as non-admin member → user removed from group, other admins unaffected
- [ ] Verify `invite_tokens` lookup docs are removed alongside invite link docs
- [ ] Verify game invitations are deleted and `pendingInviteeIds` is cleaned on game docs
- [ ] Verify avatar files are removed from Cloud Storage
- [ ] Verify completed games remain intact after deletion
- [ ] Deploy function to dev and run manual smoke test