### PR TITLE
fix(hosting): add Play App Signing certificate to assetlinks.json

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "org.gatherli.app",
       "sha256_cert_fingerprints": [
-        "E1:4B:57:EE:BE:70:F0:CB:B4:02:AA:A6:E6:61:CB:A6:7F:F1:35:08:1F:87:AC:00:50:BB:39:4B:8C:52:85:9A"
+        "E1:4B:57:EE:BE:70:F0:CB:B4:02:AA:A6:E6:61:CB:A6:7F:F1:35:08:1F:87:AC:00:50:BB:39:4B:8C:52:85:9A",
+        "FC:E6:54:90:53:BA:08:A4:00:40:F8:94:D5:EE:4C:11:15:60:4A:67:A4:DD:AC:1E:6D:BA:F2:09:36:6B:9D:F2"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Adds the Play App Signing certificate SHA-256 fingerprint to `public/.well-known/assetlinks.json`
- Play Console uses the App Signing certificate (managed by Google) to sign production APKs, not the upload key — the previous `assetlinks.json` only contained the upload key fingerprint, causing Android App Links domain validation to fail in Play Console
- Both fingerprints are now present so deep links work for both sideloaded (upload key) and Play Store (App Signing) builds

## Test plan
- [ ] Deployed to prod hosting via `firebase deploy --only hosting --project gatherli-prod` (already done)
- [ ] Verified with Google's Digital Asset Links API — both fingerprints return `"linked": true`
- [ ] Play Console → App Integrity → App Links should now show domain verified
- [ ] Invite deep links open correctly on Android devices installed from Play Store