### PR TITLE
fix(invitations): add missing gender field to invite registration flow

### DIFF
--- a/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart
+++ b/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart
@@ -62,15 +62,20 @@ class InviteRegistrationBloc
         );
       }
 
-      // Step 3: Persist firstName and lastName to Firestore
+      // Step 3: Persist firstName, lastName and gender to Firestore
       try {
         await _authRepository.updateUserNames(
           firstName: event.firstName.trim(),
           lastName: event.lastName.trim(),
+          gender: event.gender,
         );
-        debugPrint('✅ InviteRegistrationBloc: First/last name persisted');
+        debugPrint(
+          '✅ InviteRegistrationBloc: First/last name and gender persisted',
+        );
       } catch (e) {
-        debugPrint('⚠️ InviteRegistrationBloc: Failed to persist names: $e');
+        debugPrint(
+          '⚠️ InviteRegistrationBloc: Failed to persist names/gender: $e',
+        );
       }
 
       // Step 4: Send email verification (non-blocking)
@@ -181,6 +186,9 @@ class InviteRegistrationBloc
     }
     if (event.password != event.confirmPassword) {
       return 'Passwords do not match';
+    }
+    if (!['male', 'female', 'none'].contains(event.gender)) {
+      return 'Please select a gender';
     }
     return null;
   }

--- a/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart
+++ b/lib/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart
@@ -17,6 +17,7 @@ class InviteRegistrationSubmitted extends InviteRegistrationEvent {
   final String password;
   final String confirmPassword;
   final String token;
+  final String gender;
 
   const InviteRegistrationSubmitted({
     required this.firstName,
@@ -26,6 +27,7 @@ class InviteRegistrationSubmitted extends InviteRegistrationEvent {
     required this.password,
     required this.confirmPassword,
     required this.token,
+    required this.gender,
   });
 
   @override
@@ -37,6 +39,7 @@ class InviteRegistrationSubmitted extends InviteRegistrationEvent {
     password,
     confirmPassword,
     token,
+    gender,
   ];
 }
 

--- a/lib/features/invitations/presentation/pages/invite_registration_page.dart
+++ b/lib/features/invitations/presentation/pages/invite_registration_page.dart
@@ -3,13 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
-import 'package:play_with_me/features/auth/presentation/widgets/auth_form_field.dart';
 import 'package:play_with_me/features/auth/presentation/widgets/auth_button.dart';
+import 'package:play_with_me/features/auth/presentation/widgets/auth_form_field.dart';
 import 'package:play_with_me/features/groups/presentation/pages/group_details_page.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_event.dart';
 import 'package:play_with_me/features/invitations/presentation/bloc/invite_registration/invite_registration_state.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
+
+const _kGenderMale = 'male';
+const _kGenderFemale = 'female';
+const _kGenderNone = 'none';
 
 class InviteRegistrationPage extends StatefulWidget {
   final String token;
@@ -39,6 +43,8 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
   final _confirmPasswordController = TextEditingController();
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
+  String? _selectedGender;
+  bool _genderSubmitAttempted = false;
 
   @override
   void dispose() {
@@ -92,6 +98,8 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
                     ),
                     const SizedBox(height: 12),
                     _buildConfirmPasswordField(l10n),
+                    const SizedBox(height: 16),
+                    _buildGenderSelector(l10n),
                     const SizedBox(height: 32),
                     _buildSubmitButton(blocContext, l10n),
                     const SizedBox(height: 16),
@@ -282,6 +290,76 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
     );
   }
 
