### PR TITLE
feat(games): replace invite icon with dedicated section in game details

### DIFF
--- a/lib/app/play_with_me_app.dart
+++ b/lib/app/play_with_me_app.dart
@@ -293,7 +293,7 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   int _selectedIndex = 0;
 
   // Pages for bottom navigation: Home, Stats, Groups, Community
@@ -307,6 +307,7 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
 
     final authState = context.read<AuthenticationBloc>().state;
     _groupBloc = sl<GroupBloc>();
@@ -402,7 +403,15 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _accountStatusBloc.add(const RefreshVerificationStatus());
+    }
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     HomePage.onNavigateToTab = null;
     _groupBloc.close();
     _friendRequestCountBloc.close();

--- a/lib/core/presentation/bloc/account_status/account_status_bloc.dart
+++ b/lib/core/presentation/bloc/account_status/account_status_bloc.dart
@@ -17,6 +17,7 @@ class AccountStatusBloc extends Bloc<AccountStatusEvent, AccountStatusState> {
     on<CheckAccountStatus>(_onCheckStatus);
     on<AccountEmailVerified>(_onEmailVerified);
     on<DismissAccountWarning>(_onDismissWarning);
+    on<RefreshVerificationStatus>(_onRefreshVerificationStatus);
 
     _authStateSubscription = _authRepository.authStateChanges.listen((user) {
       if (user != null && user.isEmailVerified) {
@@ -81,6 +82,25 @@ class AccountStatusBloc extends Bloc<AccountStatusEvent, AccountStatusState> {
     final currentState = state;
     if (currentState is AccountStatusPending) {
       emit(currentState.copyWith(isDismissed: true));
+    }
+  }
+
+  Future<void> _onRefreshVerificationStatus(
+    RefreshVerificationStatus event,
+    Emitter<AccountStatusState> emit,
+  ) async {
+    // Only worth reloading when we know the email is still unverified.
+    if (state is! AccountStatusPending && state is! AccountStatusRestricted) {
+      return;
+    }
+    try {
+      await _authRepository.reloadUser();
+      final user = _authRepository.currentUser;
+      if (user != null && user.isEmailVerified) {
+        emit(const AccountStatusActive());
+      }
+    } catch (_) {
+      // Silently ignore — the next natural refresh will pick it up.
     }
   }
 

--- a/lib/core/presentation/bloc/account_status/account_status_event.dart
+++ b/lib/core/presentation/bloc/account_status/account_status_event.dart
@@ -22,3 +22,10 @@ class AccountEmailVerified extends AccountStatusEvent {
 class DismissAccountWarning extends AccountStatusEvent {
   const DismissAccountWarning();
 }
+
+/// Reload user data from Firebase and re-check email verification status.
+/// Dispatched when the app resumes from background so the banner disappears
+/// automatically after the user taps the verification link in their email.
+class RefreshVerificationStatus extends AccountStatusEvent {
+  const RefreshVerificationStatus();
+}

--- a/lib/features/games/presentation/pages/game_details_page.dart
+++ b/lib/features/games/presentation/pages/game_details_page.dart
@@ -387,11 +387,10 @@ class _PlayersCard extends StatelessWidget {
             : <String, dynamic>{};
         final isOperationInProgress = state is GameDetailsOperationInProgress;
 
-        final isCreator =
-            currentUserId != null &&
-            currentUserId == game.createdBy &&
-            game.status == GameStatus.scheduled &&
-            !game.isFull;
+        final isCreator = currentUserId != null &&
+            currentUserId == game.createdBy;
+        final canInviteGuests =
+            isCreator && game.status == GameStatus.scheduled;
 
         return Card(
           child: Padding(
@@ -409,30 +408,17 @@ class _PlayersCard extends StatelessWidget {
                         color: AppColors.secondary,
                       ),
                     ),
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (isCreator)
-                          IconButton(
-                            onPressed: () =>
-                                showInviteGuestPlayersSheet(context, game.id),
-                            icon: const Icon(Icons.person_add_outlined),
-                            tooltip: l10n.inviteGuestPlayers,
-                            visualDensity: VisualDensity.compact,
-                          ),
-                        Chip(
-                          label: Text(
-                            '${game.currentPlayerCount}/${game.maxPlayers}',
-                            style: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: AppColors.secondary,
-                            ),
-                          ),
-                          backgroundColor: AppColors.primary.withValues(
-                            alpha: 0.25,
-                          ),
+                    Chip(
+                      label: Text(
+                        '${game.currentPlayerCount}/${game.maxPlayers}',
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.secondary,
                         ),
-                      ],
+                      ),
+                      backgroundColor: AppColors.primary.withValues(
+                        alpha: 0.25,
+                      ),
                     ),
                   ],
                 ),
@@ -572,6 +558,28 @@ class _PlayersCard extends StatelessWidget {
                           : null,
                     );
                   }),
+                ],
+                if (canInviteGuests) ...[
+                  const SizedBox(height: 16),
+                  const Divider(),
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n.inviteGuestPlayers,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.secondary,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () =>
+                          showInviteGuestPlayersSheet(context, game.id),
+                      icon: const Icon(Icons.person_add_outlined),
+                      label: Text(l10n.inviteGuest),
+                    ),
+                  ),
                 ],
               ],
             ),

