### PR TITLE
feat(profile): restrict avatar upload to camera only

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,12 +5,8 @@
     <!-- Required for Firebase Analytics to access advertising ID on Android 13+ -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
-    <!-- Permissions for image_picker (camera and photo library access) -->
+    <!-- Permission for camera (avatar selfie upload) -->
     <uses-permission android:name="android.permission.CAMERA"/>
-    <!-- Gallery access for Android 12 and below -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
-    <!-- Gallery access for Android 9 and below (image_cropper temp files) -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <!-- Declare camera as optional so devices without a camera can still install the app -->
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
 

--- a/functions/src/deleteUserAccount.ts
+++ b/functions/src/deleteUserAccount.ts
@@ -8,10 +8,15 @@ import * as admin from "firebase-admin";
  * Triggered by the authenticated user themselves (user-initiated deletion).
  *
  * Cascade order:
- * 1. Remove user from all groups (memberIds array)
- * 2. Delete all friendship documents (sent and received)
- * 3. Delete the Firestore user document
- * 4. Delete the Firebase Auth user (last — triggers deleteUserDocument Auth trigger)
+ * 1. Load all groups the user belongs to
+ * 2. Handle admin orphaning: promote another member or delete empty groups
+ * 3. Delete group invite links created by the user (+ invite_tokens lookup docs)
+ * 4. Remove user from all groups (memberIds + adminIds)
+ * 5. Delete all game invitations sent or received by the user
+ * 6. Delete all friendship documents (sent and received)
+ * 7. Delete avatar from Cloud Storage (non-fatal if missing)
+ * 8. Delete the Firestore user document
+ * 9. Delete the Firebase Auth user (point of no return)
  *
  * Story 27.1 — Apple Guideline 5.1.1(v) compliance
  */
@@ -28,34 +33,160 @@ export const deleteUserAccount = functions
     const uid = context.auth.uid;
     const db = admin.firestore();
 
-    functions.logger.info(`[deleteUserAccount] Starting account deletion for uid=${uid}`);
+    functions.logger.info(
+      `[deleteUserAccount] Starting account deletion for uid=${uid}`
+    );
 
-    // 1. Remove user from all groups
+    // ── 1. Load all groups where user is a member ──────────────────────────
     const groupsSnap = await db
       .collection("groups")
       .where("memberIds", "array-contains", uid)
       .get();
 
