### PR TITLE
fix(ui): equalise performance overview card heights and update welcome text

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1392,6 +1392,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4073,9 +4086,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -4089,9 +4102,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -4101,9 +4114,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6484,9 +6498,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7142,9 +7156,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -7365,9 +7379,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8312,9 +8326,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/lib/features/profile/presentation/widgets/home_stats_section.dart
+++ b/lib/features/profile/presentation/widgets/home_stats_section.dart
@@ -53,22 +53,28 @@ class HomeStatsSection extends StatelessWidget {
               ),
             ),
           ),
-          // Row 1: ELO + Win Rate side-by-side
-          Row(
-            children: [
-              Expanded(child: _buildEloCard(context, l10n, trendData)),
-              const SizedBox(width: 15),
-              Expanded(child: _buildWinRateCard(context, l10n)),
-            ],
+          // Row 1: ELO + Win Rate side-by-side — IntrinsicHeight ensures equal height
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(child: _buildEloCard(context, l10n, trendData)),
+                const SizedBox(width: 15),
+                Expanded(child: _buildWinRateCard(context, l10n)),
+              ],
+            ),
           ),
           const SizedBox(height: 15),
-          // Row 2: Streak + Games Played side-by-side
-          Row(
-            children: [
-              Expanded(child: _buildStreakCard(context, l10n, hasStreak)),
-              const SizedBox(width: 15),
-              Expanded(child: _buildGamesPlayedCard(context, l10n)),
-            ],
+          // Row 2: Streak + Games Played side-by-side — IntrinsicHeight ensures equal height
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(child: _buildStreakCard(context, l10n, hasStreak)),
+                const SizedBox(width: 15),
+                Expanded(child: _buildGamesPlayedCard(context, l10n)),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -223,7 +223,7 @@
   "setQuietHours": "Ruhezeiten Festlegen",
   "error": "Fehler: {message}",
   "pleaseLogInToAddFriends": "Bitte melden Sie sich an, um Freunde hinzuzufügen",
-  "welcomeBack": "Willkommen Zurück!",
+  "welcomeBack": "Willkommen!",
   "signInToContinue": "Melden Sie sich an, um Ihre Volleyball-Spiele zu organisieren",
   "emailRequired": "E-Mail ist erforderlich",
   "validEmailRequired": "Bitte geben Sie eine gültige E-Mail ein",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1142,7 +1142,7 @@
     "description": "Message when user needs to log in to add friends"
   },
 
