### PR TITLE
Story 14.16: Chat message push notifications (Cloud Function)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -79,6 +79,7 @@ export {
   onWaitlistPromoted,
   onGameResultSubmitted, // Story 14.15
   onGameCancelled,
+  onChatMessageCreated, // Story 14.16 (chat message notification)
 } from "./notifications";
 
 // Export game update triggers

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -2686,3 +2686,181 @@ export const onGameCancelled = functions.region('europe-west6').firestore
       return null;
     }
   });
+
+/**
+ * Send notification to all players in a game when a new chat message is created.
+ * Skips the sender. Respects notification preferences and quiet hours.
+ */
+export const onChatMessageCreated = functions
+  .region("europe-west6")
+  .firestore.document("games/{gameId}/messages/{messageId}")
+  .onCreate(async (snapshot, context) => {
+    const messageData = snapshot.data();
+    const gameId = context.params.gameId;
+
+    if (!messageData) {
+      functions.logger.warn("[onChatMessageCreated] Message data missing", { gameId });
+      return null;
+    }
+
+    const senderId: string = messageData.senderId;
+    const senderDisplayName: string = messageData.senderDisplayName || "Someone";
+    const text: string = messageData.text || "";
+
+    // Truncate message body for the notification (max 100 chars)
+    const bodyText = text.length > 100 ? `${text.substring(0, 97)}...` : text;
+
+    functions.logger.info("[onChatMessageCreated] New chat message, processing notifications", {
+      gameId,
+      senderId,
+    });
+
+    try {
+      // Fetch the parent game to get playerIds and groupId
+      const gameDoc = await admin.firestore().collection("games").doc(gameId).get();
+      if (!gameDoc.exists) {
+        functions.logger.warn("[onChatMessageCreated] Game not found", { gameId });
+        return null;
+      }
+
+      const gameData = gameDoc.data()!;
+      const playerIds: string[] = gameData.playerIds || [];
+      const groupId: string = gameData.groupId || "";
+
+      if (playerIds.length === 0) {
+        functions.logger.info("[onChatMessageCreated] No players to notify", { gameId });
+        return null;
+      }
+
+      // Track tokens per user for later invalid-token cleanup
+      const userTokenMap = new Map<string, string[]>();
+      const allTokens: string[] = [];
+
+      for (const playerId of playerIds) {
+        // Don't notify the sender
+        if (playerId === senderId) continue;
+
+        const playerDoc = await admin.firestore().collection("users").doc(playerId).get();
+        const playerData = playerDoc.data();
+        if (!playerData) continue;
+
+        const fcmTokens: string[] = playerData.fcmTokens || [];
+        if (fcmTokens.length === 0) continue;
+
+        const prefs = playerData.notificationPreferences || {};
+        const groupPrefs = prefs.groupSpecific?.[groupId];
+        const shouldNotify =
+          groupPrefs?.chatMessage !== false && prefs.chatMessage !== false;
+
+        if (!shouldNotify) {
+          functions.logger.debug("[onChatMessageCreated] Player disabled chat notifications", {
+            playerId,
+            gameId,
+          });
+          continue;
+        }
+
+        if (isQuietHours(prefs.quietHours)) {
+          functions.logger.debug("[onChatMessageCreated] Player in quiet hours", {
+            playerId,
+            gameId,
+          });
+          continue;
+        }
+
+        userTokenMap.set(playerId, fcmTokens);
+        allTokens.push(...fcmTokens);
+      }
+
+      if (allTokens.length === 0) {
+        functions.logger.info("[onChatMessageCreated] No tokens to notify", { gameId });
+        return null;
+      }
+
+      const message: admin.messaging.MulticastMessage = {
+        tokens: allTokens,
+        notification: {
+          title: `${senderDisplayName} in ${gameData.title || "your game"}`,
+          body: bodyText,
+        },
+        data: {
+          type: "chat_message",
+          gameId,
+          groupId,
+          senderId,
+          senderDisplayName,
+        },
+        android: {
+          priority: "high",
+          notification: {
+            channelId: "high_importance_channel",
+            clickAction: "FLUTTER_NOTIFICATION_CLICK",
+          },
+        },
+        apns: {
+          payload: {
+            aps: {
+              badge: 1,
+              sound: "default",
+            },
+          },
+        },
+      };
+
+      const response = await admin.messaging().sendEachForMulticast(message);
+
+      functions.logger.info("[onChatMessageCreated] Notification sent", {
+        gameId,
+        senderId,
+        successCount: response.successCount,
+        failureCount: response.failureCount,
+      });
+
+      // Remove invalid tokens
+      if (response.failureCount > 0) {
+        const invalidTokensByUser = new Map<string, string[]>();
+
+        response.responses.forEach((resp, idx) => {
+          if (
+            !resp.success &&
+            (resp.error?.code === "messaging/invalid-registration-token" ||
+              resp.error?.code === "messaging/registration-token-not-registered")
+          ) {
+            const invalidToken = allTokens[idx];
+            for (const [userId, tokens] of userTokenMap.entries()) {
+              if (tokens.includes(invalidToken)) {
+                if (!invalidTokensByUser.has(userId)) {
+                  invalidTokensByUser.set(userId, []);
+                }
+                invalidTokensByUser.get(userId)!.push(invalidToken);
+                break;
+              }
+            }
+          }
+        });
+
+        for (const [userId, tokensToRemove] of invalidTokensByUser.entries()) {
+          await admin
+            .firestore()
+            .collection("users")
+            .doc(userId)
+            .update({
+              fcmTokens: admin.firestore.FieldValue.arrayRemove(...tokensToRemove),
+            });
+          functions.logger.info("[onChatMessageCreated] Removed invalid FCM tokens", {
+            userId,
+            gameId,
+            removedCount: tokensToRemove.length,
+          });
+        }
+      }
+
+      return null;
+    } catch (error) {
+      functions.logger.error("[onChatMessageCreated] Error sending chat notification", {
+        gameId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  });

--- a/functions/test/unit/onChatMessageCreated.test.ts
+++ b/functions/test/unit/onChatMessageCreated.test.ts
@@ -1,0 +1,351 @@
+// Unit tests for onChatMessageCreated Firestore trigger
+// Validates that chat message notifications are sent to all players except the sender,
+// respecting notification preferences and quiet hours.
+
+import * as admin from "firebase-admin";
+
+// ── Mock firebase-admin ──────────────────────────────────────────────────────
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+          arrayRemove: jest.fn((...elements: any[]) => ({
+            _methodName: "FieldValue.arrayRemove",
+            _elements: elements,
+          })),
+        },
+      }
+    ),
+    messaging: jest.fn(() => ({
+      sendEachForMulticast: jest.fn(),
+    })),
+  };
+});
+
+// ── Mock firebase-functions ──────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    firestore: {
+      document: jest.fn(() => ({
+        onCreate: jest.fn((h: any) => h),
+        onUpdate: jest.fn((h: any) => h),
+        onDelete: jest.fn((h: any) => h),
+      })),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+  fn.region = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSnapshot(data: Record<string, any> | null) {
+  return { data: () => data ?? undefined } as any;
+}
+
+function makeContext(gameId = "game-1", messageId = "msg-1") {
+  return { params: { gameId, messageId } } as any;
+}
+
+function makeGameDoc(exists: boolean, playerIds: string[], groupId = "group-1", title = "Beach Volleyball") {
+  return {
+    exists,
+    data: () => exists ? { playerIds, groupId, title } : undefined,
+  };
+}
+
+function makeUserDoc(exists: boolean, fcmTokens: string[], prefs: Record<string, any> = {}) {
+  return {
+    exists,
+    data: () => exists ? { fcmTokens, notificationPreferences: prefs } : undefined,
+  };
+}
+
+function buildDb(gameDoc: any, userDocs: Record<string, any>, updateMock = jest.fn()) {
+  const db: any = {
+    collection: jest.fn((col: string) => {
+      if (col === "games") {
+        return {
+          doc: jest.fn(() => ({ get: jest.fn().mockResolvedValue(gameDoc) })),
+        };
+      }
+      // "users" collection
+      return {
+        doc: jest.fn((userId: string) => ({
+          get: jest.fn().mockResolvedValue(userDocs[userId] ?? makeUserDoc(false, [])),
+          update: updateMock,
+        })),
+      };
+    }),
+  };
+  return db;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("onChatMessageCreated", () => {
+  let mockMessaging: any;
+  let handler: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockMessaging = {
+      sendEachForMulticast: jest.fn().mockResolvedValue({
+        successCount: 1,
+        failureCount: 0,
+        responses: [{ success: true }],
+      }),
+    };
+    (admin.messaging as jest.Mock).mockReturnValue(mockMessaging);
+
+    // Import handler fresh each test (mocks reset above)
+    const mod = await import("../../src/notifications");
+    handler = (mod as any).onChatMessageCreated;
+  });
+
+  // ── Guard conditions ──────────────────────────────────────────────────────
+
+  describe("no-op conditions", () => {
+    it("does nothing when message data is missing", async () => {
+      const db = buildDb(makeGameDoc(true, ["player-1"]), {});
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(makeSnapshot(null), makeContext());
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when game is not found", async () => {
+      const db = buildDb(makeGameDoc(false, []), {});
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "user-1", senderDisplayName: "Alice", text: "Hi" }),
+        makeContext()
+      );
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when game has no players", async () => {
+      const db = buildDb(makeGameDoc(true, []), {});
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "user-1", senderDisplayName: "Alice", text: "Hi" }),
+        makeContext()
+      );
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when all players are the sender", async () => {
+      const db = buildDb(makeGameDoc(true, ["user-1"]), {
+        "user-1": makeUserDoc(true, ["token-1"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "user-1", senderDisplayName: "Alice", text: "Hi" }),
+        makeContext()
+      );
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no players have FCM tokens", async () => {
+      const db = buildDb(makeGameDoc(true, ["user-1", "user-2"]), {
+        "user-1": makeUserDoc(true, []),
+        "user-2": makeUserDoc(true, []),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "user-1", senderDisplayName: "Alice", text: "Hi" }),
+        makeContext()
+      );
+
+      expect(mockMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Notification sending ──────────────────────────────────────────────────
+
+  describe("notification sending", () => {
+    it("sends notification to all players except the sender", async () => {
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2", "player-3"]), {
+        "player-2": makeUserDoc(true, ["token-p2"]),
+        "player-3": makeUserDoc(true, ["token-p3"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+      mockMessaging.sendEachForMulticast.mockResolvedValue({
+        successCount: 2,
+        failureCount: 0,
+        responses: [{ success: true }, { success: true }],
+      });
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "See you at 6!" }),
+        makeContext()
+      );
+
+      expect(mockMessaging.sendEachForMulticast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokens: expect.arrayContaining(["token-p2", "token-p3"]),
+          notification: expect.objectContaining({
+            title: "Alice in Beach Volleyball",
+            body: "See you at 6!",
+          }),
+          data: expect.objectContaining({
+            type: "chat_message",
+            gameId: "game-1",
+            senderId: "sender",
+          }),
+        })
+      );
+    });
+
+    it("truncates long message body to 100 characters in notification", async () => {
+      const longText = "A".repeat(150);
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2"]), {
+        "player-2": makeUserDoc(true, ["token-p2"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: longText }),
+        makeContext()
+      );
+
+      const call = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(call.notification.body.length).toBe(100);
+      expect(call.notification.body.endsWith("...")).toBe(true);
+    });
+
+    it("skips player who has disabled chat notifications", async () => {
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2", "player-3"]), {
+        "player-2": makeUserDoc(true, ["token-p2"], { chatMessage: false }),
+        "player-3": makeUserDoc(true, ["token-p3"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "Hi!" }),
+        makeContext()
+      );
+
+      const call = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(call.tokens).toEqual(["token-p3"]);
+      expect(call.tokens).not.toContain("token-p2");
+    });
+
+    it("skips player who has disabled chat notifications at group level", async () => {
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2", "player-3"]), {
+        "player-2": makeUserDoc(true, ["token-p2"], {
+          groupSpecific: { "group-1": { chatMessage: false } },
+        }),
+        "player-3": makeUserDoc(true, ["token-p3"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "Hi!" }),
+        makeContext()
+      );
+
+      const call = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(call.tokens).toEqual(["token-p3"]);
+    });
+
+    it("skips player in quiet hours", async () => {
+      // Set quiet hours to span the full day so any time falls in them
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2", "player-3"]), {
+        "player-2": makeUserDoc(true, ["token-p2"], {
+          quietHours: { enabled: true, start: "00:00", end: "23:59" },
+        }),
+        "player-3": makeUserDoc(true, ["token-p3"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "Hi!" }),
+        makeContext()
+      );
+
+      const call = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(call.tokens).toEqual(["token-p3"]);
+    });
+
+    it("includes correct data payload fields", async () => {
+      const db = buildDb(makeGameDoc(true, ["sender", "player-2"], "grp-99"), {
+        "player-2": makeUserDoc(true, ["token-p2"]),
+      });
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "Ready!" }),
+        makeContext("game-42", "msg-99")
+      );
+
+      const call = mockMessaging.sendEachForMulticast.mock.calls[0][0];
+      expect(call.data).toEqual(
+        expect.objectContaining({
+          type: "chat_message",
+          gameId: "game-42",
+          groupId: "grp-99",
+          senderId: "sender",
+          senderDisplayName: "Alice",
+        })
+      );
+    });
+  });
+
+  // ── Invalid token cleanup ─────────────────────────────────────────────────
+
+  describe("invalid token cleanup", () => {
+    it("removes invalid FCM tokens after failed delivery", async () => {
+      const updateMock = jest.fn().mockResolvedValue(undefined);
+      const db = buildDb(
+        makeGameDoc(true, ["sender", "player-2"]),
+        { "player-2": makeUserDoc(true, ["bad-token"]) },
+        updateMock
+      );
+      (admin.firestore as unknown as jest.Mock).mockReturnValue(db);
+
+      mockMessaging.sendEachForMulticast.mockResolvedValue({
+        successCount: 0,
+        failureCount: 1,
+        responses: [
+          { success: false, error: { code: "messaging/registration-token-not-registered" } },
+        ],
+      });
+
+      await handler(
+        makeSnapshot({ senderId: "sender", senderDisplayName: "Alice", text: "Hi!" }),
+        makeContext()
+      );
+
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fcmTokens: expect.objectContaining({ _methodName: "FieldValue.arrayRemove" }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `onChatMessageCreated` Firestore trigger in `functions/src/notifications.ts` that sends FCM push notifications to all game players except the sender
- Respects per-user and per-group `chatMessage` notification preferences and quiet-hours settings
- Automatically removes invalid/expired FCM tokens from user documents after failed delivery

## Tests
- 12 unit tests covering: guard conditions (no data, game not found, no players, sender-only, no tokens), notification payload shape, preference filtering (global + group-level), quiet hours, and invalid token cleanup
- All 531 Cloud Function tests pass

## Test plan
- [ ] CI passes (functions unit tests + Flutter tests)
- [ ] Push notification arrives for a game player when another player sends a chat message
- [ ] No notification sent to the sender
- [ ] Notification suppressed when `chatMessage: false` set globally or at group level
- [ ] Notification suppressed during quiet hours window
- [ ] Invalid token removed from user document after `messaging/registration-token-not-registered` error