-    if (!groupsSnap.empty) {
+    // ── 2. Handle admin orphaning ──────────────────────────────────────────
+    // For each group where the user is the sole admin:
+    //   • If other members exist → promote the first non-admin member to admin
+    //   • If no other members remain → delete the group entirely
+    const groupsToDelete: FirebaseFirestore.DocumentReference[] = [];
+    const promotionBatch = db.batch();
+    let promotionBatchHasOps = false;
+
+    for (const groupDoc of groupsSnap.docs) {
+      const data = groupDoc.data();
+      const adminIds: string[] = data.adminIds ?? [];
+      const memberIds: string[] = data.memberIds ?? [];
+      const createdBy: string = data.createdBy;
+
+      const isOnlyAdmin =
+        adminIds.includes(uid) &&
+        adminIds.filter((id) => id !== uid).length === 0;
+      const isCreator = createdBy === uid;
+
+      if (!isOnlyAdmin && !isCreator) continue;
+
+      const otherMembers = memberIds.filter((id) => id !== uid);
+
+      if (otherMembers.length === 0) {
+        // Nobody left — schedule group for deletion
+        groupsToDelete.push(groupDoc.ref);
+        functions.logger.info(
+          `[deleteUserAccount] Group ${groupDoc.id} will be deleted (no remaining members)`
+        );
+      } else {
+        // Promote first available member
+        const newAdmin = otherMembers[0];
+        promotionBatch.update(groupDoc.ref, {
+          adminIds: admin.firestore.FieldValue.arrayUnion(newAdmin),
+          ...(isCreator ? { createdBy: newAdmin } : {}),
+        });
+        promotionBatchHasOps = true;
+        functions.logger.info(
+          `[deleteUserAccount] Promoting uid=${newAdmin} to admin in group ${groupDoc.id}`
+        );
+      }
+    }
+
+    if (promotionBatchHasOps) {
+      await promotionBatch.commit();
+    }
+
+    for (const groupRef of groupsToDelete) {
+      await groupRef.delete();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted empty group ${groupRef.id}`
+      );
+    }
+
+    // ── 3. Delete group invite links created by this user ─────────────────
+    // Uses collectionGroup to query across all groups' "invites" subcollections.
+    // For each invite, also delete the corresponding invite_tokens lookup doc.
+    const inviteLinksSnap = await db
+      .collectionGroup("invites")
+      .where("createdBy", "==", uid)
+      .get();
+
+    if (!inviteLinksSnap.empty) {
+      const inviteBatch = db.batch();
+      for (const inviteDoc of inviteLinksSnap.docs) {
+        const token: string | undefined = inviteDoc.data().token;
+        inviteBatch.delete(inviteDoc.ref);
+        if (token) {
+          inviteBatch.delete(db.collection("invite_tokens").doc(token));
+        }
+      }
+      await inviteBatch.commit();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted ${inviteLinksSnap.size} group invite link(s)`
+      );
+    }
+
+    // ── 4. Remove user from all groups (memberIds + adminIds) ──────────────
+    const survivingGroups = groupsSnap.docs.filter(
+      (doc) => !groupsToDelete.some((ref) => ref.id === doc.id)
+    );
+
+    if (survivingGroups.length > 0) {
       const groupBatch = db.batch();
-      groupsSnap.docs.forEach((doc) => {
+      survivingGroups.forEach((doc) => {
         groupBatch.update(doc.ref, {
           memberIds: admin.firestore.FieldValue.arrayRemove(uid),
+          adminIds: admin.firestore.FieldValue.arrayRemove(uid),
         });
       });
       await groupBatch.commit();
       functions.logger.info(
-        `[deleteUserAccount] Removed user from ${groupsSnap.size} group(s)`
+        `[deleteUserAccount] Removed user from ${survivingGroups.length} group(s)`
       );
     }
 
-    // 2. Delete all friendship documents
-    const [sentSnap, receivedSnap] = await Promise.all([
+    // ── 5. Delete game invitations ─────────────────────────────────────────
+    // Delete invitations where the user is the inviter or the invitee.
+    // When the user is the invitee, also remove them from pendingInviteeIds
+    // on the game document so the game stays consistent.
+    const [sentGameInvites, receivedGameInvites] = await Promise.all([
+      db.collection("gameInvitations").where("inviterId", "==", uid).get(),
+      db.collection("gameInvitations").where("inviteeId", "==", uid).get(),
+    ]);
+
+    const allGameInvites = [
+      ...sentGameInvites.docs,
+      ...receivedGameInvites.docs,
+    ];
+
+    if (allGameInvites.length > 0) {
+      const gameInviteBatch = db.batch();
+      const gameIdsToClean = new Set<string>();
+
+      allGameInvites.forEach((doc) => {
+        gameInviteBatch.delete(doc.ref);
+        // Track games where the deleted user was a pending invitee
+        if (doc.data().inviteeId === uid) {
+          const gameId: string = doc.data().gameId;
+          if (gameId) gameIdsToClean.add(gameId);
+        }
+      });
+
+      // Remove uid from pendingInviteeIds on affected game documents
+      gameIdsToClean.forEach((gameId) => {
+        gameInviteBatch.update(db.collection("games").doc(gameId), {
+          pendingInviteeIds: admin.firestore.FieldValue.arrayRemove(uid),
+        });
+      });
+
+      await gameInviteBatch.commit();
+      functions.logger.info(
+        `[deleteUserAccount] Deleted ${allGameInvites.length} game invitation(s), ` +
+          `cleaned pendingInviteeIds on ${gameIdsToClean.size} game(s)`
+      );
+    }
+
+    // ── 6. Delete all friendship documents ────────────────────────────────
+    const [sentFriendships, receivedFriendships] = await Promise.all([
       db.collection("friendships").where("requesterId", "==", uid).get(),
       db.collection("friendships").where("receiverId", "==", uid).get(),
     ]);
 
-    const allFriendshipDocs = [...sentSnap.docs, ...receivedSnap.docs];
+    const allFriendshipDocs = [...sentFriendships.docs, ...receivedFriendships.docs];
     if (allFriendshipDocs.length > 0) {
       const friendBatch = db.batch();
       allFriendshipDocs.forEach((doc) => friendBatch.delete(doc.ref));
@@ -65,13 +196,33 @@ export const deleteUserAccount = functions
       );
     }
 
-    // 3. Delete Firestore user document
-    await db.collection("users").doc(uid).delete();
-    functions.logger.info(`[deleteUserAccount] Deleted Firestore user document`);
+    // ── 7. Delete avatar from Cloud Storage ───────────────────────────────
+    // Storage path: avatars/{uid}/
+    // Non-fatal: a missing avatar must not block account deletion.
+    try {
+      const bucket = admin.storage().bucket();
+      await bucket.deleteFiles({ prefix: `avatars/${uid}/` });
+      functions.logger.info(
+        `[deleteUserAccount] Deleted avatar files from Storage`
+      );
+    } catch (storageError) {
+      functions.logger.warn(
+        `[deleteUserAccount] Could not delete avatar files (non-fatal)`,
+        { storageError }
+      );
+    }
 
-    // 4. Delete Firebase Auth user (this is the point of no return)
+    // ── 8. Delete Firestore user document ─────────────────────────────────
+    await db.collection("users").doc(uid).delete();
+    functions.logger.info(
+      `[deleteUserAccount] Deleted Firestore user document`
+    );
+
+    // ── 9. Delete Firebase Auth user (point of no return) ─────────────────
     await admin.auth().deleteUser(uid);
-    functions.logger.info(`[deleteUserAccount] Firebase Auth user deleted — account fully removed`);
+    functions.logger.info(
+      `[deleteUserAccount] Firebase Auth user deleted — account fully removed`
+    );
 
     return { success: true };
   });

--- a/lib/core/services/image_picker_service.dart
+++ b/lib/core/services/image_picker_service.dart
@@ -51,20 +51,10 @@ class ImagePickerService {
           'Camera access denied. Please enable camera access in your device settings.',
         );
       }
