### PR TITLE
Story 31.4: Make groupId nullable and introduce GameContextType

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,6 +17,13 @@ service cloud.firestore {
              request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.adminIds;
     }
 
+    /// Check if user is a member of the specified group.
+    /// Always returns false when groupId is null (pickup games — Story 31.4).
+    function isGameGroupMember(groupId) {
+      return groupId != null &&
+             request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberIds;
+    }
+
     // ============================================
     // User Documents
     // ============================================
@@ -188,36 +195,40 @@ service cloud.firestore {
     // Games
     // ============================================
 
-    // Games: Group members can read, creators can manage
+    // Games: Group members can read, creators can manage.
+    // groupId is nullable since Story 31.4 (pickup games have no group).
+    // isGameGroupMember() safely returns false when groupId is null.
     match /games/{gameId} {
       // Individual game reads allowed for:
       //  - players already in the game (playerIds)
-      //  - group members (via group membership)
+      //  - group members when game has a groupId
       //  - pending invitees (pendingInviteeIds, managed by CFs — allows reading before accepting)
       allow get: if isAuthenticated() &&
                     (request.auth.uid in resource.data.playerIds ||
-                     request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds ||
+                     isGameGroupMember(resource.data.groupId) ||
                      ('pendingInviteeIds' in resource.data && request.auth.uid in resource.data.pendingInviteeIds));
 
       // List/query operations allowed for group members OR players in the game.
       // Supports getMyGames() query (playerIds array-contains uid) for guest players.
       allow list: if isAuthenticated() &&
                      (request.auth.uid in resource.data.playerIds ||
-                      request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds ||
+                      isGameGroupMember(resource.data.groupId) ||
                       ('pendingInviteeIds' in resource.data && request.auth.uid in resource.data.pendingInviteeIds));
 
-      // Game creation allowed for authenticated users
+      // Game creation allowed for authenticated users.
+      // Group games: creator must be a group member.
+      // Pickup games (groupId null): any authenticated user can create.
       allow create: if isAuthenticated() &&
                        request.auth.uid == request.resource.data.createdBy &&
-                       // Verify user is a member of the group they're creating a game for
-                       request.auth.uid in get(/databases/$(database)/documents/groups/$(request.resource.data.groupId)).data.memberIds;
+                       (request.resource.data.groupId == null ||
+                        request.auth.uid in get(/databases/$(database)/documents/groups/$(request.resource.data.groupId)).data.memberIds);
 
-      // Game updates allowed for creator, group members, or existing players
+      // Game updates allowed for creator, group members (when groupId set), or existing players
       // (playerIds covers guest players invited from another group — Story 28.11).
       // Special validation for result confirmation (Story 14.11)
       allow update: if isAuthenticated() &&
                        (request.auth.uid == resource.data.createdBy ||
-                        request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds ||
+                        isGameGroupMember(resource.data.groupId) ||
                         request.auth.uid in resource.data.playerIds) &&
                        // CRITICAL: Result confirmation security validation
                        (

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -12,7 +12,9 @@ class GameModel with _$GameModel {
     required String id,
     required String title,
     String? description,
-    required String groupId,
+    // Nullable since Story 31.4: group games set this; pickup games leave it null.
+    String? groupId,
+    @Default(GameContextType.group) GameContextType contextType,
     required String createdBy,
     @TimestampConverter() required DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -612,6 +614,19 @@ class GameResult with _$GameResult {
     final wins = gamesWon;
     return '${wins['teamA']}-${wins['teamB']}';
   }
+}
+
+/// Describes the context in which a game was created (Story 31.4).
+/// - [group]: tied to a specific group (existing behaviour, groupId is set)
+/// - [pickup]: standalone game between friends, not tied to any group (groupId is null)
+/// - [championship]: tied to a championship match from Epic 30 (groupId may be set)
+enum GameContextType {
+  @JsonValue('group')
+  group,
+  @JsonValue('pickup')
+  pickup,
+  @JsonValue('championship')
+  championship,
 }
 
 enum GameStatus {

--- a/lib/core/data/models/game_model.freezed.dart
+++ b/lib/core/data/models/game_model.freezed.dart
@@ -23,8 +23,10 @@ GameModel _$GameModelFromJson(Map<String, dynamic> json) {
 mixin _$GameModel {
   String get id => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
-  String? get description => throw _privateConstructorUsedError;
-  String get groupId => throw _privateConstructorUsedError;
+  String? get description =>
+      throw _privateConstructorUsedError; // Nullable since Story 31.4: group games set this; pickup games leave it null.
+  String? get groupId => throw _privateConstructorUsedError;
+  GameContextType get contextType => throw _privateConstructorUsedError;
   String get createdBy => throw _privateConstructorUsedError;
   @TimestampConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
@@ -98,7 +100,8 @@ abstract class $GameModelCopyWith<$Res> {
     String id,
     String title,
     String? description,
-    String groupId,
+    String? groupId,
+    GameContextType contextType,
     String createdBy,
     @TimestampConverter() DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -157,7 +160,8 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
     Object? id = null,
     Object? title = null,
     Object? description = freezed,
-    Object? groupId = null,
+    Object? groupId = freezed,
+    Object? contextType = null,
     Object? createdBy = null,
     Object? createdAt = null,
     Object? updatedAt = freezed,
@@ -206,10 +210,14 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
                 ? _value.description
                 : description // ignore: cast_nullable_to_non_nullable
                       as String?,
-            groupId: null == groupId
+            groupId: freezed == groupId
                 ? _value.groupId
                 : groupId // ignore: cast_nullable_to_non_nullable
-                      as String,
+                      as String?,
+            contextType: null == contextType
+                ? _value.contextType
+                : contextType // ignore: cast_nullable_to_non_nullable
+                      as GameContextType,
             createdBy: null == createdBy
                 ? _value.createdBy
                 : createdBy // ignore: cast_nullable_to_non_nullable
@@ -399,7 +407,8 @@ abstract class _$$GameModelImplCopyWith<$Res>
     String id,
     String title,
     String? description,
-    String groupId,
+    String? groupId,
+    GameContextType contextType,
     String createdBy,
     @TimestampConverter() DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -460,7 +469,8 @@ class __$$GameModelImplCopyWithImpl<$Res>
     Object? id = null,
     Object? title = null,
     Object? description = freezed,
-    Object? groupId = null,
+    Object? groupId = freezed,
+    Object? contextType = null,
     Object? createdBy = null,
     Object? createdAt = null,
     Object? updatedAt = freezed,
@@ -509,10 +519,14 @@ class __$$GameModelImplCopyWithImpl<$Res>
             ? _value.description
             : description // ignore: cast_nullable_to_non_nullable
                   as String?,
-        groupId: null == groupId
+        groupId: freezed == groupId
             ? _value.groupId
             : groupId // ignore: cast_nullable_to_non_nullable
-                  as String,
+                  as String?,
+        contextType: null == contextType
+            ? _value.contextType
+            : contextType // ignore: cast_nullable_to_non_nullable
+                  as GameContextType,
         createdBy: null == createdBy
             ? _value.createdBy
             : createdBy // ignore: cast_nullable_to_non_nullable
@@ -657,7 +671,8 @@ class _$GameModelImpl extends _GameModel {
     required this.id,
     required this.title,
     this.description,
-    required this.groupId,
+    this.groupId,
+    this.contextType = GameContextType.group,
     required this.createdBy,
     @TimestampConverter() required this.createdAt,
     @NullableTimestampConverter() this.updatedAt,
@@ -708,8 +723,12 @@ class _$GameModelImpl extends _GameModel {
   final String title;
   @override
   final String? description;
+  // Nullable since Story 31.4: group games set this; pickup games leave it null.
   @override
-  final String groupId;
+  final String? groupId;
+  @override
+  @JsonKey()
+  final GameContextType contextType;
   @override
   final String createdBy;
   @override
@@ -855,7 +874,7 @@ class _$GameModelImpl extends _GameModel {
 
   @override
   String toString() {
-    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, eloUpdates: $eloUpdates, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes, gameGenderType: $gameGenderType)';
+    return 'GameModel(id: $id, title: $title, description: $description, groupId: $groupId, contextType: $contextType, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, scheduledAt: $scheduledAt, startedAt: $startedAt, endedAt: $endedAt, location: $location, status: $status, maxPlayers: $maxPlayers, minPlayers: $minPlayers, playerIds: $playerIds, waitlistIds: $waitlistIds, allowWaitlist: $allowWaitlist, allowPlayerInvites: $allowPlayerInvites, visibility: $visibility, notes: $notes, equipment: $equipment, estimatedDuration: $estimatedDuration, courtInfo: $courtInfo, gameType: $gameType, skillLevel: $skillLevel, scores: $scores, winnerId: $winnerId, teams: $teams, result: $result, resultSubmittedBy: $resultSubmittedBy, confirmedBy: $confirmedBy, eloCalculated: $eloCalculated, eloUpdates: $eloUpdates, completedAt: $completedAt, weatherDependent: $weatherDependent, weatherNotes: $weatherNotes, gameGenderType: $gameGenderType)';
   }
 
   @override
@@ -868,6 +887,8 @@ class _$GameModelImpl extends _GameModel {
             (identical(other.description, description) ||
                 other.description == description) &&
             (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.contextType, contextType) ||
+                other.contextType == contextType) &&
             (identical(other.createdBy, createdBy) ||
                 other.createdBy == createdBy) &&
             (identical(other.createdAt, createdAt) ||
@@ -948,6 +969,7 @@ class _$GameModelImpl extends _GameModel {
     title,
     description,
     groupId,
+    contextType,
     createdBy,
     createdAt,
     updatedAt,
@@ -1002,7 +1024,8 @@ abstract class _GameModel extends GameModel {
     required final String id,
     required final String title,
     final String? description,
-    required final String groupId,
+    final String? groupId,
+    final GameContextType contextType,
     required final String createdBy,
     @TimestampConverter() required final DateTime createdAt,
     @NullableTimestampConverter() final DateTime? updatedAt,
@@ -1047,9 +1070,11 @@ abstract class _GameModel extends GameModel {
   @override
   String get title;
   @override
-  String? get description;
+  String? get description; // Nullable since Story 31.4: group games set this; pickup games leave it null.
   @override
-  String get groupId;
+  String? get groupId;
+  @override
+  GameContextType get contextType;
   @override
   String get createdBy;
   @override

--- a/lib/core/data/models/game_model.g.dart
+++ b/lib/core/data/models/game_model.g.dart
@@ -12,7 +12,10 @@ _$GameModelImpl _$$GameModelImplFromJson(
   id: json['id'] as String,
   title: json['title'] as String,
   description: json['description'] as String?,
-  groupId: json['groupId'] as String,
+  groupId: json['groupId'] as String?,
+  contextType:
+      $enumDecodeNullable(_$GameContextTypeEnumMap, json['contextType']) ??
+      GameContextType.group,
   createdBy: json['createdBy'] as String,
   createdAt: const TimestampConverter().fromJson(json['createdAt'] as Object),
   updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
@@ -86,6 +89,7 @@ Map<String, dynamic> _$$GameModelImplToJson(
   'title': instance.title,
   'description': instance.description,
   'groupId': instance.groupId,
+  'contextType': _$GameContextTypeEnumMap[instance.contextType]!,
   'createdBy': instance.createdBy,
   'createdAt': const TimestampConverter().toJson(instance.createdAt),
   'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
@@ -121,6 +125,12 @@ Map<String, dynamic> _$$GameModelImplToJson(
   'weatherDependent': instance.weatherDependent,
   'weatherNotes': instance.weatherNotes,
   'gameGenderType': _$GameGenderTypeEnumMap[instance.gameGenderType],
+};
+
+const _$GameContextTypeEnumMap = {
+  GameContextType.group: 'group',
+  GameContextType.pickup: 'pickup',
+  GameContextType.championship: 'championship',
 };
 
 const _$GameStatusEnumMap = {

--- a/lib/core/data/models/group_activity_item.dart
+++ b/lib/core/data/models/group_activity_item.dart
@@ -29,8 +29,8 @@ class GroupActivityItem with _$GroupActivityItem {
   String get title =>
       when(game: (game) => game.title, training: (session) => session.title);
 
-  /// Get the group ID
-  String get groupId => when(
+  /// Get the group ID. Null for pickup games (Story 31.4).
+  String? get groupId => when(
     game: (game) => game.groupId,
     training: (session) => session.groupId,
   );


### PR DESCRIPTION
## Story 31.4 — Data layer foundation for pickup games

### What changed

**`GameModel`**
- `groupId` is now `String?` (nullable). Group games set it as before; pickup games will leave it `null`.
- New `GameContextType` enum (`group` / `pickup` / `championship`) with default `GameContextType.group`, serialised as a JSON string field on every game document.

**`firestore.rules`**
- New `isGameGroupMember(groupId)` helper — safely returns `false` when `groupId` is `null`, avoiding a runtime path-construction error on pickup games.
- All four game rules (`get`, `list`, `create`, `update`) updated to handle null `groupId` cleanly. Create rule allows creation when `groupId` is null (pickup) or creator is a group member.

**`GroupActivityItem`**
- `groupId` getter widened to `String?` to match the nullable model field.

### What did NOT change
- Group game UX is completely untouched — no visible difference to users.
- Repository interface and implementation unchanged.
- No pickup game UI (planned as a future story).

### Tests
- All 3581 unit + widget tests pass.
- `flutter analyze`: 0 issues.