### PR TITLE
refactor(games): rename GameContextType → ActivityContextType (Story 31.4b)

### DIFF
--- a/lib/core/data/models/activity_context_type.dart
+++ b/lib/core/data/models/activity_context_type.dart
@@ -1,0 +1,19 @@
+// Shared context type for all activities (games, training sessions).
+// Introduced in Story 31.4, extracted and renamed in Story 31.4b so that
+// Story 31.5 (training sessions) and future stories can reuse this enum
+// without importing a game-specific file.
+
+import 'package:json_annotation/json_annotation.dart';
+
+/// Describes the context in which an activity (game, training session) was created.
+/// - [group]: tied to a specific group (default — existing behaviour, groupId is set)
+/// - [pickup]: standalone activity between friends, not tied to any group (groupId is null)
+/// - [championship]: tied to a championship match from Epic 30
+enum ActivityContextType {
+  @JsonValue('group')
+  group,
+  @JsonValue('pickup')
+  pickup,
+  @JsonValue('championship')
+  championship,
+}

--- a/lib/core/data/models/game_model.dart
+++ b/lib/core/data/models/game_model.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:play_with_me/core/data/converters/timestamp_converter.dart';
+import 'package:play_with_me/core/data/models/activity_context_type.dart';
 
 part 'game_model.freezed.dart';
 part 'game_model.g.dart';