-      if (e.code == 'photo_access_denied') {
-        throw Exception(
-          'Photo library access denied. Please enable photo access in your device settings.',
-        );
-      }
       throw Exception('Failed to pick image: ${e.message}');
     } catch (e) {
       throw Exception('Failed to pick image: $e');
     }
-  }
-
-  /// Pick image from gallery
-  Future<File?> pickFromGallery({bool cropSquare = true}) async {
-    return pickImage(source: ImageSource.gallery, cropSquare: cropSquare);
   }
 
   /// Pick image from camera

--- a/lib/features/profile/presentation/widgets/avatar_upload_widget.dart
+++ b/lib/features/profile/presentation/widgets/avatar_upload_widget.dart
@@ -206,7 +206,12 @@ class _AvatarUploadContent extends StatelessWidget {
                           size: 18,
                           color: Colors.white,
                         ),
-                        onPressed: () => _showImageSourceDialog(context),
+                        onPressed: () =>
+                            context.read<AvatarUploadBloc>().add(
+                              const AvatarUploadEvent.imageSourceSelected(
+                                source: ImageSource.camera,
+                              ),
+                            ),
                         padding: EdgeInsets.zero,
                       ),
                     ),
@@ -260,52 +265,6 @@ class _AvatarUploadContent extends StatelessWidget {
           ],
         );
       },