-  "welcomeBack": "Welcome Back!",
+  "welcomeBack": "Welcome!",
   "@welcomeBack": {
     "description": "Welcome back heading on login page"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -223,7 +223,7 @@
   "setQuietHours": "Establecer Horas de Silencio",
   "error": "Error: {message}",
   "pleaseLogInToAddFriends": "Inicia sesión para agregar amigos",
-  "welcomeBack": "¡Bienvenido de Nuevo!",
+  "welcomeBack": "¡Bienvenido!",
   "signInToContinue": "Inicia sesión para continuar organizando tus partidos de voleibol",
   "emailRequired": "El correo electrónico es requerido",
   "validEmailRequired": "Por favor ingresa un correo válido",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -223,7 +223,7 @@
   "setQuietHours": "Définir les Heures Calmes",
   "error": "Erreur : {message}",
   "pleaseLogInToAddFriends": "Veuillez vous connecter pour ajouter des amis",
-  "welcomeBack": "Bon Retour !",
+  "welcomeBack": "Bienvenue !",
   "signInToContinue": "Connectez-vous pour continuer à organiser vos matchs de volleyball",
   "emailRequired": "L'e-mail est requis",
   "validEmailRequired": "Veuillez entrer un e-mail valide",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -223,7 +223,7 @@
   "setQuietHours": "Imposta Ore Silenziose",
   "error": "Errore: {message}",
   "pleaseLogInToAddFriends": "Accedi per aggiungere amici",
-  "welcomeBack": "Bentornato!",
+  "welcomeBack": "Benvenuto!",
   "signInToContinue": "Accedi per continuare a organizzare le tue partite di pallavolo",
   "emailRequired": "L'email è obbligatoria",
   "validEmailRequired": "Inserisci un'email valida",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1445,7 +1445,7 @@ abstract class AppLocalizations {
   /// Welcome back heading on login page
   ///
   /// In en, this message translates to:
-  /// **'Welcome Back!'**
+  /// **'Welcome!'**
   String get welcomeBack;
 
   /// Subtitle on login page

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -725,7 +725,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bitte melden Sie sich an, um Freunde hinzuzufügen';
 
   @override
-  String get welcomeBack => 'Willkommen Zurück!';
+  String get welcomeBack => 'Willkommen!';
 
   @override
   String get signInToContinue =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -715,7 +715,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pleaseLogInToAddFriends => 'Please log in to add friends';
 
   @override
-  String get welcomeBack => 'Welcome Back!';
+  String get welcomeBack => 'Welcome!';
 
   @override
   String get signInToContinue =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -722,7 +722,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pleaseLogInToAddFriends => 'Inicia sesión para agregar amigos';
 
   @override
-  String get welcomeBack => '¡Bienvenido de Nuevo!';
+  String get welcomeBack => '¡Bienvenido!';
 
   @override
   String get signInToContinue =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -729,7 +729,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Veuillez vous connecter pour ajouter des amis';
 
   @override
-  String get welcomeBack => 'Bon Retour !';
+  String get welcomeBack => 'Bienvenue !';
 
   @override
   String get signInToContinue =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -723,7 +723,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pleaseLogInToAddFriends => 'Accedi per aggiungere amici';
 
   @override
-  String get welcomeBack => 'Bentornato!';
+  String get welcomeBack => 'Benvenuto!';
 
   @override
   String get signInToContinue =>

--- a/test/unit/app/play_with_me_app_test.dart
+++ b/test/unit/app/play_with_me_app_test.dart
@@ -51,7 +51,7 @@ void main() {
       await tester.pump(); // Rebuild with new state
 
       // Should show login screen for unauthenticated users
-      expect(find.text('Welcome Back!'), findsOneWidget);
+      expect(find.text('Welcome!'), findsOneWidget);
       expect(
         find.text('Sign in to continue organizing your volleyball games'),
         findsOneWidget,
@@ -75,7 +75,7 @@ void main() {
       await tester.pump(); // Rebuild with new state
 
       // App shows authentication screen regardless of environment
-      expect(find.text('Welcome Back!'), findsOneWidget);
+      expect(find.text('Welcome!'), findsOneWidget);
       expect(
         find.text('Sign in to continue organizing your volleyball games'),
         findsOneWidget,
@@ -160,7 +160,7 @@ void main() {
         await tester.pump(); // Rebuild with new unauthenticated state
 
         // Should transition to login screen (Unauthenticated state)
-        expect(find.text('Welcome Back!'), findsOneWidget);
+        expect(find.text('Welcome!'), findsOneWidget);
         expect(
           find.text('Sign in to continue organizing your volleyball games'),
           findsOneWidget,
@@ -188,7 +188,7 @@ void main() {
         expect(find.byType(BottomNavigationBar), findsOneWidget);
 
         // Should no longer show login screen elements
-        expect(find.text('Welcome Back!'), findsNothing);
+        expect(find.text('Welcome!'), findsNothing);
         expect(
           find.text('Sign in to continue organizing your volleyball games'),
           findsNothing,

--- a/test/unit/widget_test.dart
+++ b/test/unit/widget_test.dart
@@ -54,7 +54,7 @@ void main() {
       await tester.pump();
 
       // Verify authentication UI elements are present (not old static content)
-      expect(find.text('Welcome Back!'), findsOneWidget);
+      expect(find.text('Welcome!'), findsOneWidget);
       expect(
         find.text('Sign in to continue organizing your volleyball games'),
         findsOneWidget,

--- a/test/widget/features/auth/presentation/pages/login_page_test.dart
+++ b/test/widget/features/auth/presentation/pages/login_page_test.dart
@@ -90,7 +90,7 @@ void main() {
       testWidgets('renders welcome text', (tester) async {
         await tester.pumpWidget(createTestWidget());
 
-        expect(find.text('Welcome Back!'), findsOneWidget);
+        expect(find.text('Welcome!'), findsOneWidget);
         expect(
           find.text('Sign in to continue organizing your volleyball games'),
           findsOneWidget,


### PR DESCRIPTION
## Summary
- Wrap ELO/Win Rate and Streak/Games Played rows in `IntrinsicHeight` so both cards in each pair always match the height of the taller one
- Change login page greeting from \"Welcome Back!\" to \"Welcome!\" across all 5 languages (EN, FR, DE, ES, IT)

## Test plan
- [ ] Open home page — ELO and Win Rate cards are the same height
- [ ] Open home page — Streak and Games Played cards are the same height
- [ ] Open login page — greeting shows \"Welcome!\" (or localised equivalent)