### PR TITLE
fix(ranking): prevent impossible rank display when no games played

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1392,6 +1392,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4073,9 +4086,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -4089,9 +4102,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -4101,9 +4114,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6484,9 +6498,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7142,9 +7156,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -7365,9 +7379,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8312,9 +8326,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/functions/src/calculateUserRanking.ts
+++ b/functions/src/calculateUserRanking.ts
@@ -63,6 +63,17 @@ export async function calculateUserRankingHandler(
       eloGamesPlayed,
     });
 
+    // User has not played any ELO-eligible games yet — no ranking available.
+    // Returning a rank when the user is excluded from totalUsers would produce
+    // a nonsensical result such as "16 of 15".
+    if (eloGamesPlayed === 0) {
+      functions.logger.info("User has no ELO games played, skipping ranking", {userId});
+      throw new functions.https.HttpsError(
+        "failed-precondition",
+        "No ELO games played yet."
+      );
+    }
+
     // 3 & 4. Run both count queries in parallel — they only depend on userElo
     const [higherEloCount, totalUsersSnapshot] = await Promise.all([
       db.collection("users")

--- a/functions/test/unit/calculateUserRanking.test.ts
+++ b/functions/test/unit/calculateUserRanking.test.ts
@@ -174,7 +174,7 @@ describe("calculateUserRankingHandler", () => {
     expect(result.totalUsers).toBe(5);
   });
 
-  it("handles user with default ELO (no eloRating field)", async () => {
+  it("throws failed-precondition when user has no ELO games played", async () => {
     mockDb.doc.mockReturnValue({
       get: jest.fn().mockResolvedValue({
         exists: true,
@@ -182,21 +182,11 @@ describe("calculateUserRankingHandler", () => {
       }),
     });
 
-    mockDb.collection.mockImplementation(() => {
-      const get = jest.fn().mockResolvedValue({data: () => ({count: 0})});
-      const countFn = jest.fn().mockReturnValue({get});
-      const where2 = jest.fn().mockReturnValue({count: countFn});
-      const where1 = jest.fn().mockReturnValue({where: where2, count: countFn});
-      return {where: where1};
+    await expect(
+      calculateUserRankingHandler({}, {auth: {uid: "user-123"}} as any)
+    ).rejects.toMatchObject({
+      code: "failed-precondition",
+      message: "No ELO games played yet.",
     });
-
-    const result = await calculateUserRankingHandler(
-      {},
-      {auth: {uid: "user-123"}} as any
-    );
-
-    // Default ELO is 1600, 0 users above → rank 1
-    expect(result.globalRank).toBe(1);
-    expect(typeof result.calculatedAt).toBe("number");
   });
 });

--- a/integration_test/user_ranking_calculation_test.dart
+++ b/integration_test/user_ranking_calculation_test.dart
@@ -59,7 +59,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(users[3]);
+      final ranking = (await repository.getUserRanking(users[3]))!;
 
       // 4. Verify global ranking
       expect(ranking.globalRank, equals(4)); // 3 users have higher ELO
@@ -101,7 +101,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(users[4]);
+      final ranking = (await repository.getUserRanking(users[4]))!;
 
       // 4. Verify #1 rank
       expect(ranking.globalRank, equals(1));
@@ -160,7 +160,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(mainUser.uid);
+      final ranking = (await repository.getUserRanking(mainUser.uid))!;
 
       // 6. Verify friends ranking
       // Main user (1700) should be #3 of 5 friends
@@ -211,7 +211,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(user.uid);
+      final ranking = (await repository.getUserRanking(user.uid))!;
 
       // 4. Verify no friends ranking
       expect(ranking.friendsRank, isNull);
@@ -279,7 +279,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(userWithGames2.uid);
+      final ranking = (await repository.getUserRanking(userWithGames2.uid))!;
 
       // 4. Verify only users with games are counted
       expect(ranking.totalUsers, equals(2)); // Only 2 users with games
@@ -359,7 +359,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(mainUser.uid);
+      final ranking = (await repository.getUserRanking(mainUser.uid))!;
 
       // 5. Verify only friends with games are counted
       expect(ranking.totalFriends, equals(2)); // friend1 and friend3 only
@@ -406,7 +406,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(user.uid);
+      final ranking = (await repository.getUserRanking(user.uid))!;
 
       // 3. Verify ranking for single user
       expect(ranking.globalRank, equals(1));
@@ -446,7 +446,7 @@ void main() {
         functions: FirebaseFunctions.instance,
       );
 
-      final ranking = await repository.getUserRanking(users[49]);
+      final ranking = (await repository.getUserRanking(users[49]))!;
 
       // 4. Verify percentile
       expect(ranking.globalRank, equals(50)); // 49 users have higher ELO

--- a/lib/core/data/repositories/firestore_user_repository.dart
+++ b/lib/core/data/repositories/firestore_user_repository.dart
@@ -697,7 +697,7 @@ class FirestoreUserRepository implements UserRepository {
   }
 
   @override
-  Future<UserRanking> getUserRanking(String userId) {
+  Future<UserRanking?> getUserRanking(String userId) {
     return PerformanceTracer.trace('repo_calculate_user_ranking', () async {
       try {
         final callable = _functions.httpsCallable('calculateUserRanking');
@@ -706,6 +706,9 @@ class FirestoreUserRepository implements UserRepository {
         return UserRanking.fromJson(result.data);
       } on FirebaseFunctionsException catch (e) {
         switch (e.code) {
+          case 'failed-precondition':
+            // User has not played any ELO-eligible games yet — no ranking available.
+            return null;
           case 'unauthenticated':
             throw UserException(
               'You must be logged in to view rankings',

--- a/lib/core/domain/repositories/user_repository.dart
+++ b/lib/core/domain/repositories/user_repository.dart
@@ -113,8 +113,9 @@ abstract class UserRepository {
   Stream<List<HeadToHeadStats>> getAllHeadToHeadStats(String userId);
 
   /// Get user's ranking (global, percentile, friends) via Cloud Function (Story 302.2)
-  /// Calls calculateUserRanking Cloud Function which performs cross-user queries
-  Future<UserRanking> getUserRanking(String userId);
+  /// Calls calculateUserRanking Cloud Function which performs cross-user queries.
+  /// Returns null when the user has not played any ELO-eligible games yet.
+  Future<UserRanking?> getUserRanking(String userId);
 
   /// Sync email verification status from Firebase Auth to Firestore.
   /// Called when the app detects the current user has verified their email.

--- a/lib/features/profile/presentation/widgets/ranking_stats_cards.dart
+++ b/lib/features/profile/presentation/widgets/ranking_stats_cards.dart
@@ -21,20 +21,16 @@ class RankingStatsCards extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (ranking == null) {
-      return _buildEmptyState(context);
-    }
-
     return LayoutBuilder(
       builder: (context, constraints) {
         if (constraints.maxWidth < 280) {
           return Column(
             children: [
-              _GlobalRankCard(ranking: ranking!),
+              _GlobalRankCard(ranking: ranking),
               const SizedBox(height: 8),
-              _PercentileCard(ranking: ranking!),
+              _PercentileCard(ranking: ranking),
               const SizedBox(height: 8),
-              _FriendsRankCard(ranking: ranking!),
+              _FriendsRankCard(ranking: ranking),
               const SizedBox(height: 8),
               _StreakCard(currentStreak: currentStreak),
             ],
@@ -43,11 +39,11 @@ class RankingStatsCards extends StatelessWidget {
 
         return Row(
           children: [
-            Expanded(child: _GlobalRankCard(ranking: ranking!)),
+            Expanded(child: _GlobalRankCard(ranking: ranking)),
             const SizedBox(width: 6),
-            Expanded(child: _PercentileCard(ranking: ranking!)),
+            Expanded(child: _PercentileCard(ranking: ranking)),
             const SizedBox(width: 6),
-            Expanded(child: _FriendsRankCard(ranking: ranking!)),
+            Expanded(child: _FriendsRankCard(ranking: ranking)),
             const SizedBox(width: 6),
             Expanded(child: _StreakCard(currentStreak: currentStreak)),
           ],
@@ -55,39 +51,11 @@ class RankingStatsCards extends StatelessWidget {
       },
     );
   }
-
-  Widget _buildEmptyState(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.lock_outline,
-            size: 20,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(width: 8),
-          Text(
-            AppLocalizations.of(context)!.playGamesToUnlockRankings,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 /// Global ranking card
 class _GlobalRankCard extends StatelessWidget {
-  final UserRanking ranking;
+  final UserRanking? ranking;
 
   const _GlobalRankCard({required this.ranking});
 
@@ -97,14 +65,14 @@ class _GlobalRankCard extends StatelessWidget {
       icon: Icons.public,
       iconColor: AppColors.secondary,
       label: AppLocalizations.of(context)!.globalRank,
-      value: ranking.globalRankDisplay,
+      value: ranking?.globalRankDisplay ?? '-',
     );
   }
 }
 
 /// Percentile card — uses a gaussian curve painter instead of a Material icon.
 class _PercentileCard extends StatelessWidget {
-  final UserRanking ranking;
+  final UserRanking? ranking;
 
   const _PercentileCard({required this.ranking});
 
@@ -119,14 +87,14 @@ class _PercentileCard extends StatelessWidget {
         ),
       ),
       label: AppLocalizations.of(context)!.percentile,
-      value: ranking.percentileDisplay,
+      value: ranking?.percentileDisplay ?? '-',
     );
   }
 }
 
 /// Friends ranking card
 class _FriendsRankCard extends StatelessWidget {
-  final UserRanking ranking;
+  final UserRanking? ranking;
 
   const _FriendsRankCard({required this.ranking});
 
@@ -136,9 +104,7 @@ class _FriendsRankCard extends StatelessWidget {
       icon: Icons.people,
       iconColor: AppColors.secondary,
       label: AppLocalizations.of(context)!.friendsRank,
-      value: ranking.friendsRank != null && ranking.totalFriends != null
-          ? ranking.friendsRankDisplay!
-          : '-',
+      value: ranking?.friendsRankDisplay ?? '-',
     );
   }
 }

--- a/test/unit/core/data/repositories/firestore_user_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_user_repository_test.dart
@@ -1303,6 +1303,23 @@ void main() {
           ),
         );
       });
+
+      test('returns null when user has no ELO games played (failed-precondition)', () async {
+        final mockCallable = MockHttpsCallable();
+
+        when(
+          () => mockFunctions.httpsCallable('calculateUserRanking'),
+        ).thenReturn(mockCallable);
+        when(() => mockCallable.call<Map<String, dynamic>>()).thenThrow(
+          FirebaseFunctionsException(
+            code: 'failed-precondition',
+            message: 'No ELO games played yet.',
+          ),
+        );
+
+        final result = await repository.getUserRanking(testUserId);
+        expect(result, isNull);
+      });
     });
 
     group('getTeammateStats', () {

--- a/test/widget/features/profile/presentation/widgets/ranking_stats_cards_test.dart
+++ b/test/widget/features/profile/presentation/widgets/ranking_stats_cards_test.dart
@@ -8,7 +8,7 @@ import 'package:play_with_me/features/profile/presentation/widgets/ranking_stats
 
 void main() {
   group('RankingStatsCards', () {
-    testWidgets('shows empty state when ranking is null', (tester) async {
+    testWidgets('shows dash for all ranking cards when ranking is null', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: const [
@@ -22,8 +22,11 @@ void main() {
         ),
       );
 
-      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
-      expect(find.text('Play games to unlock rankings'), findsOneWidget);
+      // All three ranking cards (global rank, percentile, friends rank) show '-'
+      // Streak card also shows '-' when currentStreak is 0 (default)
+      expect(find.text('-'), findsNWidgets(4));
+      expect(find.byIcon(Icons.lock_outline), findsNothing);
+      expect(find.text('Play games to unlock rankings'), findsNothing);
     });
 
     testWidgets('displays global rank correctly', (tester) async {


### PR DESCRIPTION
## Summary

- `calculateUserRanking` Cloud Function now throws `failed-precondition` when `eloGamesPlayed === 0`, preventing the nonsensical "16/15" rank that occurred because users with 0 games were excluded from `totalUsers` but still assigned a `globalRank`
- `getUserRanking` in the repository maps `failed-precondition` to `null` (other errors still throw)
- `RankingStatsCards` always renders all four cards and shows `'-'` when ranking is null, replacing the lock-icon empty state

## Test plan

- [ ] Cloud Function unit test: `failed-precondition` thrown when `eloGamesPlayed === 0`
- [ ] Repository unit test: `failed-precondition` response returns `null`
- [ ] Widget test: all four ranking cards show `'-'` when ranking is null