### PR TITLE
Story 14.15: In-game chat — Flutter UI in game details page

### DIFF
--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -8,6 +8,7 @@ import 'package:cloud_functions/cloud_functions.dart';
 
 import '../../domain/exceptions/repository_exceptions.dart';
 import '../../domain/repositories/game_repository.dart';
+import '../models/chat_message_model.dart';
 import '../models/game_model.dart';
 
 class FirestoreGameRepository implements GameRepository {
@@ -1610,6 +1611,70 @@ class FirestoreGameRepository implements GameRepository {
       );
     } catch (e) {
       throw GameException('Failed to get completed games: $e', code: 'unknown');
+    }
+  }
+
+  @override
+  Stream<List<ChatMessageModel>> getMessages(String gameId) {
+    try {
+      return _firestore
+          .collection(_collection)
+          .doc(gameId)
+          .collection('messages')
+          .orderBy('sentAt', descending: false)
+          .snapshots()
+          .map(
+            (snapshot) => snapshot.docs
+                .map((doc) => ChatMessageModel.fromFirestore(doc))
+                .toList(),
+          )
+          .handleError((error) {
+            if (error is FirebaseException) {
+              throw GameException(
+                'Failed to stream messages: ${error.message}',
+                code: error.code,
+              );
+            }
+            throw GameException(
+              'Failed to stream messages: $error',
+              code: 'stream-error',
+            );
+          });
+    } catch (e) {
+      throw GameException(
+        'Failed to stream messages: $e',
+        code: 'stream-error',
+      );
+    }
+  }
+
+  @override
+  Future<void> sendMessage({
+    required String gameId,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+  }) async {
+    try {
+      final message = ChatMessageModel(
+        id: '',
+        senderId: senderId,
+        senderDisplayName: senderDisplayName,
+        text: text,
+        sentAt: DateTime.now(),
+      );
+      await _firestore
+          .collection(_collection)
+          .doc(gameId)
+          .collection('messages')
+          .add(message.toFirestore());
+    } on FirebaseException catch (e) {
+      throw GameException(
+        'Failed to send message: ${e.message}',
+        code: e.code,
+      );
+    } catch (e) {
+      throw GameException('Failed to send message: $e');
     }
   }
 }

--- a/lib/core/domain/repositories/game_repository.dart
+++ b/lib/core/domain/repositories/game_repository.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../../data/models/chat_message_model.dart';
 import '../../data/models/game_model.dart';
 
 abstract class GameRepository {
@@ -186,6 +187,17 @@ abstract class GameRepository {
     DateTime? startDate,
     DateTime? endDate,
     DocumentSnapshot? lastDocument,
+  });
+
+  /// Stream real-time messages for a game (ordered by sentAt ascending)
+  Stream<List<ChatMessageModel>> getMessages(String gameId);
+
+  /// Send a message to the game chat
+  Future<void> sendMessage({
+    required String gameId,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
   });
 }
 