+  Widget _buildGenderSelector(AppLocalizations l10n) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n.genderSelectionTitle,
+              style: Theme.of(
+                context,
+              ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(width: 4),
+            Tooltip(
+              message: l10n.registrationGenderTooltip,
+              triggerMode: TooltipTriggerMode.tap,
+              showDuration: const Duration(seconds: 6),
+              child: const Icon(
+                Icons.help_outline,
+                size: 16,
+                color: AppColors.textMuted,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: _GenderOption(
+                label: l10n.genderMale,
+                value: _kGenderMale,
+                selected: _selectedGender == _kGenderMale,
+                onTap: () => setState(() => _selectedGender = _kGenderMale),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _GenderOption(
+                label: l10n.genderFemale,
+                value: _kGenderFemale,
+                selected: _selectedGender == _kGenderFemale,
+                onTap: () => setState(() => _selectedGender = _kGenderFemale),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _GenderOption(
+                label: l10n.genderPreferNotToSay,
+                value: _kGenderNone,
+                selected: _selectedGender == _kGenderNone,
+                onTap: () => setState(() => _selectedGender = _kGenderNone),
+              ),
+            ),
+          ],
+        ),
+        if (_genderSubmitAttempted && _selectedGender == null)
+          Padding(
+            padding: const EdgeInsets.only(top: 6, left: 4),
+            child: Text(
+              l10n.registrationGenderRequired,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
   Widget _buildSubmitButton(BuildContext blocContext, AppLocalizations l10n) {
     return BlocBuilder<InviteRegistrationBloc, InviteRegistrationState>(
       builder: (context, state) {
@@ -315,7 +393,8 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
   }
 
   void _submitRegistration(BuildContext blocContext) {
-    if (_formKey.currentState!.validate()) {
+    setState(() => _genderSubmitAttempted = true);
+    if (_formKey.currentState!.validate() && _selectedGender != null) {
       blocContext.read<InviteRegistrationBloc>().add(
         InviteRegistrationSubmitted(
           firstName: _firstNameController.text.trim(),
@@ -325,12 +404,16 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
           password: _passwordController.text,
           confirmPassword: _confirmPasswordController.text,
           token: widget.token,
+          gender: _selectedGender!,
         ),
       );
     }
   }
 
-  void _onStateChange(BuildContext context, InviteRegistrationState state) {
+  void _onStateChange(
+    BuildContext context,
+    InviteRegistrationState state,
+  ) {
     final l10n = AppLocalizations.of(context)!;
 
     if (state is InviteRegistrationFailure) {
@@ -361,5 +444,58 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
       );
       Navigator.of(context).pushNamedAndRemoveUntil('/login', (route) => false);
     }
+  }
+}
+
+class _GenderOption extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _GenderOption({
+    required this.label,
+    required this.value,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: selected ? AppColors.primary : Colors.transparent,
+              border: Border.all(
+                color: selected
+                    ? AppColors.primary
+                    : AppColors.textMuted.withValues(alpha: 0.4),
+                width: selected ? 2 : 1,
+              ),
+            ),
+            child: selected
+                ? const Icon(Icons.check, color: Colors.white, size: 14)
+                : null,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+              color: selected ? AppColors.primary : AppColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/test/unit/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc_test.dart
+++ b/test/unit/features/invitations/presentation/bloc/invite_registration/invite_registration_bloc_test.dart
@@ -53,6 +53,7 @@ void main() {
     password: 'Password1',
     confirmPassword: 'Password1',
     token: 'test-token',
+    gender: 'male',
   );
 
   const joinResult = (
@@ -77,6 +78,7 @@ void main() {
       () => mockAuthRepo.updateUserNames(
         firstName: any(named: 'firstName'),
         lastName: any(named: 'lastName'),
+        gender: any(named: 'gender'),
       ),
     ).thenAnswer((_) async {});
     when(() => mockAuthRepo.sendEmailVerification()).thenAnswer((_) async {});
@@ -122,6 +124,7 @@ void main() {
               () => mockAuthRepo.updateUserNames(
                 firstName: 'John',
                 lastName: 'Doe',
+                gender: 'male',
               ),
             ).called(1);
             verify(() => mockAuthRepo.sendEmailVerification()).called(1);
@@ -269,6 +272,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -289,6 +293,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -311,6 +316,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -331,6 +337,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -353,6 +360,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -375,6 +383,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -397,6 +406,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -419,6 +429,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -439,6 +450,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -461,6 +473,7 @@ void main() {
               password: 'Pass1',
               confirmPassword: 'Pass1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -483,6 +496,7 @@ void main() {
               password: 'password1',
               confirmPassword: 'password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -505,6 +519,7 @@ void main() {
               password: 'Password',
               confirmPassword: 'Password',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
@@ -527,11 +542,33 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password2',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
           expect: () => [
             const InviteRegistrationCreatingAccount(),
             const InviteRegistrationFailure(message: 'Passwords do not match'),
+          ],
+        );
+
+        blocTest<InviteRegistrationBloc, InviteRegistrationState>(
+          'emits failure when gender is invalid',
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const InviteRegistrationSubmitted(
+              firstName: 'John',
+              lastName: 'Doe',
+              displayName: 'JohnD',
+              email: 'john@example.com',
+              password: 'Password1',
+              confirmPassword: 'Password1',
+              token: 'test-token',
+              gender: '',
+            ),
+          ),
+          expect: () => [
+            const InviteRegistrationCreatingAccount(),
+            const InviteRegistrationFailure(message: 'Please select a gender'),
           ],
         );
       });

--- a/test/widget/features/invitations/presentation/pages/invite_registration_page_test.dart
+++ b/test/widget/features/invitations/presentation/pages/invite_registration_page_test.dart
@@ -58,6 +58,12 @@ void main() {
 
   /// Helper to scroll the submit button into view and tap it.
   Future<void> scrollAndTapSubmit(WidgetTester tester) async {
+    // Expand the test viewport so the full form fits without scrolling issues.
+    tester.view.physicalSize = const Size(800, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpAndSettle();
+
     final submitButton = find.text('Create Account & Join');
     await tester.ensureVisible(submitButton);
     await tester.pumpAndSettle();
@@ -450,6 +456,11 @@ void main() {
           'Password1',
         );
 
+        // Select gender
+        await tester.ensureVisible(find.text('Male'));
+        await tester.tap(find.text('Male'));
+        await tester.pumpAndSettle();
+
         await scrollAndTapSubmit(tester);
 
         verify(
@@ -462,6 +473,7 @@ void main() {
               password: 'Password1',
               confirmPassword: 'Password1',
               token: 'test-token',
+              gender: 'male',
             ),
           ),
         ).called(1);


### PR DESCRIPTION
## Summary

- Users registering via an invite link had no `gender` field saved to their Firestore profile. The `InviteRegistrationPage` collected first name, last name, display name, email and password — but not gender.
- As a result, games created by invite-registered users defaulted to mixed regardless of their actual gender.
- Added the gender selector (matching the regular registration page), wired it through the `InviteRegistrationSubmitted` event and the BLoC's `updateUserNames` call.

**Root cause confirmed on user** `W3BoRmUi2vVym52AhMMVd1E7diH2` — their Firestore document had no `gender` field and they registered via an invite link.

## Test plan

- [ ] Register via an invite link and verify the gender selector appears
- [ ] Submit without selecting gender — error message shown
- [ ] Complete registration with a gender — `gender` field is present in Firestore user document
- [ ] Create a game after invite registration — game gender reflects the user's gender, not mixed
- [ ] All 26 unit tests pass (`flutter test test/unit/features/invitations/`)
- [ ] `flutter analyze` passes with 0 warnings