-    );
-  }
-
-  /// Show dialog to select image source (camera or gallery)
-  void _showImageSourceDialog(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    showModalBottomSheet(
-      context: context,
-      builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.camera_alt),
-              title: Text(l10n.takePhoto),
-              onTap: () {
-                Navigator.of(sheetContext).pop();
-                context.read<AvatarUploadBloc>().add(
-                  const AvatarUploadEvent.imageSourceSelected(
-                    source: ImageSource.camera,
-                  ),
-                );
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.photo_library),
-              title: Text(l10n.chooseFromGallery),
-              onTap: () {
-                Navigator.of(sheetContext).pop();
-                context.read<AvatarUploadBloc>().add(
-                  const AvatarUploadEvent.imageSourceSelected(
-                    source: ImageSource.gallery,
-                  ),
-                );
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.cancel),
-              title: Text(l10n.cancel),
-              onTap: () {
-                Navigator.of(sheetContext).pop();
-              },
-            ),
-          ],
-        ),
-      ),
     );
   }
 

--- a/test/unit/core/services/image_picker_service_test.dart
+++ b/test/unit/core/services/image_picker_service_test.dart
@@ -17,7 +17,7 @@ void main() {
   late ImagePickerService imagePickerService;
 
   setUpAll(() {
-    registerFallbackValue(ImageSource.gallery);
+    registerFallbackValue(ImageSource.camera);
   });
 
   setUp(() {
@@ -42,7 +42,7 @@ void main() {
 
         // Act
         final result = await imagePickerService.pickImage(
-          source: ImageSource.gallery,
+          source: ImageSource.camera,
           cropSquare: false, // Disable cropping for this test
         );
 
@@ -51,7 +51,7 @@ void main() {
         expect(result?.path, contains('test_image.jpg'));
         verify(
           () => mockImagePicker.pickImage(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
             maxWidth: 1024,
             maxHeight: 1024,
             imageQuality: 85,
@@ -72,7 +72,7 @@ void main() {
 
         // Act
         final result = await imagePickerService.pickImage(
-          source: ImageSource.gallery,
+          source: ImageSource.camera,
           cropSquare: false,
         );
 
@@ -80,7 +80,7 @@ void main() {
         expect(result, isNull);
         verify(
           () => mockImagePicker.pickImage(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
             maxWidth: 1024,
             maxHeight: 1024,
             imageQuality: 85,
@@ -102,7 +102,7 @@ void main() {
         // Act & Assert
         expect(
           () => imagePickerService.pickImage(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
             cropSquare: false,
           ),
           throwsA(
@@ -145,36 +145,6 @@ void main() {
         },
       );
 
-      test(
-        'throws user-friendly exception when photo library access is denied',
-        () async {
-          // Arrange
-          when(
-            () => mockImagePicker.pickImage(
-              source: any(named: 'source'),
-              maxWidth: any(named: 'maxWidth'),
-              maxHeight: any(named: 'maxHeight'),
-              imageQuality: any(named: 'imageQuality'),
-            ),
-          ).thenThrow(PlatformException(code: 'photo_access_denied'));
-
-          // Act & Assert
-          expect(
-            () => imagePickerService.pickImage(
-              source: ImageSource.gallery,
-              cropSquare: false,
-            ),
-            throwsA(
-              isA<Exception>().having(
-                (e) => e.toString(),
-                'message',
-                contains('Photo library access denied'),
-              ),
-            ),
-          );
-        },
-      );
-
       test('wraps other PlatformException with generic message', () async {
         // Arrange
         when(
@@ -191,7 +161,7 @@ void main() {
         // Act & Assert
         expect(
           () => imagePickerService.pickImage(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
             cropSquare: false,
           ),
           throwsA(
@@ -202,38 +172,6 @@ void main() {
             ),
           ),
         );
-      });
-    });
-
-    group('pickFromGallery', () {
-      test('picks image from gallery with correct source', () async {
-        // Arrange
-        final mockXFile = MockXFile();
-        when(() => mockXFile.path).thenReturn('/tmp/gallery_image.jpg');
-        when(
-          () => mockImagePicker.pickImage(
-            source: any(named: 'source'),
-            maxWidth: any(named: 'maxWidth'),
-            maxHeight: any(named: 'maxHeight'),
-            imageQuality: any(named: 'imageQuality'),
-          ),
-        ).thenAnswer((_) async => mockXFile);
-
-        // Act
-        final result = await imagePickerService.pickFromGallery(
-          cropSquare: false,
-        );
-
-        // Assert
-        expect(result, isNotNull);
-        verify(
-          () => mockImagePicker.pickImage(
-            source: ImageSource.gallery,
-            maxWidth: 1024,
-            maxHeight: 1024,
-            imageQuality: 85,
-          ),
-        ).called(1);
       });
     });
 

--- a/test/unit/features/profile/presentation/bloc/avatar_upload_bloc_test.dart
+++ b/test/unit/features/profile/presentation/bloc/avatar_upload_bloc_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     // Register fallback values
     registerFallbackValue(File(''));
-    registerFallbackValue(ImageSource.gallery);
+    registerFallbackValue(ImageSource.camera);
   });
 
   AvatarUploadBloc createBloc() {
@@ -95,7 +95,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(
           const AvatarUploadEvent.imageSourceSelected(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
           ),
         ),
         expect: () => [
@@ -140,7 +140,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(
           const AvatarUploadEvent.imageSourceSelected(
-            source: ImageSource.gallery,
+            source: ImageSource.camera,
           ),
         ),
         expect: () => [

--- a/test/unit/features/profile/presentation/pages/profile_edit_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/profile_edit_page_test.dart
@@ -332,7 +332,7 @@ void main() {
         expect(cameraIcon, findsOneWidget);
       });
 
-      testWidgets('camera button opens image source selection dialog', (
+      testWidgets('camera button directly opens camera without bottom sheet', (
         tester,
       ) async {
         await tester.pumpWidget(createWidgetUnderTest(testUser));
@@ -343,11 +343,9 @@ void main() {
         await tester.tap(cameraButton);
         await tester.pumpAndSettle();
 
-        // Verify bottom sheet appears with options
-        expect(find.text('Take Photo'), findsOneWidget);
-        expect(find.text('Choose from Gallery'), findsOneWidget);
-        // Note: "Cancel" text appears in both AppBar and bottom sheet, so we check for at least one
-        expect(find.text('Cancel'), findsWidgets);
+        // Verify no source-selection bottom sheet appears
+        expect(find.text('Take Photo'), findsNothing);
+        expect(find.text('Choose from Gallery'), findsNothing);
       });
 
       testWidgets('shows delete button when user has current photo', (
@@ -432,12 +430,12 @@ void main() {
         final cameraButton = find.widgetWithIcon(IconButton, Icons.camera_alt);
         expect(cameraButton, findsOneWidget);
 
-        // Try tapping - should work without errors
+        // Try tapping - should work without errors and not show a bottom sheet
         await tester.tap(cameraButton);
         await tester.pumpAndSettle();
 
-        // Bottom sheet should appear
-        expect(find.text('Take Photo'), findsOneWidget);
+        // Camera opens directly — no source-selection bottom sheet
+        expect(find.text('Take Photo'), findsNothing);
       });
     });
 


### PR DESCRIPTION
## Summary

- Camera icon now opens the device camera directly — no source-selection bottom sheet
- Gallery / file picker option removed entirely
- `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions removed from `AndroidManifest.xml`
- Dead code removed: `pickFromGallery`, `photo_access_denied` handler in `ImagePickerService`
- Tests updated to assert no bottom sheet appears on camera button tap

## Test plan

- [ ] Tap the camera icon on the profile edit page → device camera opens immediately
- [ ] Verify no "Take Photo / Choose from Gallery" sheet appears
- [ ] Verify photo taken with camera uploads correctly
- [ ] Verify avatar delete flow still works
- [ ] Test on Android and iOS