--- a/lib/features/games/presentation/bloc/game_chat/game_chat_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_chat/game_chat_bloc.dart
@@ -1,0 +1,73 @@
+// Manages real-time in-game chat messages and send actions.
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'game_chat_event.dart';
+import 'game_chat_state.dart';
+
+class GameChatBloc extends Bloc<GameChatEvent, GameChatState> {
+  final GameRepository _gameRepository;
+  StreamSubscription<dynamic>? _messagesSubscription;
+
+  GameChatBloc({required GameRepository gameRepository})
+      : _gameRepository = gameRepository,
+        super(const GameChatInitial()) {
+    on<LoadGameChat>(_onLoadGameChat);
+    on<GameChatMessagesUpdated>(_onMessagesUpdated);
+    on<SendChatMessage>(_onSendChatMessage);
+  }
+
+  Future<void> _onLoadGameChat(
+    LoadGameChat event,
+    Emitter<GameChatState> emit,
+  ) async {
+    emit(const GameChatLoading());
+    await _messagesSubscription?.cancel();
+    _messagesSubscription = _gameRepository.getMessages(event.gameId).listen(
+      (messages) => add(GameChatMessagesUpdated(messages: messages)),
+      onError: (_) => add(const GameChatMessagesUpdated(messages: [])),
+    );
+  }
+
+  void _onMessagesUpdated(
+    GameChatMessagesUpdated event,
+    Emitter<GameChatState> emit,
+  ) {
+    final isSending =
+        state is GameChatLoaded ? (state as GameChatLoaded).isSending : false;
+    emit(GameChatLoaded(messages: event.messages, isSending: isSending));
+  }
+
+  Future<void> _onSendChatMessage(
+    SendChatMessage event,
+    Emitter<GameChatState> emit,
+  ) async {
+    if (state is! GameChatLoaded) return;
+    final current = state as GameChatLoaded;
+    emit(current.copyWith(isSending: true));
+    try {
+      await _gameRepository.sendMessage(
+        gameId: event.gameId,
+        senderId: event.senderId,
+        senderDisplayName: event.senderDisplayName,
+        text: event.text,
+      );
+      // Stream will update messages; just clear sending flag
+      emit(current.copyWith(isSending: false));
+    } on GameException catch (e) {
+      emit(current.copyWith(isSending: false));
+      // Don't emit error — just restore state (snackbar handled in widget)
+      addError(Exception(e.message));
+    } catch (e) {
+      emit(current.copyWith(isSending: false));
+      addError(e is Exception ? e : Exception(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _messagesSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/games/presentation/bloc/game_chat/game_chat_event.dart
+++ b/lib/features/games/presentation/bloc/game_chat/game_chat_event.dart
@@ -1,0 +1,38 @@
+// Events for GameChatBloc managing in-game chat.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+
+abstract class GameChatEvent extends Equatable {
+  const GameChatEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadGameChat extends GameChatEvent {
+  final String gameId;
+  const LoadGameChat({required this.gameId});
+  @override
+  List<Object?> get props => [gameId];
+}
+
+class GameChatMessagesUpdated extends GameChatEvent {
+  final List<ChatMessageModel> messages;
+  const GameChatMessagesUpdated({required this.messages});
+  @override
+  List<Object?> get props => [messages];
+}
+
+class SendChatMessage extends GameChatEvent {
+  final String gameId;
+  final String senderId;
+  final String senderDisplayName;
+  final String text;
+  const SendChatMessage({
+    required this.gameId,
+    required this.senderId,
+    required this.senderDisplayName,
+    required this.text,
+  });
+  @override
+  List<Object?> get props => [gameId, senderId, senderDisplayName, text];
+}

--- a/lib/features/games/presentation/bloc/game_chat/game_chat_state.dart
+++ b/lib/features/games/presentation/bloc/game_chat/game_chat_state.dart
@@ -1,0 +1,41 @@
+// States for GameChatBloc managing in-game chat.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+
+abstract class GameChatState extends Equatable {
+  const GameChatState();
+  @override
+  List<Object?> get props => [];
+}
+
+class GameChatInitial extends GameChatState {
+  const GameChatInitial();
+}
+
+class GameChatLoading extends GameChatState {
+  const GameChatLoading();
+}
+
+class GameChatLoaded extends GameChatState {
+  final List<ChatMessageModel> messages;
+  final bool isSending;
+
+  const GameChatLoaded({required this.messages, this.isSending = false});
+
+  @override
+  List<Object?> get props => [messages, isSending];
+
+  GameChatLoaded copyWith({List<ChatMessageModel>? messages, bool? isSending}) {
+    return GameChatLoaded(
+      messages: messages ?? this.messages,
+      isSending: isSending ?? this.isSending,
+    );
+  }
+}
+
+class GameChatError extends GameChatState {
+  final String message;
+  const GameChatError({required this.message});
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/games/presentation/pages/game_details_page.dart
+++ b/lib/features/games/presentation/pages/game_details_page.dart
@@ -24,6 +24,7 @@ import '../bloc/game_details/game_details_bloc.dart';
 import '../bloc/game_details/game_details_event.dart';
 import '../bloc/game_details/game_details_state.dart';
 import '../bloc/game_guest_invitation/game_guest_invitation_bloc.dart';
+import '../widgets/game_chat_section.dart';
 import '../widgets/invite_guest_players_sheet.dart';
 import 'score_entry_page.dart';
 import 'game_result_view_page.dart';
@@ -226,6 +227,8 @@ class _GameDetailsView extends StatelessWidget {
                     const SizedBox(height: 16),
                   ],
                   _PlayersCard(game: game),
+                  const SizedBox(height: 16),
+                  _ChatSectionWrapper(game: game),
                 ],
               ),
             ),
@@ -240,6 +243,26 @@ class _GameDetailsView extends StatelessWidget {
     }
 
     return const SizedBox.shrink();
+  }
+}
+
+class _ChatSectionWrapper extends StatelessWidget {
+  final GameModel game;
+  const _ChatSectionWrapper({required this.game});
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = context.read<AuthenticationBloc>().state;
+    if (authState is! AuthenticationAuthenticated) return const SizedBox.shrink();
+    final currentUserId = authState.user.uid;
+    final currentUserDisplayName = authState.user.displayNameOrEmail;
+    final isPlayer = game.isPlayer(currentUserId);
+    return GameChatSection(
+      gameId: game.id,
+      currentUserId: currentUserId,
+      currentUserDisplayName: currentUserDisplayName,
+      isPlayer: isPlayer,
+    );
   }
 }
 

--- a/lib/features/games/presentation/widgets/game_chat_section.dart
+++ b/lib/features/games/presentation/widgets/game_chat_section.dart
@@ -1,0 +1,351 @@
+// Widget displaying the in-game chat section with real-time messages and send input.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+import '../bloc/game_chat/game_chat_bloc.dart';
+import '../bloc/game_chat/game_chat_event.dart';
+import '../bloc/game_chat/game_chat_state.dart';
+
+class GameChatSection extends StatelessWidget {
+  final String gameId;
+  final String currentUserId;
+  final String currentUserDisplayName;
+  final bool isPlayer;
+  final GameRepository? gameRepository;
+
+  const GameChatSection({
+    super.key,
+    required this.gameId,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+    required this.isPlayer,
+    this.gameRepository,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => GameChatBloc(
+        gameRepository: gameRepository ?? sl<GameRepository>(),
+      )..add(LoadGameChat(gameId: gameId)),
+      child: _GameChatView(
+        gameId: gameId,
+        currentUserId: currentUserId,
+        currentUserDisplayName: currentUserDisplayName,
+        isPlayer: isPlayer,
+      ),
+    );
+  }
+}
+
+class _GameChatView extends StatefulWidget {
+  final String gameId;
+  final String currentUserId;
+  final String currentUserDisplayName;
+  final bool isPlayer;
+
+  const _GameChatView({
+    required this.gameId,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+    required this.isPlayer,
+  });
+
+  @override
+  State<_GameChatView> createState() => _GameChatViewState();
+}
+
+class _GameChatViewState extends State<_GameChatView> {
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _sendMessage(BuildContext context) {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
+    _textController.clear();
+    context.read<GameChatBloc>().add(
+      SendChatMessage(
+        gameId: widget.gameId,
+        senderId: widget.currentUserId,
+        senderDisplayName: widget.currentUserDisplayName,
+        text: text,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(
+                  Icons.chat_bubble_outline,
+                  color: AppColors.secondary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  l10n.chatSectionTitle,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.secondary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            BlocConsumer<GameChatBloc, GameChatState>(
+              listener: (context, state) {
+                if (state is GameChatLoaded) {
+                  _scrollToBottom();
+                }
+              },
+              builder: (context, state) {
+                if (state is GameChatLoading || state is GameChatInitial) {
+                  return const SizedBox(
+                    height: 120,
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+
+                final messages = state is GameChatLoaded
+                    ? state.messages
+                    : <ChatMessageModel>[];
+                final isSending =
+                    state is GameChatLoaded ? state.isSending : false;
+
+                return Column(
+                  children: [
+                    SizedBox(
+                      height: 240,
+                      child: messages.isEmpty
+                          ? Center(
+                              child: Text(
+                                l10n.chatEmpty,
+                                style: Theme.of(
+                                  context,
+                                ).textTheme.bodyMedium?.copyWith(
+                                  color: AppColors.textMuted,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                            )
+                          : ListView.builder(
+                              controller: _scrollController,
+                              itemCount: messages.length,
+                              itemBuilder: (context, index) => _MessageBubble(
+                                message: messages[index],
+                                isCurrentUser:
+                                    messages[index].senderId ==
+                                    widget.currentUserId,
+                              ),
+                            ),
+                    ),
+                    const SizedBox(height: 8),
+                    if (widget.isPlayer)
+                      _ChatInput(
+                        controller: _textController,
+                        isSending: isSending,
+                        onSend: () => _sendMessage(context),
+                        hint: l10n.chatInputHint,
+                      )
+                    else
+                      Text(
+                        l10n.chatPlayersOnly,
+                        style: Theme.of(
+                          context,
+                        ).textTheme.bodySmall?.copyWith(
+                          color: AppColors.textMuted,
+                          fontStyle: FontStyle.italic,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  final ChatMessageModel message;
+  final bool isCurrentUser;
+
+  const _MessageBubble({required this.message, required this.isCurrentUser});
+
+  @override
+  Widget build(BuildContext context) {
+    final timeFormat = DateFormat('HH:mm');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Align(
+        alignment:
+            isCurrentUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: Column(
+          crossAxisAlignment: isCurrentUser
+              ? CrossAxisAlignment.end
+              : CrossAxisAlignment.start,
+          children: [
+            if (!isCurrentUser)
+              Padding(
+                padding: const EdgeInsets.only(left: 8, bottom: 2),
+                child: Text(
+                  message.senderDisplayName,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: AppColors.textMuted,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            Row(
+              mainAxisAlignment: isCurrentUser
+                  ? MainAxisAlignment.end
+                  : MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                if (!isCurrentUser) const SizedBox(width: 4),
+                Flexible(
+                  child: Container(
+                    constraints: BoxConstraints(
+                      maxWidth: MediaQuery.of(context).size.width * 0.65,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: isCurrentUser
+                          ? AppColors.secondary
+                          : AppColors.divider,
+                      borderRadius: BorderRadius.only(
+                        topLeft: const Radius.circular(16),
+                        topRight: const Radius.circular(16),
+                        bottomLeft: Radius.circular(isCurrentUser ? 16 : 4),
+                        bottomRight: Radius.circular(isCurrentUser ? 4 : 16),
+                      ),
+                    ),
+                    child: Text(
+                      message.text,
+                      style: TextStyle(
+                        color: isCurrentUser
+                            ? Colors.white
+                            : AppColors.onSurface,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  timeFormat.format(message.sentAt),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: AppColors.textMuted,
+                    fontSize: 10,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatInput extends StatelessWidget {
+  final TextEditingController controller;
+  final bool isSending;
+  final VoidCallback onSend;
+  final String hint;
+
+  const _ChatInput({
+    required this.controller,
+    required this.isSending,
+    required this.onSend,
+    required this.hint,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: const TextStyle(color: AppColors.textMuted),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(24),
+                borderSide: const BorderSide(color: AppColors.divider),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(24),
+                borderSide: const BorderSide(color: AppColors.divider),
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 10,
+              ),
+              isDense: true,
+            ),
+            maxLines: null,
+            textInputAction: TextInputAction.send,
+            onSubmitted: (_) => onSend(),
+            enabled: !isSending,
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton(
+          onPressed: isSending ? null : onSend,
+          icon: isSending
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.send),
+          color: AppColors.secondary,
+          style: IconButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            shape: const CircleBorder(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -706,5 +706,14 @@
   "vsLabel": "vs",
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
-  }
+  },
+
+  "chatSectionTitle": "Chat",
+  "@chatSectionTitle": {},
+  "chatInputHint": "Nachricht eingeben...",
+  "@chatInputHint": {},
+  "chatEmpty": "Noch keine Nachrichten. Sei der Erste!",
+  "@chatEmpty": {},
+  "chatPlayersOnly": "Nur Spieler können Nachrichten senden",
+  "@chatPlayersOnly": {}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2941,5 +2941,22 @@
   "vsLabel": "vs",
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
+  },
+
+  "chatSectionTitle": "Chat",
+  "@chatSectionTitle": {
+    "description": "Title of the in-game chat section on the game details page"
+  },
+  "chatInputHint": "Type a message...",
+  "@chatInputHint": {
+    "description": "Hint text in the chat message input field"
+  },
+  "chatEmpty": "No messages yet. Be the first to say something!",
+  "@chatEmpty": {
+    "description": "Placeholder shown when game chat has no messages"
+  },
+  "chatPlayersOnly": "Only players can send messages",
+  "@chatPlayersOnly": {
+    "description": "Message shown to non-players instead of the chat input"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -706,5 +706,14 @@
   "vsLabel": "vs",
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
-  }
+  },
+
+  "chatSectionTitle": "Chat",
+  "@chatSectionTitle": {},
+  "chatInputHint": "Escribe un mensaje...",
+  "@chatInputHint": {},
+  "chatEmpty": "Sin mensajes aún. ¡Sé el primero en decir algo!",
+  "@chatEmpty": {},
+  "chatPlayersOnly": "Solo los jugadores pueden enviar mensajes",
+  "@chatPlayersOnly": {}
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -706,5 +706,14 @@
   "vsLabel": "vs",
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
-  }
+  },
+
+  "chatSectionTitle": "Chat",
+  "@chatSectionTitle": {},
+  "chatInputHint": "Écris un message...",
+  "@chatInputHint": {},
+  "chatEmpty": "Aucun message pour l'instant. Sois le premier à dire quelque chose !",
+  "@chatEmpty": {},
+  "chatPlayersOnly": "Seuls les joueurs peuvent envoyer des messages",
+  "@chatPlayersOnly": {}
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -706,5 +706,14 @@
   "vsLabel": "vs",
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
-  }
+  },
+
+  "chatSectionTitle": "Chat",
+  "@chatSectionTitle": {},
+  "chatInputHint": "Scrivi un messaggio...",
+  "@chatInputHint": {},
+  "chatEmpty": "Nessun messaggio ancora. Sii il primo a dire qualcosa!",
+  "@chatEmpty": {},
+  "chatPlayersOnly": "Solo i giocatori possono inviare messaggi",
+  "@chatPlayersOnly": {}
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3745,6 +3745,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'vs'**
   String get vsLabel;
+
+  /// Title of the in-game chat section on the game details page
+  ///
+  /// In en, this message translates to:
+  /// **'Chat'**
+  String get chatSectionTitle;
+
+  /// Hint text in the chat message input field
+  ///
+  /// In en, this message translates to:
+  /// **'Type a message...'**
+  String get chatInputHint;
+
+  /// Placeholder shown when game chat has no messages
+  ///
+  /// In en, this message translates to:
+  /// **'No messages yet. Be the first to say something!'**
+  String get chatEmpty;
+
+  /// Message shown to non-players instead of the chat input
+  ///
+  /// In en, this message translates to:
+  /// **'Only players can send messages'**
+  String get chatPlayersOnly;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2052,4 +2052,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get vsLabel => 'vs';
+
+  @override
+  String get chatSectionTitle => 'Chat';
+
+  @override
+  String get chatInputHint => 'Nachricht eingeben...';
+
+  @override
+  String get chatEmpty => 'Noch keine Nachrichten. Sei der Erste!';
+
+  @override
+  String get chatPlayersOnly => 'Nur Spieler können Nachrichten senden';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2014,4 +2014,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get vsLabel => 'vs';
+
+  @override
+  String get chatSectionTitle => 'Chat';
+
+  @override
+  String get chatInputHint => 'Type a message...';
+
+  @override
+  String get chatEmpty => 'No messages yet. Be the first to say something!';
+
+  @override
+  String get chatPlayersOnly => 'Only players can send messages';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2042,4 +2042,16 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get vsLabel => 'vs';
+
+  @override
+  String get chatSectionTitle => 'Chat';
+
+  @override
+  String get chatInputHint => 'Escribe un mensaje...';
+
+  @override
+  String get chatEmpty => 'Sin mensajes aún. ¡Sé el primero en decir algo!';
+
+  @override
+  String get chatPlayersOnly => 'Solo los jugadores pueden enviar mensajes';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2055,4 +2055,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get vsLabel => 'vs';
+
+  @override
+  String get chatSectionTitle => 'Chat';
+
+  @override
+  String get chatInputHint => 'Écris un message...';
+
+  @override
+  String get chatEmpty =>
+      'Aucun message pour l\'instant. Sois le premier à dire quelque chose !';
+
+  @override
+  String get chatPlayersOnly =>
+      'Seuls les joueurs peuvent envoyer des messages';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2034,4 +2034,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get vsLabel => 'vs';
+
+  @override
+  String get chatSectionTitle => 'Chat';
+
+  @override
+  String get chatInputHint => 'Scrivi un messaggio...';
+
+  @override
+  String get chatEmpty =>
+      'Nessun messaggio ancora. Sii il primo a dire qualcosa!';
+
+  @override
+  String get chatPlayersOnly => 'Solo i giocatori possono inviare messaggi';
 }

--- a/test/unit/core/data/repositories/mock_game_repository.dart
+++ b/test/unit/core/data/repositories/mock_game_repository.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart' as cloud_firestore;
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 
@@ -748,6 +749,19 @@ class MockGameRepository implements GameRepository {
 
     return controller.stream;
   }
+
+  @override
+  Stream<List<ChatMessageModel>> getMessages(String gameId) {
+    return Stream.value([]);
+  }
+
+  @override
+  Future<void> sendMessage({
+    required String gameId,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+  }) async {}
 }
 
 // Test data helpers

--- a/test/unit/features/games/presentation/bloc/game_chat/game_chat_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/game_chat/game_chat_bloc_test.dart
@@ -1,0 +1,109 @@
+// Validates GameChatBloc state transitions for chat loading and sending.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_bloc.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_event.dart';
+import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_state.dart';
+
+class MockGameRepository extends Mock implements GameRepository {}
+
+void main() {
+  late MockGameRepository mockGameRepository;
+
+  final testMessage = ChatMessageModel(
+    id: 'msg-1',
+    senderId: 'user-1',
+    senderDisplayName: 'Alice',
+    text: 'Hello!',
+    sentAt: DateTime(2025, 1, 1, 12, 0),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(Stream<List<ChatMessageModel>>.empty());
+  });
+
+  setUp(() {
+    mockGameRepository = MockGameRepository();
+  });
+
+  group('GameChatBloc', () {
+    group('LoadGameChat', () {
+      blocTest<GameChatBloc, GameChatState>(
+        'emits [loading, loaded] with messages from stream',
+        build: () {
+          when(() => mockGameRepository.getMessages('game-1'))
+              .thenAnswer((_) => Stream.value([testMessage]));
+          return GameChatBloc(gameRepository: mockGameRepository);
+        },
+        act: (bloc) => bloc.add(const LoadGameChat(gameId: 'game-1')),
+        expect: () => [
+          const GameChatLoading(),
+          GameChatLoaded(messages: [testMessage]),
+        ],
+      );
+
+      blocTest<GameChatBloc, GameChatState>(
+        'emits [loading, loaded with empty list] on stream error',
+        build: () {
+          when(() => mockGameRepository.getMessages('game-1'))
+              .thenAnswer((_) => Stream.error(Exception('error')));
+          return GameChatBloc(gameRepository: mockGameRepository);
+        },
+        act: (bloc) => bloc.add(const LoadGameChat(gameId: 'game-1')),
+        expect: () => [
+          const GameChatLoading(),
+          const GameChatLoaded(messages: []),
+        ],
+      );
+    });
+
+    group('SendChatMessage', () {
+      blocTest<GameChatBloc, GameChatState>(
+        'sends message and clears isSending flag',
+        build: () {
+          when(() => mockGameRepository.getMessages('game-1'))
+              .thenAnswer((_) => Stream.value([testMessage]));
+          when(
+            () => mockGameRepository.sendMessage(
+              gameId: any(named: 'gameId'),
+              senderId: any(named: 'senderId'),
+              senderDisplayName: any(named: 'senderDisplayName'),
+              text: any(named: 'text'),
+            ),
+          ).thenAnswer((_) async {});
+          return GameChatBloc(gameRepository: mockGameRepository);
+        },
+        seed: () => GameChatLoaded(messages: [testMessage]),
+        act: (bloc) => bloc.add(
+          const SendChatMessage(
+            gameId: 'game-1',
+            senderId: 'user-1',
+            senderDisplayName: 'Alice',
+            text: 'Hello!',
+          ),
+        ),
+        expect: () => [
+          GameChatLoaded(messages: [testMessage], isSending: true),
+          GameChatLoaded(messages: [testMessage], isSending: false),
+        ],
+      );
+
+      blocTest<GameChatBloc, GameChatState>(
+        'does nothing when state is not loaded',
+        build: () => GameChatBloc(gameRepository: mockGameRepository),
+        act: (bloc) => bloc.add(
+          const SendChatMessage(
+            gameId: 'game-1',
+            senderId: 'user-1',
+            senderDisplayName: 'Alice',
+            text: 'Hello!',
+          ),
+        ),
+        expect: () => [],
+      );
+    });
+  });
+}

--- a/test/widget/features/games/presentation/pages/game_details_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_page_test.dart
@@ -9,6 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
@@ -53,6 +54,7 @@ void main() {
 
     await sl.reset();
     sl.registerLazySingleton<FirebaseAnalytics>(() => mockAnalytics);
+    sl.registerLazySingleton<GameRepository>(() => mockGameRepository);
     when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
     when(
       () => mockInvitationBloc.stream,

--- a/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
+++ b/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
@@ -1,0 +1,179 @@
+// Widget tests for GameChatSection verifying message rendering and send interaction.
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/features/games/presentation/widgets/game_chat_section.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+// Minimal fake repository for widget tests — no streams, no Firebase.
+class _FakeGameRepository implements GameRepository {
+  final List<ChatMessageModel> messages;
+  final List<Map<String, String>> sentMessages = [];
+
+  _FakeGameRepository({this.messages = const []});
+
+  @override
+  Stream<List<ChatMessageModel>> getMessages(String gameId) =>
+      Stream.value(messages);
+
+  @override
+  Future<void> sendMessage({
+    required String gameId,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+  }) async {
+    sentMessages.add({
+      'gameId': gameId,
+      'senderId': senderId,
+      'senderDisplayName': senderDisplayName,
+      'text': text,
+    });
+  }
+
+  // All other methods throw UnimplementedError — they are not used by GameChatSection.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+        '${invocation.memberName} is not implemented in _FakeGameRepository',
+      );
+}
+
+Widget _buildWidget({
+  required _FakeGameRepository repo,
+  bool isPlayer = true,
+}) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en')],
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: GameChatSection(
+          gameId: 'game-1',
+          currentUserId: 'current-user',
+          currentUserDisplayName: 'Alice',
+          isPlayer: isPlayer,
+          gameRepository: repo,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  final messageFromOther = ChatMessageModel(
+    id: 'msg-1',
+    senderId: 'other-user',
+    senderDisplayName: 'Bob',
+    text: 'Hello team!',
+    sentAt: DateTime(2025, 1, 1, 12, 0),
+  );
+
+  final messageFromSelf = ChatMessageModel(
+    id: 'msg-2',
+    senderId: 'current-user',
+    senderDisplayName: 'Alice',
+    text: 'Ready to play!',
+    sentAt: DateTime(2025, 1, 1, 12, 1),
+  );
+
+  group('GameChatSection', () {
+    testWidgets('shows empty message when no messages', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+      expect(
+        find.text('No messages yet. Be the first to say something!'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders other user messages', (tester) async {
+      final repo = _FakeGameRepository(messages: [messageFromOther]);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+      expect(find.text('Hello team!'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+    });
+
+    testWidgets('renders own messages without sender name', (tester) async {
+      final repo = _FakeGameRepository(messages: [messageFromSelf]);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+      expect(find.text('Ready to play!'), findsOneWidget);
+      // Own messages don't show the sender name above the bubble
+      expect(find.text('Alice'), findsNothing);
+    });
+
+    testWidgets('shows input field for players', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo, isPlayer: true));
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byIcon(Icons.send), findsOneWidget);
+    });
+
+    testWidgets('shows players-only message for non-players', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo, isPlayer: false));
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('Only players can send messages'), findsOneWidget);
+    });
+
+    testWidgets('send button calls sendMessage on repository', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Hello!');
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump();
+
+      expect(repo.sentMessages, hasLength(1));
+      expect(repo.sentMessages.first['text'], 'Hello!');
+      expect(repo.sentMessages.first['gameId'], 'game-1');
+      expect(repo.sentMessages.first['senderId'], 'current-user');
+      expect(repo.sentMessages.first['senderDisplayName'], 'Alice');
+    });
+
+    testWidgets('shows chat section title', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+      expect(find.text('Chat'), findsOneWidget);
+    });
+
+    testWidgets('clears text field after sending', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Test message');
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump();
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller?.text, isEmpty);
+    });
+
+    testWidgets('does not send empty message', (tester) async {
+      final repo = _FakeGameRepository(messages: []);
+      await tester.pumpWidget(_buildWidget(repo: repo));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump();
+
+      expect(repo.sentMessages, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `GameChatSection` widget to game details page with real-time Firestore message stream
- Add `getMessages` and `sendMessage` to `GameRepository`; implemented in `FirestoreGameRepository`
- New `GameChatBloc` manages stream subscription and send actions (separate from `GameDetailsBloc`)
- Current user's messages aligned right (dark `#004E64` bubbles), others aligned left (light bubbles); sender name shown on others' messages only
- Non-players see "Only players can send messages" instead of the input field
- Chat section appears below the players card in the game details scrollable content
- Localized in 5 languages (EN, FR, DE, ES, IT)

## Test plan
- [ ] Run unit tests: `flutter test test/unit/`
- [ ] Run widget tests: `flutter test test/widget/`
- [ ] Open a game in dev as a player — verify chat loads, messages render, and sending works in real time
- [ ] Verify non-player sees read-only view (no input field)
- [ ] Verify new messages auto-scroll to bottom of the message list

Closes #737