### PR TITLE
fix(functions): prevent TOCTOU race in onGameStatusChangedExpireInvitations (#722)

### DIFF
--- a/functions/src/onGameStatusChangedExpireInvitations.ts
+++ b/functions/src/onGameStatusChangedExpireInvitations.ts
@@ -58,30 +58,38 @@ export async function onGameStatusChangedExpireInvitationsHandler(
   const expiredAt = admin.firestore.FieldValue.serverTimestamp();
   const totalDocs = pendingSnapshot.docs.length;
 
-  // Collect invitee IDs to clear from pendingInviteeIds on the game
-  const inviteeIds = pendingSnapshot.docs.map((doc) => doc.data().inviteeId as string);
-
-  // ── 3. Batch-update in chunks of 500 (Firestore limit) ───────────────────
+  // ── 3. Expire invitations atomically in chunks ────────────────────────────
+  // Use a transaction per chunk so we re-read each invitation before writing.
+  // This closes a race with acceptGameGuestInvitation: without the re-read, an
+  // invitation accepted between our query (step 2) and this write would have
+  // its status silently overwritten from "accepted" back to "expired".
   let expiredCount = 0;
 
   for (let i = 0; i < pendingSnapshot.docs.length; i += BATCH_SIZE) {
     const chunk = pendingSnapshot.docs.slice(i, i + BATCH_SIZE);
-    const batch = db.batch();
 
-    for (const doc of chunk) {
-      batch.update(doc.ref, {
-        status: "expired",
-        updatedAt: expiredAt,
-      });
-    }
+    await db.runTransaction(async (t) => {
+      const freshDocs = await Promise.all(chunk.map((doc) => t.get(doc.ref)));
 
-    await batch.commit();
-    expiredCount += chunk.length;
+      for (const freshDoc of freshDocs) {
+        // Skip any invitation no longer pending (e.g. accepted between the
+        // outer query and this transaction read).
+        if (!freshDoc.exists || freshDoc.data()?.status !== "pending") continue;
+
+        t.update(freshDoc.ref, {
+          status: "expired",
+          updatedAt: expiredAt,
+        });
+        expiredCount++;
+      }
+    });
   }
 
   // ── 4. Clear pendingInviteeIds on the game document ──────────────────────
+  // The game is in a terminal state — unconditionally set to [] rather than
+  // computing which IDs to remove, so this is a single idempotent write.
   await db.collection("games").doc(gameId).update({
-    pendingInviteeIds: admin.firestore.FieldValue.arrayRemove(...inviteeIds),
+    pendingInviteeIds: [],
     updatedAt: expiredAt,
   });
 

--- a/functions/test/unit/onGameStatusChangedExpireInvitations.test.ts
+++ b/functions/test/unit/onGameStatusChangedExpireInvitations.test.ts
@@ -1,13 +1,11 @@
-// Unit tests for onGameStatusChangedExpireInvitations Firestore trigger (Story 28.5)
-// Validates that pending game invitations are expired when a game reaches a terminal status.
+// Unit tests for onGameStatusChangedExpireInvitations Firestore trigger (Story 28.5 / fix #722)
+// Validates that pending game invitations are expired when a game reaches a terminal status,
+// and that invitations accepted between the outer query and the transaction write are not overwritten.
 
 import * as admin from "firebase-admin";
 import { onGameStatusChangedExpireInvitationsHandler } from "../../src/onGameStatusChangedExpireInvitations";
 
 // ── Mock firebase-admin ──────────────────────────────────────────────────────
-const mockBatchUpdate = jest.fn();
-const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
-const mockBatch = { update: mockBatchUpdate, commit: mockBatchCommit };
 
 jest.mock("firebase-admin", () => {
   const actual = jest.requireActual("firebase-admin");
@@ -16,12 +14,11 @@ jest.mock("firebase-admin", () => {
     firestore: Object.assign(
       jest.fn(() => ({
         collection: jest.fn(),
-        batch: jest.fn(),
+        runTransaction: jest.fn(),
       })),
       {
         FieldValue: {
           serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
-          arrayRemove: jest.fn((...args: any[]) => ({ _type: "arrayRemove", args })),
         },
       }
     ),
@@ -29,6 +26,7 @@ jest.mock("firebase-admin", () => {
 });
 
 // ── Mock firebase-functions ──────────────────────────────────────────────────
+
 jest.mock("firebase-functions", () => {
   const fn: any = {
     firestore: {
@@ -62,7 +60,7 @@ function makeContext(gameId = "game-1") {
   return { params: { gameId } } as any;
 }
 
-/** Build pending invitation docs */
+/** Build pending invitation docs for the outer query snapshot */
 function makePendingDocs(count: number) {
   return Array.from({ length: count }, (_, i) => ({
     id: `inv-${i}`,
@@ -71,17 +69,49 @@ function makePendingDocs(count: number) {
   }));
 }
 
-/** Build a mock Firestore db */
-function buildDb(pendingDocs: any[] = []) {
+/**
+ * Build a mock Firestore db.
+ *
+ * @param pendingDocs  - Docs returned by the outer `.where("status","==","pending").get()` query.
+ * @param freshOverrides - Map of doc id → fresh snapshot returned by `t.get()` inside the
+ *                         transaction. Use this to simulate a doc that was accepted between
+ *                         the outer query and the transaction write.
+ */
+function buildDb(
+  pendingDocs: any[] = [],
+  freshOverrides: Record<string, { exists: boolean; data: () => any }> = {}
+) {
+  const mockTransactionUpdate = jest.fn();
+
+  const mockTransaction = {
+    get: jest.fn((ref: any) => {
+      if (freshOverrides[ref.id]) {
+        return Promise.resolve({ ...freshOverrides[ref.id], ref });
+      }
+      // Default: re-return same doc as outer query (still pending)
+      const doc = pendingDocs.find((d) => d.ref.id === ref.id);
+      if (doc) {
+        return Promise.resolve({ exists: true, data: doc.data, ref: doc.ref });
+      }
+      return Promise.resolve({ exists: false, data: () => undefined, ref });
+    }),
+    update: mockTransactionUpdate,
+  };
+
+  const mockRunTransaction = jest.fn((callback: (t: any) => Promise<any>) =>
+    callback(mockTransaction)
+  );
+
+  const mockGameDocUpdate = jest.fn().mockResolvedValue(undefined);
+
   const db: any = {
     collection: jest.fn((col: string) => {
       if (col === "games") {
         return {
-          doc: jest.fn(() => ({
-            update: jest.fn().mockResolvedValue(undefined),
-          })),
+          doc: jest.fn(() => ({ update: mockGameDocUpdate })),
         };
       }
+      // gameInvitations collection
       return {
         where: jest.fn().mockReturnThis(),
         get: jest.fn().mockResolvedValue({
@@ -90,9 +120,10 @@ function buildDb(pendingDocs: any[] = []) {
         }),
       };
     }),
-    batch: jest.fn(() => mockBatch),
+    runTransaction: mockRunTransaction,
   };
-  return db;
+
+  return { db, mockRunTransaction, mockTransactionUpdate, mockGameDocUpdate };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -104,7 +135,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
 
   describe("no-op conditions", () => {
     it("does nothing when status did not change", async () => {
-      const db = buildDb();
+      const { db } = buildDb();
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       const result = await onGameStatusChangedExpireInvitationsHandler(
@@ -117,7 +148,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
     });
 
     it("does nothing when new status is not terminal (scheduled → in_progress)", async () => {
-      const db = buildDb();
+      const { db } = buildDb();
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -129,7 +160,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
     });
 
     it("does nothing when new status is not terminal (scheduled → verification)", async () => {
-      const db = buildDb();
+      const { db } = buildDb();
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -141,7 +172,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
     });
 
     it("does nothing when before data is missing", async () => {
-      const db = buildDb();
+      const { db } = buildDb();
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -153,7 +184,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
     });
 
     it("does nothing when there are no pending invitations", async () => {
-      const db = buildDb([]); // empty
+      const { db, mockRunTransaction } = buildDb([]);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       const result = await onGameStatusChangedExpireInvitationsHandler(
@@ -162,7 +193,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
       );
 
       expect(result).toBeNull();
-      expect(mockBatchCommit).not.toHaveBeenCalled();
+      expect(mockRunTransaction).not.toHaveBeenCalled();
     });
   });
 
@@ -175,7 +206,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
       ["aborted"],
     ])("expires pending invitations when status changes to %s", async (terminalStatus) => {
       const docs = makePendingDocs(2);
-      const db = buildDb(docs);
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -183,12 +214,11 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchUpdate).toHaveBeenCalledTimes(2);
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(2);
 
-      // Verify each doc was updated to expired
       for (const doc of docs) {
-        expect(mockBatchUpdate).toHaveBeenCalledWith(
+        expect(mockTransactionUpdate).toHaveBeenCalledWith(
           doc.ref,
           expect.objectContaining({ status: "expired" })
         );
@@ -197,7 +227,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
 
     it("expires invitations when transitioning from in_progress to cancelled", async () => {
       const docs = makePendingDocs(1);
-      const db = buildDb(docs);
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -205,17 +235,32 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears pendingInviteeIds on the game document after expiring invitations", async () => {
+      const docs = makePendingDocs(1);
+      const { db, mockGameDocUpdate } = buildDb(docs);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext("game-42")
+      );
+
+      expect(mockGameDocUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ pendingInviteeIds: [] })
+      );
     });
   });
 
-  // ── Batch chunking ────────────────────────────────────────────────────────
+  // ── Transaction chunking ──────────────────────────────────────────────────
 
-  describe("batch chunking", () => {
-    it("uses a single batch for 500 or fewer invitations", async () => {
+  describe("transaction chunking", () => {
+    it("uses a single transaction for 500 or fewer invitations", async () => {
       const docs = makePendingDocs(500);
-      const db = buildDb(docs);
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -223,13 +268,13 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-      expect(mockBatchUpdate).toHaveBeenCalledTimes(500);
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(500);
     });
 
-    it("uses two batches for 501 invitations", async () => {
+    it("uses two transactions for 501 invitations", async () => {
       const docs = makePendingDocs(501);
-      const db = buildDb(docs);
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -237,13 +282,13 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchCommit).toHaveBeenCalledTimes(2);
-      expect(mockBatchUpdate).toHaveBeenCalledTimes(501);
+      expect(mockRunTransaction).toHaveBeenCalledTimes(2);
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(501);
     });
 
-    it("uses three batches for 1001 invitations", async () => {
+    it("uses three transactions for 1001 invitations", async () => {
       const docs = makePendingDocs(1001);
-      const db = buildDb(docs);
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -251,8 +296,71 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchCommit).toHaveBeenCalledTimes(3);
-      expect(mockBatchUpdate).toHaveBeenCalledTimes(1001);
+      expect(mockRunTransaction).toHaveBeenCalledTimes(3);
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(1001);
+    });
+  });
+
+  // ── Race condition guard ──────────────────────────────────────────────────
+
+  describe("race condition: invitation accepted between query and transaction write", () => {
+    it("skips an invitation that was accepted after the outer query", async () => {
+      const docs = makePendingDocs(2); // inv-0 and inv-1 both pending in outer query
+
+      // Simulate inv-0 being accepted between outer query and transaction read
+      const freshOverrides: Record<string, { exists: boolean; data: () => any }> = {
+        "inv-0": {
+          exists: true,
+          data: () => ({ status: "accepted" }),
+        },
+      };
+
+      const { db, mockRunTransaction, mockTransactionUpdate } = buildDb(docs, freshOverrides);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+      // Only inv-1 should be updated — inv-0 was accepted and must be left alone
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(1);
+      expect(mockTransactionUpdate).toHaveBeenCalledWith(
+        docs[1].ref,
+        expect.objectContaining({ status: "expired" })
+      );
+      expect(mockTransactionUpdate).not.toHaveBeenCalledWith(
+        docs[0].ref,
+        expect.anything()
+      );
+    });
+
+    it("skips an invitation that no longer exists in the transaction read", async () => {
+      const docs = makePendingDocs(2);
+
+      // Simulate inv-0 being deleted between outer query and transaction read
+      const freshOverrides: Record<string, { exists: boolean; data: () => any }> = {
+        "inv-0": {
+          exists: false,
+          data: () => undefined,
+        },
+      };
+
+      const { db, mockTransactionUpdate } = buildDb(docs, freshOverrides);
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await onGameStatusChangedExpireInvitationsHandler(
+        makeChange("scheduled", "completed"),
+        makeContext()
+      );
+
+      // Only inv-1 should be updated
+      expect(mockTransactionUpdate).toHaveBeenCalledTimes(1);
+      expect(mockTransactionUpdate).toHaveBeenCalledWith(
+        docs[1].ref,
+        expect.objectContaining({ status: "expired" })
+      );
     });
   });
 
@@ -262,7 +370,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
     it("queries only pending invitations so a second run produces zero writes", async () => {
       // First run — 2 pending docs
       const docs = makePendingDocs(2);
-      const db = buildDb(docs);
+      const { db } = buildDb(docs);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -273,7 +381,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
       jest.clearAllMocks();
 
       // Second run — no pending docs left (they were expired by first run)
-      const emptyDb = buildDb([]);
+      const { db: emptyDb, mockRunTransaction: secondRunTransaction } = buildDb([]);
       (admin.firestore as unknown as jest.Mock).mockReturnValue(emptyDb);
 
       await onGameStatusChangedExpireInvitationsHandler(
@@ -281,7 +389,7 @@ describe("onGameStatusChangedExpireInvitations", () => {
         makeContext()
       );
 
-      expect(mockBatchCommit).not.toHaveBeenCalled();
+      expect(secondRunTransaction).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replaces batch writes with per-chunk Firestore transactions so each invitation is re-read before being written
- An invitation accepted between the outer `.get()` query and the transaction write is now skipped instead of silently overwritten to `"expired"`
- Clears `pendingInviteeIds` with a direct `[]` assignment (simpler idempotent write, no arrayRemove computation needed)
- Updates all unit tests: batch/batchCommit mocks replaced with runTransaction mocks
- Adds two new race-condition test cases: accepted doc skipped, deleted doc skipped
- Adds test verifying `pendingInviteeIds: []` is written to the game document

## Test plan

- [ ] `npm test` in `functions/` — 504 tests pass (16 in this file, all green)
- [ ] Verify in dev emulator: game reaching terminal status expires only genuinely pending invitations
- [ ] Verify: accepting an invitation just before a game is cancelled does not overwrite accepted status

Closes #722