--- a/lib/features/profile/presentation/pages/email_verification_page.dart
+++ b/lib/features/profile/presentation/pages/email_verification_page.dart
@@ -7,7 +7,11 @@ import 'package:play_with_me/features/profile/presentation/bloc/email_verificati
 
 /// Page for email verification flow with status display and resend functionality
 class EmailVerificationPage extends StatelessWidget {
-  const EmailVerificationPage({super.key});
+  /// Called when the page confirms the user's email is now verified.
+  /// Use this to notify blocs above the navigator (e.g. AccountStatusBloc).
+  final VoidCallback? onVerified;
+
+  const EmailVerificationPage({super.key, this.onVerified});
 
   @override
   Widget build(BuildContext context) {
@@ -38,6 +42,12 @@ class EmailVerificationPage extends StatelessWidget {
                 duration: const Duration(seconds: 4),
               ),
             );
+          }
+
+          // When the email is confirmed verified, notify the caller so blocs
+          // above the navigator (AccountStatusBloc) can dismiss the banner.
+          if (state is EmailVerificationVerified) {
+            onVerified?.call();
           }
         },
         builder: (context, state) {
@@ -216,7 +226,14 @@ class EmailVerificationPage extends StatelessWidget {
             context,
             icon: Icons.looks_3,
             title: 'Refresh Status',
-            description: 'Return here and refresh to confirm verification.',
+            description: emailSent
+                ? 'Tap here to check if your email has been verified.'
+                : 'Return here and refresh to confirm verification.',
+            onTap: emailSent
+                ? () => context.read<EmailVerificationBloc>().add(
+                      const EmailVerificationEvent.refreshStatus(),
+                    )
+                : null,
           ),
           const SizedBox(height: 32),
 
@@ -326,15 +343,21 @@ class EmailVerificationPage extends StatelessWidget {
     required IconData icon,
     required String title,
     required String description,
+    VoidCallback? onTap,
   }) {
     final theme = Theme.of(context);
 
-    return Container(
+    final content = Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: theme.colorScheme.outlineVariant, width: 1),
+        border: Border.all(
+          color: onTap != null
+              ? theme.colorScheme.primary.withValues(alpha: 0.4)
+              : theme.colorScheme.outlineVariant,
+          width: onTap != null ? 1.5 : 1,
+        ),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -368,8 +391,24 @@ class EmailVerificationPage extends StatelessWidget {
               ],
             ),
           ),
+          if (onTap != null) ...[
+            const SizedBox(width: 8),
+            Icon(
+              Icons.chevron_right,
+              size: 20,
+              color: theme.colorScheme.primary,
+            ),
+          ],
         ],
       ),
+    );
+
+    if (onTap == null) return content;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: content,
     );
   }
 

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -10,6 +10,8 @@ import 'package:play_with_me/features/auth/presentation/bloc/authentication/auth
 import 'package:play_with_me/features/profile/presentation/bloc/account_deletion/account_deletion_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/account_deletion/account_deletion_event.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/account_deletion/account_deletion_state.dart';
