### PR TITLE
fix(chat): show join-to-view message to non-players instead of empty chat

### DIFF
--- a/lib/features/games/presentation/widgets/game_chat_section.dart
+++ b/lib/features/games/presentation/widgets/game_chat_section.dart
@@ -124,76 +124,79 @@ class _GameChatViewState extends State<_GameChatView> {
               ],
             ),
             const SizedBox(height: 12),
-            BlocConsumer<GameChatBloc, GameChatState>(
-              listener: (context, state) {
-                if (state is GameChatLoaded) {
-                  _scrollToBottom();
-                }
-              },
-              builder: (context, state) {
-                if (state is GameChatLoading || state is GameChatInitial) {
-                  return const SizedBox(
-                    height: 120,
-                    child: Center(child: CircularProgressIndicator()),
-                  );
-                }
-
-                final messages = state is GameChatLoaded
-                    ? state.messages
-                    : <ChatMessageModel>[];
-                final isSending =
-                    state is GameChatLoaded ? state.isSending : false;
-
-                return Column(
-                  children: [
-                    SizedBox(
-                      height: 240,
-                      child: messages.isEmpty
-                          ? Center(
-                              child: Text(
-                                l10n.chatEmpty,
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.bodyMedium?.copyWith(
-                                  color: AppColors.textMuted,
-                                ),
-                                textAlign: TextAlign.center,
-                              ),
-                            )
-                          : ListView.builder(
-                              controller: _scrollController,
-                              itemCount: messages.length,
-                              itemBuilder: (context, index) => _MessageBubble(
-                                message: messages[index],
-                                isCurrentUser:
-                                    messages[index].senderId ==
-                                    widget.currentUserId,
-                              ),
-                            ),
+            if (!widget.isPlayer)
+              SizedBox(
+                height: 80,
+                child: Center(
+                  child: Text(
+                    l10n.chatJoinToView,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textMuted,
+                      fontStyle: FontStyle.italic,
                     ),
-                    const SizedBox(height: 8),
-                    if (widget.isPlayer)
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              )
+            else
+              BlocConsumer<GameChatBloc, GameChatState>(
+                listener: (context, state) {
+                  if (state is GameChatLoaded) {
+                    _scrollToBottom();
+                  }
+                },
+                builder: (context, state) {
+                  if (state is GameChatLoading || state is GameChatInitial) {
+                    return const SizedBox(
+                      height: 120,
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+
+                  final messages = state is GameChatLoaded
+                      ? state.messages
+                      : <ChatMessageModel>[];
+                  final isSending =
+                      state is GameChatLoaded ? state.isSending : false;
+
+                  return Column(
+                    children: [
+                      SizedBox(
+                        height: 240,
+                        child: messages.isEmpty
+                            ? Center(
+                                child: Text(
+                                  l10n.chatEmpty,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.bodyMedium?.copyWith(
+                                    color: AppColors.textMuted,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              )
+                            : ListView.builder(
+                                controller: _scrollController,
+                                itemCount: messages.length,
+                                itemBuilder: (context, index) => _MessageBubble(
+                                  message: messages[index],
+                                  isCurrentUser:
+                                      messages[index].senderId ==
+                                      widget.currentUserId,
+                                ),
+                              ),
+                      ),
+                      const SizedBox(height: 8),
                       _ChatInput(
                         controller: _textController,
                         isSending: isSending,
                         onSend: () => _sendMessage(context),
                         hint: l10n.chatInputHint,
-                      )
-                    else
-                      Text(
-                        l10n.chatPlayersOnly,
-                        style: Theme.of(
-                          context,
-                        ).textTheme.bodySmall?.copyWith(
-                          color: AppColors.textMuted,
-                          fontStyle: FontStyle.italic,
-                        ),
-                        textAlign: TextAlign.center,
                       ),
-                  ],
-                );
-              },
-            ),
+                    ],
+                  );
+                },
+              ),
           ],
         ),
       ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -715,5 +715,7 @@
   "chatEmpty": "Noch keine Nachrichten. Sei der Erste!",
   "@chatEmpty": {},
   "chatPlayersOnly": "Nur Spieler können Nachrichten senden",
-  "@chatPlayersOnly": {}
+  "@chatPlayersOnly": {},
+  "chatJoinToView": "Du musst dem Spiel beitreten, um den Chat zu sehen",
+  "@chatJoinToView": {}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2958,5 +2958,9 @@
   "chatPlayersOnly": "Only players can send messages",
   "@chatPlayersOnly": {
     "description": "Message shown to non-players instead of the chat input"
+  },
+  "chatJoinToView": "You need to join the game to see the chat",
+  "@chatJoinToView": {
+    "description": "Message shown to users who are not in the game and cannot see the chat"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -715,5 +715,7 @@
   "chatEmpty": "Sin mensajes aún. ¡Sé el primero en decir algo!",
   "@chatEmpty": {},
   "chatPlayersOnly": "Solo los jugadores pueden enviar mensajes",
-  "@chatPlayersOnly": {}
+  "@chatPlayersOnly": {},
+  "chatJoinToView": "Debes unirte al juego para ver el chat",
+  "@chatJoinToView": {}
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -715,5 +715,7 @@
   "chatEmpty": "Aucun message pour l'instant. Sois le premier à dire quelque chose !",
   "@chatEmpty": {},
   "chatPlayersOnly": "Seuls les joueurs peuvent envoyer des messages",
-  "@chatPlayersOnly": {}
+  "@chatPlayersOnly": {},
+  "chatJoinToView": "Vous devez rejoindre la partie pour voir le chat",
+  "@chatJoinToView": {}
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -715,5 +715,7 @@
   "chatEmpty": "Nessun messaggio ancora. Sii il primo a dire qualcosa!",
   "@chatEmpty": {},
   "chatPlayersOnly": "Solo i giocatori possono inviare messaggi",
-  "@chatPlayersOnly": {}
+  "@chatPlayersOnly": {},
+  "chatJoinToView": "Devi unirti alla partita per vedere la chat",
+  "@chatJoinToView": {}
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3769,6 +3769,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Only players can send messages'**
   String get chatPlayersOnly;
+
+  /// Message shown to users who are not in the game and cannot see the chat
+  ///
+  /// In en, this message translates to:
+  /// **'You need to join the game to see the chat'**
+  String get chatJoinToView;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2064,4 +2064,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatPlayersOnly => 'Nur Spieler können Nachrichten senden';
+
+  @override
+  String get chatJoinToView =>
+      'Du musst dem Spiel beitreten, um den Chat zu sehen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2026,4 +2026,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chatPlayersOnly => 'Only players can send messages';
+
+  @override
+  String get chatJoinToView => 'You need to join the game to see the chat';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2054,4 +2054,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get chatPlayersOnly => 'Solo los jugadores pueden enviar mensajes';
+
+  @override
+  String get chatJoinToView => 'Debes unirte al juego para ver el chat';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2069,4 +2069,8 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get chatPlayersOnly =>
       'Seuls les joueurs peuvent envoyer des messages';
+
+  @override
+  String get chatJoinToView =>
+      'Vous devez rejoindre la partie pour voir le chat';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2047,4 +2047,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get chatPlayersOnly => 'Solo i giocatori possono inviare messaggi';
+
+  @override
+  String get chatJoinToView => 'Devi unirti alla partita per vedere la chat';
 }

--- a/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
+++ b/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
@@ -119,12 +119,13 @@ void main() {
       expect(find.byIcon(Icons.send), findsOneWidget);
     });
 
-    testWidgets('shows players-only message for non-players', (tester) async {
+    testWidgets('shows join-to-view message for non-players instead of chat', (tester) async {
       final repo = _FakeGameRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo, isPlayer: false));
       await tester.pumpAndSettle();
       expect(find.byType(TextField), findsNothing);
-      expect(find.text('Only players can send messages'), findsOneWidget);
+      expect(find.text('You need to join the game to see the chat'), findsOneWidget);
+      expect(find.text('Only players can send messages'), findsNothing);
     });
 
     testWidgets('send button calls sendMessage on repository', (tester) async {


### PR DESCRIPTION
## Summary
- Non-players no longer see the chat history or the "Only players can send messages" hint
- Instead they see a single centered message: "You need to join the game to see the chat"
- The `GameChatBloc` is never created for non-players, avoiding an unnecessary Firestore stream subscription
- Localized in all 5 languages (EN, FR, DE, ES, IT) via new `chatJoinToView` ARB key
- Widget test updated to assert the new non-player behaviour

## Test plan
- [ ] As a non-player, open a game detail page → see "You need to join the game to see the chat" (no chat history, no input field)
- [ ] As a player, open a game detail page → full chat works as before
- [ ] Run `flutter test test/widget/features/games/presentation/widgets/game_chat_section_test.dart`
- [ ] Verify all 5 locales render the join-to-view message correctly