### PR TITLE
fix(web): universal App Store URL + Android deep-link on invite page

### DIFF
--- a/public/auth/action.html
+++ b/public/auth/action.html
@@ -99,7 +99,7 @@
     <h1>Email verified!</h1>
     <p>Thank you for verifying your email address.<br>You're all set — welcome to Gatherli! 🎉</p>
     <div class="store-badges">
-      <a href="https://apps.apple.com/us/app/gatherli/id6760428234">
+      <a href="https://apps.apple.com/app/id6760428234">
         <img src="/badge-app-store.svg" alt="Download on the App Store">
       </a>
       <a href="https://play.google.com/store/apps/details?id=org.gatherli.app">

--- a/public/index.html
+++ b/public/index.html
@@ -102,7 +102,7 @@
     <p class="tagline">Organize sports games, track ELO ratings<br>and train with your group.</p>
 
     <div class="badges">
-      <a class="badge" href="https://apps.apple.com/us/app/gatherli/id6760428234" target="_blank" rel="noopener">
+      <a class="badge" href="https://apps.apple.com/app/id6760428234" target="_blank" rel="noopener">
         <img src="/badge-app-store.svg" alt="Download on the App Store">
       </a>
       <a class="badge" href="https://play.google.com/store/apps/details?id=org.gatherli.app" target="_blank" rel="noopener">

--- a/public/invite.html
+++ b/public/invite.html
@@ -176,15 +176,27 @@
     showFallback();
   }
 
-  // ── Android: auto-redirect with Play Install Referrer ─────────────────────
+  // ── Android: try deep-link into app first, fall back to Play Store ────────
   function redirectAndroid() {
-    var referrer = token
-      ? encodeURIComponent('invite_token=' + token)
-      : '';
-    var url = 'https://play.google.com/store/apps/details?id=' + PLAY_STORE_ID;
-    if (referrer) url += '&referrer=' + referrer;
-    // replace() so the redirect page is not in browser history
-    window.location.replace(url);
+    var playStoreUrl = 'https://play.google.com/store/apps/details?id=' + PLAY_STORE_ID;
+
+    if (token) {
+      // Intent URL: Chrome for Android attempts to open the app via the custom
+      // scheme. If the app is installed it opens directly on the invite page.
+      // If not installed, Chrome follows S.browser_fallback_url to Play Store.
+      var referrer = encodeURIComponent('invite_token=' + token);
+      var fallback  = encodeURIComponent(playStoreUrl + '&referrer=' + referrer);
+      var intentUrl = 'intent://invite/' + token
+        + '#Intent'
+        + ';scheme=gatherli'
+        + ';package=' + PLAY_STORE_ID
+        + ';S.browser_fallback_url=' + fallback
+        + ';end';
+      window.location.href = intentUrl;
+    } else {
+      // No token — just send to Play Store
+      window.location.replace(playStoreUrl);
+    }
   }
 
   // ── iOS: clipboard write on user tap, then App Store redirect ─────────────

--- a/public/invite.html
+++ b/public/invite.html
@@ -150,7 +150,7 @@
 <script>
 (function () {
   // ── Constants ──────────────────────────────────────────────────────────────
-  var APP_STORE_URL  = 'https://apps.apple.com/us/app/gatherli/id6760428234';
+  var APP_STORE_URL  = 'https://apps.apple.com/app/id6760428234';
   var PLAY_STORE_ID  = 'org.gatherli.app';
   var CUSTOM_SCHEME  = 'gatherli://invite/';
 


### PR DESCRIPTION
## Summary

Two invite link bugs fixed in the same set of landing pages.

### 1. App Store region error (iOS / desktop)
Users outside the US were seeing "This app is not available in your country or region" when tapping invite links.

**Root cause:** All three pages hardcoded `/us/` in the App Store URL, forcing everyone into the US storefront.

**Fix:** Replaced with the region-agnostic format across `invite.html`, `index.html`, and `auth/action.html`:
```
❌ https://apps.apple.com/us/app/gatherli/id6760428234
✅ https://apps.apple.com/app/id6760428234
```

### 2. Android always redirecting to Play Store even when app is installed
Android users with the app already installed were being sent to Google Play instead of opening the app on the group acceptance page.

**Root cause:** `redirectAndroid()` always called `window.location.replace(playStoreUrl)` with no attempt to open the app first.

**Fix:** Replaced with an Android Intent URL:
```
intent://invite/<token>#Intent;scheme=gatherli;package=org.gatherli.app;S.browser_fallback_url=<play_store_url>;end
```
Chrome for Android tries `gatherli://invite/<token>` first. If the app is installed it opens directly on the group acceptance page. If not installed, Chrome follows `browser_fallback_url` to the Play Store (with install referrer preserved).

## Test plan

- [ ] iOS (non-US account): tapping invite link opens correct local App Store page
- [ ] Android (app installed): tapping invite link opens app on group acceptance page
- [ ] Android (app not installed): tapping invite link redirects to Play Store
- [ ] Desktop: both store badges link correctly