+import 'package:play_with_me/core/presentation/bloc/account_status/account_status_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/account_status/account_status_event.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_event.dart';
 import 'package:play_with_me/features/profile/presentation/pages/email_verification_page.dart';
@@ -147,6 +149,10 @@ class _ProfileContent extends StatelessWidget {
 
   void _navigateToEmailVerification(BuildContext context) {
     final authRepository = sl<AuthRepository>();
+    // Capture the AccountStatusBloc before navigating so the pushed route
+    // (which is outside AccountStatusBloc's provider scope) can still dismiss
+    // the banner when the email is confirmed verified.
+    final accountStatusBloc = context.read<AccountStatusBloc>();
 
     Navigator.of(context).push(
       MaterialPageRoute(
@@ -154,7 +160,10 @@ class _ProfileContent extends StatelessWidget {
           create: (context) =>
               EmailVerificationBloc(authRepository: authRepository)
                 ..add(const EmailVerificationEvent.checkStatus()),
-          child: const EmailVerificationPage(),
+          child: EmailVerificationPage(
+            onVerified: () =>
+                accountStatusBloc.add(const AccountEmailVerified()),
+          ),
         ),
       ),
     );

--- a/test/unit/core/presentation/bloc/account_status/account_status_bloc_test.dart
+++ b/test/unit/core/presentation/bloc/account_status/account_status_bloc_test.dart
@@ -265,6 +265,75 @@ void main() {
       });
     });
 
+    group('RefreshVerificationStatus', () {
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'emits [AccountStatusActive] when reload finds email is now verified',
+        setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
+          when(
+            () => mockAuthRepository.currentUser,
+          ).thenReturn(createUser(isEmailVerified: true));
+        },
+        build: buildBloc,
+        seed: () => const AccountStatusPending(daysRemaining: 5),
+        act: (bloc) => bloc.add(const RefreshVerificationStatus()),
+        expect: () => [const AccountStatusActive()],
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'emits nothing when reload finds email still unverified',
+        setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
+          when(
+            () => mockAuthRepository.currentUser,
+          ).thenReturn(createUser(isEmailVerified: false));
+        },
+        build: buildBloc,
+        seed: () => const AccountStatusPending(daysRemaining: 5),
+        act: (bloc) => bloc.add(const RefreshVerificationStatus()),
+        expect: () => <AccountStatusState>[],
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'emits [AccountStatusActive] from restricted state when email verified',
+        setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
+          when(
+            () => mockAuthRepository.currentUser,
+          ).thenReturn(createUser(isEmailVerified: true));
+        },
+        build: buildBloc,
+        seed: () => const AccountStatusRestricted(daysUntilDeletion: 10),
+        act: (bloc) => bloc.add(const RefreshVerificationStatus()),
+        expect: () => [const AccountStatusActive()],
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'emits nothing when state is already active',
+        setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
+        },
+        build: buildBloc,
+        seed: () => const AccountStatusActive(),
+        act: (bloc) => bloc.add(const RefreshVerificationStatus()),
+        expect: () => <AccountStatusState>[],
+        verify: (_) => verifyNever(() => mockAuthRepository.reloadUser()),
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'silently ignores reloadUser errors',
+        setUp: () {
+          when(
+            () => mockAuthRepository.reloadUser(),
+          ).thenThrow(Exception('network error'));
+        },
+        build: buildBloc,
+        seed: () => const AccountStatusPending(daysRemaining: 5),
+        act: (bloc) => bloc.add(const RefreshVerificationStatus()),
+        expect: () => <AccountStatusState>[],
+      );
+    });
+
     group('AccountStatusEvent equatable', () {
       test('CheckAccountStatus instances are equal', () {
         expect(const CheckAccountStatus(), equals(const CheckAccountStatus()));
@@ -281,6 +350,13 @@ void main() {
         expect(
           const DismissAccountWarning(),
           equals(const DismissAccountWarning()),
+        );
+      });
+
+      test('RefreshVerificationStatus instances are equal', () {
+        expect(
+          const RefreshVerificationStatus(),
+          equals(const RefreshVerificationStatus()),
         );
       });
     });

--- a/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
@@ -366,6 +366,125 @@ void main() {
       });
     });
 
