### PR TITLE
fix: 4 bugs found in v0.8.6-beta testing

### DIFF
--- a/functions/src/deleteUserAccount.ts
+++ b/functions/src/deleteUserAccount.ts
@@ -98,16 +98,24 @@ export const deleteUserAccount = functions
     }
 
     // ── 3. Delete group invite links created by this user ─────────────────
-    // Uses collectionGroup to query across all groups' "invites" subcollections.
-    // For each invite, also delete the corresponding invite_tokens lookup doc.
-    const inviteLinksSnap = await db
-      .collectionGroup("invites")
-      .where("createdBy", "==", uid)
-      .get();
+    // Query each group's invites subcollection directly rather than using
+    // collectionGroup, which requires a COLLECTION_GROUP-scoped index.
+    // This is safe since invite links can only be created within groups the
+    // user belongs to.
+    const allInviteDocs: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+    for (const groupDoc of groupsSnap.docs) {
+      const invitesSnap = await db
+        .collection("groups")
+        .doc(groupDoc.id)
+        .collection("invites")
+        .where("createdBy", "==", uid)
+        .get();
+      allInviteDocs.push(...invitesSnap.docs);
+    }
 
-    if (!inviteLinksSnap.empty) {
+    if (allInviteDocs.length > 0) {
       const inviteBatch = db.batch();
-      for (const inviteDoc of inviteLinksSnap.docs) {
+      for (const inviteDoc of allInviteDocs) {
         const token: string | undefined = inviteDoc.data().token;
         inviteBatch.delete(inviteDoc.ref);
         if (token) {
@@ -116,7 +124,7 @@ export const deleteUserAccount = functions
       }
       await inviteBatch.commit();
       functions.logger.info(
-        `[deleteUserAccount] Deleted ${inviteLinksSnap.size} group invite link(s)`
+        `[deleteUserAccount] Deleted ${allInviteDocs.length} group invite link(s)`
       );
     }
 
@@ -182,8 +190,8 @@ export const deleteUserAccount = functions
 
     // ── 6. Delete all friendship documents ────────────────────────────────
     const [sentFriendships, receivedFriendships] = await Promise.all([
-      db.collection("friendships").where("requesterId", "==", uid).get(),
-      db.collection("friendships").where("receiverId", "==", uid).get(),
+      db.collection("friendships").where("initiatorId", "==", uid).get(),
+      db.collection("friendships").where("recipientId", "==", uid).get(),
     ]);
 
     const allFriendshipDocs = [...sentFriendships.docs, ...receivedFriendships.docs];

--- a/lib/core/presentation/bloc/account_status/account_status_bloc.dart
+++ b/lib/core/presentation/bloc/account_status/account_status_bloc.dart
@@ -42,8 +42,22 @@ class AccountStatusBloc extends Bloc<AccountStatusEvent, AccountStatusState> {
       return;
     }
 
+    // Reload to get the freshest email-verification status from Firebase.
+    // This handles the case where the user verified their email before the
+    // app cold-started (cached token still has isEmailVerified = false).
+    try {
+      await _authRepository.reloadUser();
+      final freshUser = _authRepository.currentUser;
+      if (freshUser != null && freshUser.isEmailVerified) {
+        emit(const AccountStatusActive());
+        return;
+      }
+    } catch (_) {
+      // Ignore reload failures; proceed with cached status.
+    }
+
     final status = computeAccountStatus(
-      isEmailVerified: user.isEmailVerified,
+      isEmailVerified: false,
       accountCreatedAt: user.createdAt,
     );
 

--- a/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
+++ b/lib/features/groups/presentation/widgets/member_list_item_with_friendship.dart
@@ -166,8 +166,33 @@ class MemberListItemWithFriendship extends StatelessWidget {
   }
 
   Widget? _buildTrailingWidget(BuildContext context) {
-    // Admin action menu takes priority when viewer is an admin
+    // Admin action menu takes priority when viewer is an admin.
+    // For non-community members, show both the add-friend button and the
+    // admin menu so admins can take either action.
     if (isCurrentUserAdmin && onMemberAction != null) {
+      if (!isFriend &&
+          requestStatus == FriendRequestStatus.none &&
+          onSendFriendRequest != null) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.person_add_outlined),
+              onPressed: () => _sendFriendRequest(context),
+              tooltip: 'Add to Community',
+              color: Theme.of(context).colorScheme.primary,
+              iconSize: 20,
+            ),
+            MemberActionMenu(
+              isCurrentUserAdmin: isCurrentUserAdmin,
+              isTargetUserAdmin: isAdmin,
+              isTargetUserCreator: isCreator,
+              canDemote: canDemote,
+              onActionSelected: onMemberAction!,
+            ),
+          ],
+        );
+      }
       return MemberActionMenu(
         isCurrentUserAdmin: isCurrentUserAdmin,
         isTargetUserAdmin: isAdmin,

--- a/lib/features/profile/presentation/pages/email_verification_page.dart
+++ b/lib/features/profile/presentation/pages/email_verification_page.dart
@@ -226,14 +226,10 @@ class EmailVerificationPage extends StatelessWidget {
             context,
             icon: Icons.looks_3,
             title: 'Refresh Status',
-            description: emailSent
-                ? 'Tap here to check if your email has been verified.'
-                : 'Return here and refresh to confirm verification.',
-            onTap: emailSent
-                ? () => context.read<EmailVerificationBloc>().add(
-                      const EmailVerificationEvent.refreshStatus(),
-                    )
-                : null,
+            description: 'Tap here to check if your email has been verified.',
+            onTap: () => context.read<EmailVerificationBloc>().add(
+              const EmailVerificationEvent.refreshStatus(),
+            ),
           ),
           const SizedBox(height: 32),
 

--- a/test/unit/core/presentation/bloc/account_status/account_status_bloc_test.dart
+++ b/test/unit/core/presentation/bloc/account_status/account_status_bloc_test.dart
@@ -67,8 +67,25 @@ void main() {
       );
 
       blocTest<AccountStatusBloc, AccountStatusState>(
+        'emits [AccountStatusActive] when reloadUser finds email is now verified',
+        setUp: () {
+          // First call returns unverified, reload updates it to verified
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
+          var callCount = 0;
+          when(() => mockAuthRepository.currentUser).thenAnswer((_) {
+            callCount++;
+            return createUser(isEmailVerified: callCount > 1);
+          });
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const CheckAccountStatus()),
+        expect: () => [const AccountStatusActive()],
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
         'emits [AccountStatusPending] when unverified and within grace period',
         setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
           when(() => mockAuthRepository.currentUser).thenReturn(
             createUser(
               isEmailVerified: false,
@@ -88,6 +105,7 @@ void main() {
       blocTest<AccountStatusBloc, AccountStatusState>(
         'emits [AccountStatusPending] with 7 days for new account',
         setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
           when(() => mockAuthRepository.currentUser).thenReturn(
             createUser(isEmailVerified: false, createdAt: DateTime.now()),
           );
@@ -106,6 +124,7 @@ void main() {
       blocTest<AccountStatusBloc, AccountStatusState>(
         'emits [AccountStatusPending] when createdAt is null',
         setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
           when(
             () => mockAuthRepository.currentUser,
           ).thenReturn(createUser(isEmailVerified: false, createdAt: null));
@@ -124,6 +143,7 @@ void main() {
       blocTest<AccountStatusBloc, AccountStatusState>(
         'emits [AccountStatusRestricted] when past grace period',
         setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
           when(() => mockAuthRepository.currentUser).thenReturn(
             createUser(
               isEmailVerified: false,
@@ -145,6 +165,7 @@ void main() {
       blocTest<AccountStatusBloc, AccountStatusState>(
         'emits [AccountStatusRestricted] with 0 days when past deletion period',
         setUp: () {
+          when(() => mockAuthRepository.reloadUser()).thenAnswer((_) async {});
           when(() => mockAuthRepository.currentUser).thenReturn(
             createUser(
               isEmailVerified: false,
@@ -155,6 +176,30 @@ void main() {
         build: buildBloc,
         act: (bloc) => bloc.add(const CheckAccountStatus()),
         expect: () => [const AccountStatusRestricted(daysUntilDeletion: 0)],
+      );
+
+      blocTest<AccountStatusBloc, AccountStatusState>(
+        'silently ignores reloadUser errors during CheckAccountStatus',
+        setUp: () {
+          when(
+            () => mockAuthRepository.reloadUser(),
+          ).thenThrow(Exception('network error'));
+          when(() => mockAuthRepository.currentUser).thenReturn(
+            createUser(
+              isEmailVerified: false,
+              createdAt: DateTime.now(),
+            ),
+          );
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const CheckAccountStatus()),
+        expect: () => [
+          isA<AccountStatusPending>().having(
+            (s) => s.daysRemaining,
+            'daysRemaining',
+            gracePeriodDays,
+          ),
+        ],
       );
     });
 

--- a/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
+++ b/test/unit/features/profile/presentation/pages/email_verification_page_test.dart
@@ -409,7 +409,7 @@ void main() {
       );
 
       testWidgets(
-        'card #3 is not tappable before the verification email is sent',
+        'card #3 is always tappable even before the verification email is sent',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
             const EmailVerificationState.pending(
@@ -423,13 +423,13 @@ void main() {
 
           await tester.pumpWidget(createWidgetUnderTest());
 
-          // Non-tappable description shown
+          // Tappable description always shown
           expect(
-            find.text('Return here and refresh to confirm verification.'),
+            find.text('Tap here to check if your email has been verified.'),
             findsOneWidget,
           );
-          // No chevron
-          expect(find.byIcon(Icons.chevron_right), findsNothing);
+          // Chevron visible (card is tappable)
+          expect(find.byIcon(Icons.chevron_right), findsOneWidget);
         },
       );
     });


### PR DESCRIPTION
## Summary

- **Bug 1 (Invite icons)**: Admin action menu was unconditionally overriding the `person_add` icon for non-community group members. Now shows both the add-friend button and the admin menu side-by-side when the viewer is an admin and the target has no pending request.
- **Bug 2 (Banner not dismissing)**: `AccountStatusBloc._onCheckStatus` now calls `reloadUser()` before computing account status when the cached token has `isEmailVerified = false`. Banner dismisses immediately on cold start if email was already verified.
- **Bug 3 (Refresh Status disabled)**: The "Refresh Status" instruction card on `EmailVerificationPage` was gated on `emailSent == true`, blocking users who navigated there directly. The condition is removed — the card is always tappable.
- **Bug 4 (Account deletion failing)**: `deleteUserAccount.ts` had two bugs: (a) friendship queries used wrong field names (`requesterId`/`receiverId` → fixed to `initiatorId`/`recipientId`), and (b) `collectionGroup("invites")` required an undeployed COLLECTION_GROUP Firestore index — replaced with direct per-group subcollection queries.

## Test plan

- [x] All `account_status_bloc_test.dart` tests updated and passing (36 tests, +2 new)
- [x] All group widget tests passing (138 tests)
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] Flutter analyze reports no issues on changed files
- [ ] Manually verify: non-community member in group shows both add-friend icon and 3-dot menu when viewer is admin
- [ ] Manually verify: email verification banner disappears on cold start after verifying email
- [ ] Manually verify: "Refresh Status" card tappable even before sending email
- [ ] Manually verify: account deletion succeeds in dev