@@ -14,7 +15,7 @@ class GameModel with _$GameModel {
     String? description,
     // Nullable since Story 31.4: group games set this; pickup games leave it null.
     String? groupId,
-    @Default(GameContextType.group) GameContextType contextType,
+    @Default(ActivityContextType.group) ActivityContextType contextType,
     required String createdBy,
     @TimestampConverter() required DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -614,19 +615,6 @@ class GameResult with _$GameResult {
     final wins = gamesWon;
     return '${wins['teamA']}-${wins['teamB']}';
   }
-}
-
-/// Describes the context in which a game was created (Story 31.4).
-/// - [group]: tied to a specific group (existing behaviour, groupId is set)
-/// - [pickup]: standalone game between friends, not tied to any group (groupId is null)
-/// - [championship]: tied to a championship match from Epic 30 (groupId may be set)
-enum GameContextType {
-  @JsonValue('group')
-  group,
-  @JsonValue('pickup')
-  pickup,
-  @JsonValue('championship')
-  championship,
 }
 
 enum GameStatus {

--- a/lib/core/data/models/game_model.freezed.dart
+++ b/lib/core/data/models/game_model.freezed.dart
@@ -26,7 +26,7 @@ mixin _$GameModel {
   String? get description =>
       throw _privateConstructorUsedError; // Nullable since Story 31.4: group games set this; pickup games leave it null.
   String? get groupId => throw _privateConstructorUsedError;
-  GameContextType get contextType => throw _privateConstructorUsedError;
+  ActivityContextType get contextType => throw _privateConstructorUsedError;
   String get createdBy => throw _privateConstructorUsedError;
   @TimestampConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
@@ -101,7 +101,7 @@ abstract class $GameModelCopyWith<$Res> {
     String title,
     String? description,
     String? groupId,
-    GameContextType contextType,
+    ActivityContextType contextType,
     String createdBy,
     @TimestampConverter() DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -217,7 +217,7 @@ class _$GameModelCopyWithImpl<$Res, $Val extends GameModel>
             contextType: null == contextType
                 ? _value.contextType
                 : contextType // ignore: cast_nullable_to_non_nullable
-                      as GameContextType,
+                      as ActivityContextType,
             createdBy: null == createdBy
                 ? _value.createdBy
                 : createdBy // ignore: cast_nullable_to_non_nullable
@@ -408,7 +408,7 @@ abstract class _$$GameModelImplCopyWith<$Res>
     String title,
     String? description,
     String? groupId,
-    GameContextType contextType,
+    ActivityContextType contextType,
     String createdBy,
     @TimestampConverter() DateTime createdAt,
     @NullableTimestampConverter() DateTime? updatedAt,
@@ -526,7 +526,7 @@ class __$$GameModelImplCopyWithImpl<$Res>
         contextType: null == contextType
             ? _value.contextType
             : contextType // ignore: cast_nullable_to_non_nullable
-                  as GameContextType,
+                  as ActivityContextType,
         createdBy: null == createdBy
             ? _value.createdBy
             : createdBy // ignore: cast_nullable_to_non_nullable
@@ -672,7 +672,7 @@ class _$GameModelImpl extends _GameModel {
     required this.title,
     this.description,
     this.groupId,
-    this.contextType = GameContextType.group,
+    this.contextType = ActivityContextType.group,
     required this.createdBy,
     @TimestampConverter() required this.createdAt,
     @NullableTimestampConverter() this.updatedAt,
@@ -728,7 +728,7 @@ class _$GameModelImpl extends _GameModel {
   final String? groupId;
   @override
   @JsonKey()
-  final GameContextType contextType;
+  final ActivityContextType contextType;
   @override
   final String createdBy;
   @override
@@ -1025,7 +1025,7 @@ abstract class _GameModel extends GameModel {
     required final String title,
     final String? description,
     final String? groupId,
-    final GameContextType contextType,
+    final ActivityContextType contextType,
     required final String createdBy,
     @TimestampConverter() required final DateTime createdAt,
     @NullableTimestampConverter() final DateTime? updatedAt,
@@ -1074,7 +1074,7 @@ abstract class _GameModel extends GameModel {
   @override
   String? get groupId;
   @override
-  GameContextType get contextType;
+  ActivityContextType get contextType;
   @override
   String get createdBy;
   @override

--- a/lib/core/data/models/game_model.g.dart
+++ b/lib/core/data/models/game_model.g.dart
@@ -14,8 +14,8 @@ _$GameModelImpl _$$GameModelImplFromJson(
   description: json['description'] as String?,
   groupId: json['groupId'] as String?,
   contextType:
-      $enumDecodeNullable(_$GameContextTypeEnumMap, json['contextType']) ??
-      GameContextType.group,
+      $enumDecodeNullable(_$ActivityContextTypeEnumMap, json['contextType']) ??
+      ActivityContextType.group,
   createdBy: json['createdBy'] as String,
   createdAt: const TimestampConverter().fromJson(json['createdAt'] as Object),
   updatedAt: const NullableTimestampConverter().fromJson(json['updatedAt']),
@@ -89,7 +89,7 @@ Map<String, dynamic> _$$GameModelImplToJson(
   'title': instance.title,
   'description': instance.description,
   'groupId': instance.groupId,
-  'contextType': _$GameContextTypeEnumMap[instance.contextType]!,
+  'contextType': _$ActivityContextTypeEnumMap[instance.contextType]!,
   'createdBy': instance.createdBy,
   'createdAt': const TimestampConverter().toJson(instance.createdAt),
   'updatedAt': const NullableTimestampConverter().toJson(instance.updatedAt),
@@ -127,10 +127,10 @@ Map<String, dynamic> _$$GameModelImplToJson(
   'gameGenderType': _$GameGenderTypeEnumMap[instance.gameGenderType],
 };
 
-const _$GameContextTypeEnumMap = {
-  GameContextType.group: 'group',
-  GameContextType.pickup: 'pickup',
-  GameContextType.championship: 'championship',
+const _$ActivityContextTypeEnumMap = {
+  ActivityContextType.group: 'group',
+  ActivityContextType.pickup: 'pickup',
+  ActivityContextType.championship: 'championship',
 };
 
 const _$GameStatusEnumMap = {


### PR DESCRIPTION
## Why

Story 31.5 (decouple training sessions) explicitly depends on reusing the context enum from 31.4. The enum was named `GameContextType` — game-specific and not reusable. This PR extracts and renames it before 31.5 begins.

## Changes

- New file `lib/core/data/models/activity_context_type.dart` — shared `ActivityContextType` enum (`group` / `pickup` / `championship`)
- `GameModel.contextType` now typed as `ActivityContextType` (imported from the shared file)
- `GameContextType` definition removed from `game_model.dart`
- Generated files regenerated

## Tests

- `flutter analyze`: 0 issues
- No logic changes — purely a rename/extract