+    group('Refresh Status card', () {
+      testWidgets(
+        'card #3 is tappable and dispatches refreshStatus when email has been sent',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            const EmailVerificationState.pending(
+              email: 'test@example.com',
+              emailSent: true,
+              lastSentAt: null,
+              resendCooldownSeconds: 0,
+            ),
+          );
+          when(() => mockBloc.stream).thenAnswer((_) => const Stream.empty());
+          when(() => mockBloc.add(any())).thenReturn(null);
+
+          await tester.pumpWidget(createWidgetUnderTest());
+
+          // Card #3 shows the tappable description
+          expect(
+            find.text('Tap here to check if your email has been verified.'),
+            findsOneWidget,
+          );
+          // Chevron indicator is visible
+          expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+
+          // Tap the InkWell that wraps card #3
+          final card3InkWell = find.ancestor(
+            of: find.text(
+              'Tap here to check if your email has been verified.',
+            ),
+            matching: find.byType(InkWell),
+          ).first;
+          await tester.ensureVisible(card3InkWell);
+          await tester.tap(card3InkWell);
+          await tester.pump();
+
+          verify(
+            () => mockBloc.add(const EmailVerificationEvent.refreshStatus()),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'card #3 is not tappable before the verification email is sent',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            const EmailVerificationState.pending(
+              email: 'test@example.com',
+              emailSent: false,
+              lastSentAt: null,
+              resendCooldownSeconds: 0,
+            ),
+          );
+          when(() => mockBloc.stream).thenAnswer((_) => const Stream.empty());
+
+          await tester.pumpWidget(createWidgetUnderTest());
+
+          // Non-tappable description shown
+          expect(
+            find.text('Return here and refresh to confirm verification.'),
+            findsOneWidget,
+          );
+          // No chevron
+          expect(find.byIcon(Icons.chevron_right), findsNothing);
+        },
+      );
+    });
+
+    group('onVerified callback', () {
+      testWidgets('calls onVerified when state transitions to verified',
+          (tester) async {
+        var callbackCalled = false;
+
+        when(() => mockBloc.state).thenReturn(
+          const EmailVerificationState.pending(
+            email: 'test@example.com',
+            emailSent: true,
+            lastSentAt: null,
+            resendCooldownSeconds: 0,
+          ),
+        );
+        when(() => mockBloc.stream).thenAnswer(
+          (_) => Stream.value(
+            EmailVerificationState.verified(verifiedAt: DateTime.now()),
+          ),
+        );
+
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(size: Size(800, 1200)),
+            child: MaterialApp(
+              localizationsDelegates: const [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [Locale('en')],
+              home: MultiBlocProvider(
+                providers: [
+                  BlocProvider<EmailVerificationBloc>.value(value: mockBloc),
+                  BlocProvider<InvitationBloc>.value(
+                    value: mockInvitationBloc,
+                  ),
+                  BlocProvider<AuthenticationBloc>.value(value: mockAuthBloc),
+                ],
+                child: EmailVerificationPage(
+                  onVerified: () => callbackCalled = true,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(callbackCalled, isTrue);
+      });
+    });
+
     testWidgets('AppBar displays correct title', (tester) async {
       when(
         () => mockBloc.state,


### PR DESCRIPTION
## Summary

- Removes the small `IconButton` (person_add icon) from the Confirmed Players header row
- Adds a dedicated section at the bottom of the players card with:
  - Section title: "Invite people from other groups" (existing l10n key `inviteGuestPlayers`)
  - Full-width outlined button labelled "Invite" (existing l10n key `inviteGuest`)
- Section is only visible to the game creator while the game status is `scheduled`
- The existing `showInviteGuestPlayersSheet` flow is unchanged

## Test plan

- [ ] Game details page (as creator, game scheduled): section appears below the players/waitlist list with title and button
- [ ] Tapping the button opens the guest invitation sheet
- [ ] Section is hidden when the game is not scheduled (completed, cancelled)
- [ ] Section is hidden for non-creator participants
- [ ] All existing widget tests pass