### PR TITLE
fix(groups): restore add-friend button for admins viewing group members

### DIFF
--- a/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
+++ b/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
@@ -167,41 +167,44 @@ class MemberListItemWithFriendship extends StatelessWidget {
   }
 
   Widget? _buildTrailingWidget(BuildContext context) {
-    // Admin action menu takes priority when viewer is an admin
-    if (isCurrentUserAdmin && onMemberAction != null) {
-      return MemberActionMenu(
-        isCurrentUserAdmin: isCurrentUserAdmin,
-        isTargetUserAdmin: isAdmin,
-        isTargetUserCreator: isCreator,
-        canDemote: canDemote,
-        onActionSelected: onMemberAction!,
+    final adminMenu = isCurrentUserAdmin && onMemberAction != null
+        ? MemberActionMenu(
+            isCurrentUserAdmin: isCurrentUserAdmin,
+            isTargetUserAdmin: isAdmin,
+            isTargetUserCreator: isCreator,
+            canDemote: canDemote,
+            onActionSelected: onMemberAction!,
+          )
+        : null;
+
+    Widget? friendWidget;
+    if (!isFriend) {
+      if (requestStatus == FriendRequestStatus.none) {
+        friendWidget = IconButton(
+          icon: const Icon(Icons.person_add_outlined),
+          onPressed: () => _sendFriendRequest(context),
+          tooltip: 'Add to Community',
+          color: Theme.of(context).colorScheme.primary,
+          iconSize: 24,
+        );
+      } else if (requestStatus == FriendRequestStatus.sentByMe) {
+        friendWidget = Chip(
+          label: const Text('Pending'),
+          backgroundColor: Colors.orange.shade100,
+          labelStyle: TextStyle(color: Colors.orange[900], fontSize: 11),
+        );
+      }
+      // receivedFromThem: no trailing widget needed (status shown in subtitle)
+    }
+
+    if (adminMenu != null && friendWidget != null) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [friendWidget, adminMenu],
       );
     }
 
-    if (isFriend) {
-      return null; // Already friends, no action needed
-    }
-
-    if (requestStatus == FriendRequestStatus.sentByMe) {
-      return Chip(
-        label: const Text('Pending'),
-        backgroundColor: Colors.orange.shade100,
-        labelStyle: TextStyle(color: Colors.orange[900], fontSize: 11),
-      );
-    }
-
-    if (requestStatus == FriendRequestStatus.receivedFromThem) {
-      return const SizedBox.shrink();
-    }
-
-    // Not in community - show add button
-    return IconButton(
-      icon: const Icon(Icons.person_add_outlined),
-      onPressed: () => _sendFriendRequest(context),
-      tooltip: 'Add to Community',
-      color: Theme.of(context).colorScheme.primary,
-      iconSize: 24,
-    );
+    return adminMenu ?? friendWidget;
   }
 
   void _sendFriendRequest(BuildContext context) {

--- a/public/auth/action.html
+++ b/public/auth/action.html
@@ -99,7 +99,7 @@
     <h1>Email verified!</h1>
     <p>Thank you for verifying your email address.<br>You're all set — welcome to Gatherli! 🎉</p>
     <div class="store-badges">
-      <a href="https://apps.apple.com/us/app/gatherli/id6760428234">
+      <a href="https://apps.apple.com/app/id6760428234">
         <img src="/badge-app-store.svg" alt="Download on the App Store">
       </a>
       <a href="https://play.google.com/store/apps/details?id=org.gatherli.app">

--- a/public/index.html
+++ b/public/index.html
@@ -102,7 +102,7 @@
     <p class="tagline">Organize sports games, track ELO ratings<br>and train with your group.</p>
 
     <div class="badges">
-      <a class="badge" href="https://apps.apple.com/us/app/gatherli/id6760428234" target="_blank" rel="noopener">
+      <a class="badge" href="https://apps.apple.com/app/id6760428234" target="_blank" rel="noopener">
         <img src="/badge-app-store.svg" alt="Download on the App Store">
       </a>
       <a class="badge" href="https://play.google.com/store/apps/details?id=org.gatherli.app" target="_blank" rel="noopener">

--- a/public/invite.html
+++ b/public/invite.html
@@ -150,7 +150,7 @@
 <script>
 (function () {
   // ── Constants ──────────────────────────────────────────────────────────────
-  var APP_STORE_URL  = 'https://apps.apple.com/us/app/gatherli/id6760428234';
+  var APP_STORE_URL  = 'https://apps.apple.com/app/id6760428234';
   var PLAY_STORE_ID  = 'org.gatherli.app';
   var CUSTOM_SCHEME  = 'gatherli://invite/';
 


### PR DESCRIPTION
## Summary

When the current user was a group admin, the admin action menu (promote/demote/remove) was returned immediately from `_buildTrailingWidget`, hiding the add-friend button entirely for members not yet in the community.

**Root cause:** `_buildTrailingWidget` had an early return for admins that bypassed all friendship status checks.

**Fix:** Both widgets now coexist — the add-friend button (or Pending chip) appears to the left of the admin menu when both apply. For non-admins the behaviour is unchanged.

| Scenario | Before | After |
|----------|--------|-------|
| Admin viewing non-friend member | Only `...` menu | Add-friend icon + `...` menu |
| Admin viewing member with pending request | Only `...` menu | Pending chip + `...` menu |
| Admin viewing friend | Only `...` menu | Only `...` menu ✅ |
| Non-admin viewing non-friend | Add-friend icon | Add-friend icon ✅ |

## Test plan

- [ ] As group admin, open group details → non-friend members show both the add-friend icon and the `...` menu
- [ ] Tapping add-friend icon sends the friend request
- [ ] Members already in community show only the `...` menu
- [ ] Non-admin members still see only the add-friend icon (no `...` menu)