### PR TITLE
feat(groups): remove gameIds array from GroupModel and eliminate dual-write (Story 31.2)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -136,3 +136,6 @@ export {getGameInvitationsForUser} from "./getGameInvitationsForUser"; // Story 
 // Story 14.16: Delete chat messages when game is completed
 export {onGameCompletedDeleteChatMessages} from "./deleteChatMessages";
 
+// Story 31.2: One-time migration — remove deprecated gameIds array from group documents
+export {migrateRemoveGroupGameIds} from "./migrateRemoveGroupGameIds";
+

--- a/functions/src/migrateRemoveGroupGameIds.ts
+++ b/functions/src/migrateRemoveGroupGameIds.ts
@@ -1,0 +1,172 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+/**
+ * Response interface for migrateRemoveGroupGameIds Cloud Function
+ */
+export interface MigrateRemoveGroupGameIdsResponse {
+  success: boolean;
+  message: string;
+  groupsProcessed: number;
+  groupsUpdated: number;
+}
+
+/**
+ * Handler function for migrateRemoveGroupGameIds (exported for testing)
+ *
+ * One-time migration: removes the `gameIds` field from all group documents.
+ *
+ * Background:
+ * - GroupModel previously stored `gameIds: List<String>` — an unbounded array
+ *   of every game ID ever created in the group.
+ * - This field is redundant because every GameModel already stores `groupId`,
+ *   and games are queried via `games.where('groupId', isEqualTo: groupId)`.
+ * - Story 31.2 removes this field from the Flutter model and all write paths.
+ * - This function cleans up existing Firestore documents in production.
+ *
+ * Safety:
+ * - Idempotent: skips documents that do not have the `gameIds` field.
+ * - Restricted to admin users only (uid must be in the allowedAdmins list or
+ *   the function must be called from a trusted context).
+ * - Processes groups in batches of 400 (Firestore batch limit is 500).
+ * - Returns a summary of how many documents were processed and updated.
+ *
+ * Deployment order:
+ * 1. Deploy this function to dev, verify output.
+ * 2. Deploy updated Flutter client (without gameIds reads/writes).
+ * 3. Run this migration on prod.
+ * 4. Optionally delete this function after migration is confirmed.
+ *
+ * @param _data - Not used; no input required
+ * @param context - Firebase Functions context with auth information
+ * @returns Promise resolving to MigrateRemoveGroupGameIdsResponse
+ */
+export async function migrateRemoveGroupGameIdsHandler(
+  _data: unknown,
+  context: functions.https.CallableContext
+): Promise<MigrateRemoveGroupGameIdsResponse> {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be authenticated to run this migration."
+    );
+  }
+
+  const callerUid = context.auth.uid;
+
+  // Restrict to admin users by checking the custom claim or a hardcoded list.
+  // Using a Firestore-based admin check to avoid shipping UIDs in source code.
+  const db = admin.firestore();
+  const adminDoc = await db.collection("appAdmins").doc(callerUid).get();
+  if (!adminDoc.exists) {
+    functions.logger.warn("[migrateRemoveGroupGameIds] Unauthorized attempt", {
+      callerUid,
+    });
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Only app admins can run data migrations."
+    );
+  }
+
+  functions.logger.info("[migrateRemoveGroupGameIds] Migration started", {
+    callerUid,
+  });
+
+  let groupsProcessed = 0;
+  let groupsUpdated = 0;
+  const batchSize = 400;
+
+  try {
+    // Paginate through all group documents
+    let lastDoc: admin.firestore.QueryDocumentSnapshot | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      let query = db.collection("groups").limit(batchSize);
+      if (lastDoc) {
+        query = query.startAfter(lastDoc);
+      }
+
+      const snapshot = await query.get();
+
+      if (snapshot.empty) {
+        hasMore = false;
+        break;
+      }
+
+      // Collect documents that still have the gameIds field
+      const docsToUpdate: admin.firestore.QueryDocumentSnapshot[] = [];
+      for (const doc of snapshot.docs) {
+        groupsProcessed++;
+        const data = doc.data();
+        if ("gameIds" in data) {
+          docsToUpdate.push(doc);
+        }
+      }
+
+      // Write in a single batch per page
+      if (docsToUpdate.length > 0) {
+        const batch = db.batch();
+        for (const doc of docsToUpdate) {
+          batch.update(doc.ref, {
+            gameIds: admin.firestore.FieldValue.delete(),
+          });
+          groupsUpdated++;
+        }
+        await batch.commit();
+
+        functions.logger.info(
+          `[migrateRemoveGroupGameIds] Batch committed: removed gameIds from ${docsToUpdate.length} groups`,
+          {batchSize: docsToUpdate.length, totalUpdatedSoFar: groupsUpdated}
+        );
+      }
+
+      lastDoc = snapshot.docs[snapshot.docs.length - 1];
+      hasMore = snapshot.docs.length === batchSize;
+    }
+
+    functions.logger.info("[migrateRemoveGroupGameIds] Migration complete", {
+      callerUid,
+      groupsProcessed,
+      groupsUpdated,
+    });
+
+    return {
+      success: true,
+      message: `Migration complete. Processed ${groupsProcessed} groups, removed gameIds from ${groupsUpdated}.`,
+      groupsProcessed,
+      groupsUpdated,
+    };
+  } catch (error) {
+    functions.logger.error("[migrateRemoveGroupGameIds] Migration failed", {
+      callerUid,
+      groupsProcessed,
+      groupsUpdated,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    throw new functions.https.HttpsError(
+      "internal",
+      `Migration failed after processing ${groupsProcessed} groups (${groupsUpdated} updated). Error: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+/**
+ * One-time callable Cloud Function to remove the deprecated `gameIds` array
+ * from all group documents in Firestore.
+ *
+ * See migrateRemoveGroupGameIdsHandler for full documentation.
+ *
+ * Restricted to app admins only (caller uid must exist in `appAdmins` collection).
+ */
+export const migrateRemoveGroupGameIds = functions
+  .region("europe-west6")
+  .runWith({
+    timeoutSeconds: 540, // Max 9 minutes — enough for large group collections
+    memory: "512MB",
+  })
+  .https.onCall(migrateRemoveGroupGameIdsHandler);

--- a/lib/core/data/models/group_model.dart
+++ b/lib/core/data/models/group_model.dart
@@ -18,7 +18,6 @@ class GroupModel with _$GroupModel {
     @NullableTimestampConverter() DateTime? updatedAt,
     @Default([]) List<String> memberIds,
     @Default([]) List<String> adminIds,
-    @Default([]) List<String> gameIds,
     @Default(GroupPrivacy.private) GroupPrivacy privacy,
     @Default(false) bool requiresApproval,
     @Default(20) int maxMembers,
@@ -172,26 +171,6 @@ class GroupModel with _$GroupModel {
     }
     return copyWith(
       adminIds: adminIds.where((id) => id != userId).toList(),
-      updatedAt: DateTime.now(),
-      lastActivity: DateTime.now(),
-    );
-  }
-
-  /// Add a game to the group
-  GroupModel addGame(String gameId) {
-    if (gameIds.contains(gameId)) return this;
-    return copyWith(
-      gameIds: [...gameIds, gameId],
-      totalGamesPlayed: totalGamesPlayed + 1,
-      updatedAt: DateTime.now(),
-      lastActivity: DateTime.now(),
-    );
-  }
-
-  /// Remove a game from the group
-  GroupModel removeGame(String gameId) {
-    return copyWith(
-      gameIds: gameIds.where((id) => id != gameId).toList(),
       updatedAt: DateTime.now(),
       lastActivity: DateTime.now(),
     );

--- a/lib/core/data/models/group_model.freezed.dart
+++ b/lib/core/data/models/group_model.freezed.dart
@@ -32,7 +32,6 @@ mixin _$GroupModel {
   DateTime? get updatedAt => throw _privateConstructorUsedError;
   List<String> get memberIds => throw _privateConstructorUsedError;
   List<String> get adminIds => throw _privateConstructorUsedError;
-  List<String> get gameIds => throw _privateConstructorUsedError;
   GroupPrivacy get privacy => throw _privateConstructorUsedError;
   bool get requiresApproval => throw _privateConstructorUsedError;
   int get maxMembers => throw _privateConstructorUsedError;
@@ -72,7 +71,6 @@ abstract class $GroupModelCopyWith<$Res> {
     @NullableTimestampConverter() DateTime? updatedAt,
     List<String> memberIds,
     List<String> adminIds,
-    List<String> gameIds,
     GroupPrivacy privacy,
     bool requiresApproval,
     int maxMembers,
@@ -109,7 +107,6 @@ class _$GroupModelCopyWithImpl<$Res, $Val extends GroupModel>
     Object? updatedAt = freezed,
     Object? memberIds = null,
     Object? adminIds = null,
-    Object? gameIds = null,
     Object? privacy = null,
     Object? requiresApproval = null,
     Object? maxMembers = null,
@@ -157,10 +154,6 @@ class _$GroupModelCopyWithImpl<$Res, $Val extends GroupModel>
             adminIds: null == adminIds
                 ? _value.adminIds
                 : adminIds // ignore: cast_nullable_to_non_nullable
-                      as List<String>,
-            gameIds: null == gameIds
-                ? _value.gameIds
-                : gameIds // ignore: cast_nullable_to_non_nullable
                       as List<String>,
             privacy: null == privacy
                 ? _value.privacy
@@ -223,7 +216,6 @@ abstract class _$$GroupModelImplCopyWith<$Res>
     @NullableTimestampConverter() DateTime? updatedAt,
     List<String> memberIds,
     List<String> adminIds,
-    List<String> gameIds,
     GroupPrivacy privacy,
     bool requiresApproval,
     int maxMembers,
@@ -259,7 +251,6 @@ class __$$GroupModelImplCopyWithImpl<$Res>
     Object? updatedAt = freezed,
     Object? memberIds = null,
     Object? adminIds = null,
-    Object? gameIds = null,
     Object? privacy = null,
     Object? requiresApproval = null,
     Object? maxMembers = null,
@@ -307,10 +298,6 @@ class __$$GroupModelImplCopyWithImpl<$Res>
         adminIds: null == adminIds
             ? _value._adminIds
             : adminIds // ignore: cast_nullable_to_non_nullable
-                  as List<String>,
-        gameIds: null == gameIds
-            ? _value._gameIds
-            : gameIds // ignore: cast_nullable_to_non_nullable
                   as List<String>,
         privacy: null == privacy
             ? _value.privacy
@@ -366,7 +353,6 @@ class _$GroupModelImpl extends _GroupModel {
     @NullableTimestampConverter() this.updatedAt,
     final List<String> memberIds = const [],
     final List<String> adminIds = const [],
-    final List<String> gameIds = const [],
     this.privacy = GroupPrivacy.private,
     this.requiresApproval = false,
     this.maxMembers = 20,
@@ -378,7 +364,6 @@ class _$GroupModelImpl extends _GroupModel {
     @NullableTimestampConverter() this.lastActivity,
   }) : _memberIds = memberIds,
        _adminIds = adminIds,
-       _gameIds = gameIds,
        super._();
 
   factory _$GroupModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -418,15 +403,6 @@ class _$GroupModelImpl extends _GroupModel {
     return EqualUnmodifiableListView(_adminIds);
   }
 
-  final List<String> _gameIds;
-  @override
-  @JsonKey()
-  List<String> get gameIds {
-    if (_gameIds is EqualUnmodifiableListView) return _gameIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_gameIds);
-  }
-
   @override
   @JsonKey()
   final GroupPrivacy privacy;
@@ -458,7 +434,7 @@ class _$GroupModelImpl extends _GroupModel {
 
   @override
   String toString() {
-    return 'GroupModel(id: $id, name: $name, description: $description, photoUrl: $photoUrl, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, memberIds: $memberIds, adminIds: $adminIds, gameIds: $gameIds, privacy: $privacy, requiresApproval: $requiresApproval, maxMembers: $maxMembers, location: $location, allowMembersToCreateGames: $allowMembersToCreateGames, allowMembersToInviteOthers: $allowMembersToInviteOthers, notifyMembersOfNewGames: $notifyMembersOfNewGames, totalGamesPlayed: $totalGamesPlayed, lastActivity: $lastActivity)';
+    return 'GroupModel(id: $id, name: $name, description: $description, photoUrl: $photoUrl, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, memberIds: $memberIds, adminIds: $adminIds, privacy: $privacy, requiresApproval: $requiresApproval, maxMembers: $maxMembers, location: $location, allowMembersToCreateGames: $allowMembersToCreateGames, allowMembersToInviteOthers: $allowMembersToInviteOthers, notifyMembersOfNewGames: $notifyMembersOfNewGames, totalGamesPlayed: $totalGamesPlayed, lastActivity: $lastActivity)';
   }
 
   @override
@@ -483,7 +459,6 @@ class _$GroupModelImpl extends _GroupModel {
               _memberIds,
             ) &&
             const DeepCollectionEquality().equals(other._adminIds, _adminIds) &&
-            const DeepCollectionEquality().equals(other._gameIds, _gameIds) &&
             (identical(other.privacy, privacy) || other.privacy == privacy) &&
             (identical(other.requiresApproval, requiresApproval) ||
                 other.requiresApproval == requiresApproval) &&
@@ -515,7 +490,7 @@ class _$GroupModelImpl extends _GroupModel {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hashAll([
+  int get hashCode => Object.hash(
     runtimeType,
     id,
     name,
@@ -526,7 +501,6 @@ class _$GroupModelImpl extends _GroupModel {
     updatedAt,
     const DeepCollectionEquality().hash(_memberIds),
     const DeepCollectionEquality().hash(_adminIds),
-    const DeepCollectionEquality().hash(_gameIds),
     privacy,
     requiresApproval,
     maxMembers,
@@ -536,7 +510,7 @@ class _$GroupModelImpl extends _GroupModel {
     notifyMembersOfNewGames,
     totalGamesPlayed,
     lastActivity,
-  ]);
+  );
 
   /// Create a copy of GroupModel
   /// with the given fields replaced by the non-null parameter values.
@@ -563,7 +537,6 @@ abstract class _GroupModel extends GroupModel {
     @NullableTimestampConverter() final DateTime? updatedAt,
     final List<String> memberIds,
     final List<String> adminIds,
-    final List<String> gameIds,
     final GroupPrivacy privacy,
     final bool requiresApproval,
     final int maxMembers,
@@ -599,8 +572,6 @@ abstract class _GroupModel extends GroupModel {
   List<String> get memberIds;
   @override
   List<String> get adminIds;
-  @override
-  List<String> get gameIds;
   @override
   GroupPrivacy get privacy;
   @override

--- a/lib/core/data/models/group_model.g.dart
+++ b/lib/core/data/models/group_model.g.dart
@@ -22,9 +22,6 @@ _$GroupModelImpl _$$GroupModelImplFromJson(
   adminIds:
       (json['adminIds'] as List<dynamic>?)?.map((e) => e as String).toList() ??
       const [],
-  gameIds:
-      (json['gameIds'] as List<dynamic>?)?.map((e) => e as String).toList() ??
-      const [],
   privacy:
       $enumDecodeNullable(_$GroupPrivacyEnumMap, json['privacy']) ??
       GroupPrivacy.private,
@@ -53,7 +50,6 @@ Map<String, dynamic> _$$GroupModelImplToJson(
   'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
   'memberIds': instance.memberIds,
   'adminIds': instance.adminIds,
-  'gameIds': instance.gameIds,
   'privacy': _$GroupPrivacyEnumMap[instance.privacy]!,
   'requiresApproval': instance.requiresApproval,
   'maxMembers': instance.maxMembers,

--- a/lib/core/data/repositories/firestore_group_repository.dart
+++ b/lib/core/data/repositories/firestore_group_repository.dart
@@ -344,44 +344,6 @@ class FirestoreGroupRepository implements GroupRepository {
   }
 
   @override
-  Future<void> addGame(String groupId, String gameId) async {
-    try {
-      final currentGroup = await getGroupById(groupId);
-      if (currentGroup == null) {
-        throw GroupException('Group not found', code: 'not-found');
-      }
-
-      final updatedGroup = currentGroup.addGame(gameId);
-
-      await _firestore
-          .collection(_collection)
-          .doc(groupId)
-          .set(updatedGroup.toFirestore(), SetOptions(merge: true));
-    } catch (e) {
-      throw GroupException('Failed to add game: $e');
-    }
-  }
-
-  @override
-  Future<void> removeGame(String groupId, String gameId) async {
-    try {
-      final currentGroup = await getGroupById(groupId);
-      if (currentGroup == null) {
-        throw GroupException('Group not found', code: 'not-found');
-      }
-
-      final updatedGroup = currentGroup.removeGame(gameId);
-
-      await _firestore
-          .collection(_collection)
-          .doc(groupId)
-          .set(updatedGroup.toFirestore(), SetOptions(merge: true));
-    } catch (e) {
-      throw GroupException('Failed to remove game: $e');
-    }
-  }
-
-  @override
   Future<void> updateActivity(String groupId) async {
     try {
       final currentGroup = await getGroupById(groupId);

--- a/lib/core/domain/repositories/group_repository.dart
+++ b/lib/core/domain/repositories/group_repository.dart
@@ -51,12 +51,6 @@ abstract class GroupRepository {
   /// Demote admin to regular member
   Future<void> demoteFromAdmin(String groupId, String userId);
 
-  /// Add game to group
-  Future<void> addGame(String groupId, String gameId);
-
-  /// Remove game from group
-  Future<void> removeGame(String groupId, String gameId);
-
   /// Update group activity timestamp
   Future<void> updateActivity(String groupId);
 

--- a/test/unit/core/data/models/group_model_test.dart
+++ b/test/unit/core/data/models/group_model_test.dart
@@ -48,7 +48,6 @@ void main() {
           updatedAt: DateTime(2024, 1, 2),
           memberIds: const ['user-1', 'user-2'],
           adminIds: const ['user-1'],
-          gameIds: const ['game-1'],
           privacy: GroupPrivacy.public,
           requiresApproval: true,
           maxMembers: 30,
@@ -337,30 +336,6 @@ void main() {
         final updated = testGroup.demoteFromAdmin('user-123');
 
         expect(updated.adminIds, contains('user-123'));
-      });
-
-      test('addGame adds game successfully', () {
-        final updated = testGroup.addGame('game-1');
-
-        expect(updated.gameIds, contains('game-1'));
-        expect(updated.totalGamesPlayed, 1);
-        expect(updated.updatedAt, isNotNull);
-      });
-
-      test('addGame does not add duplicate game', () {
-        final group = testGroup.copyWith(gameIds: ['game-1']);
-        final updated = group.addGame('game-1');
-
-        expect(updated.gameIds.length, 1);
-      });
-
-      test('removeGame removes game successfully', () {
-        final group = testGroup.copyWith(gameIds: ['game-1', 'game-2']);
-        final updated = group.removeGame('game-1');
-
-        expect(updated.gameIds, isNot(contains('game-1')));
-        expect(updated.gameIds.length, 1);
-        expect(updated.updatedAt, isNotNull);
       });
 
       test('updateActivity updates lastActivity timestamp', () {

--- a/test/unit/core/data/repositories/firestore_group_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_group_repository_test.dart
@@ -610,56 +610,6 @@ void main() {
       });
     });
 
-    group('addGame', () {
-      test('adds game to group', () async {
-        final testGroup = GroupModel(
-          id: '',
-          name: 'Test Group',
-          createdBy: 'user-123',
-          createdAt: DateTime(2024, 1, 1),
-        );
-        final groupId = await repository.createGroup(testGroup);
-
-        await repository.addGame(groupId, 'game-123');
-
-        final updatedGroup = await repository.getGroupById(groupId);
-        expect(updatedGroup!.gameIds, contains('game-123'));
-      });
-
-      test('throws exception when group does not exist', () async {
-        await expectLater(
-          repository.addGame('non-existent-id', 'game-123'),
-          throwsA(isA<GroupException>()),
-        );
-      });
-    });
-
-    group('removeGame', () {
-      test('removes game from group', () async {
-        final testGroup = GroupModel(
-          id: '',
-          name: 'Test Group',
-          createdBy: 'user-123',
-          createdAt: DateTime(2024, 1, 1),
-          gameIds: const ['game-123', 'game-456'],
-        );
-        final groupId = await repository.createGroup(testGroup);
-
-        await repository.removeGame(groupId, 'game-123');
-
-        final updatedGroup = await repository.getGroupById(groupId);
-        expect(updatedGroup!.gameIds, isNot(contains('game-123')));
-        expect(updatedGroup.gameIds, contains('game-456'));
-      });
-
-      test('throws exception when group does not exist', () async {
-        await expectLater(
-          repository.removeGame('non-existent-id', 'game-123'),
-          throwsA(isA<GroupException>()),
-        );
-      });
-    });
-
     group('updateActivity', () {
       test('updates lastActivity timestamp', () async {
         final testGroup = GroupModel(
@@ -927,7 +877,6 @@ void main() {
           createdAt: DateTime(2024, 1, 1),
           memberIds: const ['user-123', 'user-456', 'user-789'],
           adminIds: const ['user-123', 'user-456'],
-          gameIds: const ['game-1', 'game-2', 'game-3'],
           totalGamesPlayed: 3,
         );
         final groupId = await repository.createGroup(testGroup);

--- a/test/unit/core/data/repositories/mock_group_repository.dart
+++ b/test/unit/core/data/repositories/mock_group_repository.dart
@@ -188,26 +188,6 @@ class MockGroupRepository implements GroupRepository {
   }
 
   @override
-  Future<void> addGame(String groupId, String gameId) async {
-    final group = _groups[groupId];
-    if (group == null) throw Exception('Group not found');
-
-    final updatedGroup = group.addGame(gameId);
-    _groups[groupId] = updatedGroup;
-    _emitGroupsForUser();
-  }
-
-  @override
-  Future<void> removeGame(String groupId, String gameId) async {
-    final group = _groups[groupId];
-    if (group == null) throw Exception('Group not found');
-
-    final updatedGroup = group.removeGame(gameId);
-    _groups[groupId] = updatedGroup;
-    _emitGroupsForUser();
-  }
-
-  @override
   Future<void> updateActivity(String groupId) async {
     final group = _groups[groupId];
     if (group == null) throw Exception('Group not found');
@@ -294,7 +274,6 @@ class TestGroupData {
     updatedAt: DateTime.now(),
     memberIds: ['test-uid-123', 'user-uid-789'],
     adminIds: ['test-uid-123'],
-    gameIds: ['game1', 'game2'],
     privacy: GroupPrivacy.public,
     requiresApproval: false,
     maxMembers: 20,
@@ -316,7 +295,7 @@ class TestGroupData {
     updatedAt: DateTime.now(),
     memberIds: ['test-uid-123'],
     adminIds: ['test-uid-123'],
-    gameIds: [],
+
     privacy: GroupPrivacy.private,
     requiresApproval: true,
     maxMembers: 10,
@@ -338,7 +317,7 @@ class TestGroupData {
     updatedAt: DateTime.now(),
     memberIds: ['test-uid-123', 'user-uid-789'],
     adminIds: ['test-uid-123'],
-    gameIds: [],
+
     privacy: GroupPrivacy.public,
     requiresApproval: false,
     maxMembers: 2, // Already at capacity


### PR DESCRIPTION
## Summary

- Removes `gameIds: List<String>` field from `GroupModel` — an unbounded array that grew indefinitely and created dual-write race conditions on game creation
- Removes `addGame()` / `removeGame()` methods from `GroupRepository` interface, `FirestoreGroupRepository`, `GroupModel`, and all mock/test helpers
- Adds a one-time `migrateRemoveGroupGameIds` Cloud Function that removes the field from all existing Firestore group documents

## Problem

`GroupModel.gameIds` had three issues:
1. **Unbounded growth**: weekly games over 3 years → 150+ IDs per group
2. **Dual-write race condition**: creating a game required two writes (`games/{id}` + `groups/{id}.gameIds`) that were not atomic
3. **Redundant**: every `GameModel` already stores `groupId`; `GameRepository.getGamesForGroup()` already queries by that field

## Changes

| File | Change |
|------|--------|
| `lib/core/data/models/group_model.dart` | Remove `gameIds` field, `addGame()`, `removeGame()` |
| `lib/core/domain/repositories/group_repository.dart` | Remove `addGame()` and `removeGame()` from interface |
| `lib/core/data/repositories/firestore_group_repository.dart` | Remove implementations |
| `functions/src/migrateRemoveGroupGameIds.ts` | New one-time migration callable function |
| `functions/src/index.ts` | Export migration function |
| `test/**` | Remove `addGame`/`removeGame` tests and `gameIds` references |

## Migration Function

`migrateRemoveGroupGameIds` (callable, admin-only):
- Iterates all group documents in pages of 400
- Removes `gameIds` via `FieldValue.delete()` in batches
- Idempotent — skips documents that don't have the field
- Returns count of documents processed and updated
- 9-minute timeout; restricted to callers in the `appAdmins` collection

**Deployment order:**
1. Deploy migration function to **dev**, call it, verify output
2. Deploy updated Flutter client
3. Run migration on **prod**

## Test results

2720 unit tests pass · 3 skipped · 0 failures

`flutter analyze` → no issues · `npm run build` (functions) → clean