### PR TITLE
fix(firestore): add missing composite index for updateAccountStatuses query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -189,6 +189,24 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "accountStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "emailVerifiedAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "gracePeriodExpiresAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "eloRating",
           "order": "DESCENDING"
         },


### PR DESCRIPTION
## Summary
- Adds missing Firestore composite index for the `updateAccountStatuses` scheduled function
- The function queries `users` by `accountStatus`, `emailVerifiedAt`, and `gracePeriodExpiresAt` — this compound query requires a composite index that was not defined
- Without this index, the function threw `FAILED_PRECONDITION` on every daily run

## Test plan
- [ ] Index deployed to prod via `firebase deploy --only firestore:indexes --project gatherli-prod` (already done)
- [ ] `updateAccountStatuses` daily scheduled function runs without `FAILED_PRECONDITION` error
- [ ] Verify in Firebase Console → Firestore → Indexes that the index is active