### PR TITLE
feat(training): make groupId optional for standalone sessions (Story 31.5)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -270,88 +270,74 @@ service cloud.firestore {
     // Training Sessions (Epic 15)
     // ============================================
 
-    // Training Sessions: Group members can participate, creators can manage
-    // ARCHITECTURE: Training sessions are in Games layer, validate via group membership only
-    // SECURITY: Creation goes through Cloud Function for server-side validation
+    // Training Sessions: Group members or participants can read, creators can manage.
+    // groupId is nullable since Story 31.5 (standalone sessions have no group).
+    // isGameGroupMember() safely returns false when groupId is null.
+    // SECURITY: Creation goes through Cloud Function for server-side validation.
     match /trainingSessions/{sessionId} {
-      // Individual session reads allowed for members (used by session details page)
+      // Individual session reads allowed for:
+      //  - group members when session has a groupId
+      //  - existing participants (for standalone sessions)
       allow get: if isAuthenticated() &&
-                    request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds;
+                    (isGameGroupMember(resource.data.groupId) ||
+                     request.auth.uid in resource.data.participantIds);
 
-      // List/query operations allowed for group members
-      // Each document is checked individually - user must be member of the session's group
-      // Story 15.2: This also supports querying recurring session instances via parentSessionId
-      // since each instance inherits the same groupId as the parent session
+      // List/query operations: group members OR participants.
+      // Story 15.2: Also supports recurring session instance queries via parentSessionId.
       allow list: if isAuthenticated() &&
-                     request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds;
+                     (isGameGroupMember(resource.data.groupId) ||
+                      request.auth.uid in resource.data.participantIds);
 
-      // CRITICAL: Training session creation is Cloud Functions ONLY
-      // Use createTrainingSession callable function for server-side validation
-      // This keeps rules minimal and validation logic centralized
+      // CRITICAL: Training session creation is Cloud Functions ONLY.
+      // Use createTrainingSession callable function for server-side validation.
       allow create: if false;
 
-      // Training session updates allowed for creator or group members (for joining/leaving, completion)
-      // Note: Only group members can join (validated in repository layer)
+      // Updates allowed for creator or group members (when groupId set) or participants.
       allow update: if isAuthenticated() &&
                        (request.auth.uid == resource.data.createdBy ||
-                        request.auth.uid in get(/databases/$(database)/documents/groups/$(resource.data.groupId)).data.memberIds);
+                        isGameGroupMember(resource.data.groupId) ||
+                        request.auth.uid in resource.data.participantIds);
 
-      // Only creator can delete training sessions
+      // Only creator can delete training sessions.
       allow delete: if isAuthenticated() &&
                        request.auth.uid == resource.data.createdBy;
 
-      // Story 15.3: Participants subcollection rules
-      // Participants are managed via Cloud Functions (joinTrainingSession, leaveTrainingSession)
-      // for atomic operations and race condition protection
+      // Story 15.3: Participants subcollection rules.
+      // Participants are managed via Cloud Functions (joinTrainingSession, leaveTrainingSession).
       match /participants/{userId} {
-        // Read participants: group members only
+        // Read participants: group members or existing participants.
         allow get, list: if isAuthenticated() &&
-                            request.auth.uid in get(/databases/$(database)/documents/groups/$(get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.groupId)).data.memberIds;
+                            (isGameGroupMember(get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.groupId) ||
+                             request.auth.uid in get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.participantIds);
 
-        // CRITICAL: Join/leave via Cloud Functions ONLY
-        // Use joinTrainingSession and leaveTrainingSession callable functions
-        // This enforces atomic operations and prevents race conditions when checking capacity
+        // CRITICAL: Join/leave via Cloud Functions ONLY.
         allow create, update, delete: if false;
       }
 
-      // Story 15.7: Exercises subcollection rules
-      // Exercises define drills/activities for the training session
-      // Only editable before session starts
+      // Story 15.7: Exercises subcollection rules.
       match /exercises/{exerciseId} {
-        // Read exercises: group members only
+        // Read exercises: group members or participants.
         allow get, list: if isAuthenticated() &&
-                            request.auth.uid in get(/databases/$(database)/documents/groups/$(get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.groupId)).data.memberIds;
+                            (isGameGroupMember(get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.groupId) ||
+                             request.auth.uid in get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.participantIds);
 
-        // Create/update exercises: only creator and only before session starts
-        // Session creator can add exercises until session start time
+        // Create/update/delete exercises: only creator, only before session starts.
         allow create, update: if isAuthenticated() &&
                                  request.auth.uid == get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.createdBy &&
-                                 // Session hasn't started yet (startTime is in the future)
                                  get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.startTime > request.time;
 
-        // Delete exercises: only creator and only before session starts
         allow delete: if isAuthenticated() &&
                          request.auth.uid == get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.createdBy &&
-                         // Session hasn't started yet
                          get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.startTime > request.time;
       }
 
-      // Story 15.8: Anonymous Feedback subcollection rules
-      // Feedback is submitted anonymously by participants after training sessions
-      // Aggregated feedback is visible to session creator only
+      // Story 15.8: Anonymous Feedback subcollection rules.
       match /feedback/{feedbackId} {
-        // Read feedback: only session creator can read (for aggregated view)
-        // IMPORTANT: Individual feedback items are anonymous - no user IDs exposed
-        // Creator sees aggregated stats via repository layer
+        // Read feedback: only session creator.
         allow get, list: if isAuthenticated() &&
                             request.auth.uid == get(/databases/$(database)/documents/trainingSessions/$(sessionId)).data.createdBy;
 
-        // CRITICAL: Feedback submission is Cloud Functions ONLY
-        // Use submitTrainingFeedback callable function for:
-        // - Participant validation (user was in participantIds)
-        // - Duplicate prevention (via participant hash)
-        // - Anonymity enforcement (hash instead of user ID)
-        // - Session timing validation (only after endTime)
+        // CRITICAL: Feedback submission is Cloud Functions ONLY.
         allow create, update, delete: if false;
       }
     }

--- a/functions/src/createTrainingSession.ts
+++ b/functions/src/createTrainingSession.ts
@@ -18,7 +18,7 @@ interface RecurrenceRule {
 }
 
 interface CreateTrainingSessionRequest {
-  groupId: string;
+  groupId?: string; // Optional since Story 31.5: null = standalone session
   title: string;
   description?: string;
   locationName: string;
@@ -191,11 +191,11 @@ export const createTrainingSession = functions
       // 2. Input Validation
       // ========================================
 
-      // Validate required fields
-      if (!data.groupId || !data.title || !data.locationName || !data.startTime || !data.endTime) {
+      // Validate required fields (groupId is optional since Story 31.5)
+      if (!data.title || !data.locationName || !data.startTime || !data.endTime) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          "Missing required fields: groupId, title, locationName, startTime, endTime"
+          "Missing required fields: title, locationName, startTime, endTime"
         );
       }
 
@@ -244,30 +244,31 @@ export const createTrainingSession = functions
       }
 
       // ========================================
-      // 3. Group Membership Validation
+      // 3. Group Membership Validation (group sessions only)
       // ========================================
 
-      // CRITICAL: Validate group exists and user is a member
-      // This enforces the architecture rule: Training Sessions → Groups only
-      const groupData = await getGroupData(data.groupId);
+      // Standalone sessions (groupId absent) skip group validation.
+      if (data.groupId) {
+        const groupData = await getGroupData(data.groupId);
 
-      if (!groupData) {
-        functions.logger.warn("Group not found", {userId, groupId: data.groupId});
-        throw new functions.https.HttpsError(
-          "not-found",
-          "The selected group does not exist"
-        );
-      }
+        if (!groupData) {
+          functions.logger.warn("Group not found", {userId, groupId: data.groupId});
+          throw new functions.https.HttpsError(
+            "not-found",
+            "The selected group does not exist"
+          );
+        }
 
-      if (!groupData.memberIds.includes(userId)) {
-        functions.logger.warn("User not a member of group", {
-          userId,
-          groupId: data.groupId,
-        });
-        throw new functions.https.HttpsError(
-          "permission-denied",
-          "You must be a member of the group to create a training session"
-        );
+        if (!groupData.memberIds.includes(userId)) {
+          functions.logger.warn("User not a member of group", {
+            userId,
+            groupId: data.groupId,
+          });
+          throw new functions.https.HttpsError(
+            "permission-denied",
+            "You must be a member of the group to create a training session"
+          );
+        }
       }
 
       // ========================================

--- a/functions/src/joinTrainingSession.ts
+++ b/functions/src/joinTrainingSession.ts
@@ -27,7 +27,7 @@ async function getTrainingSessionData(
   db: admin.firestore.Firestore,
   sessionId: string
 ): Promise<{
-  groupId: string;
+  groupId: string | null;
   maxParticipants: number;
   status: string;
   startTime: admin.firestore.Timestamp;
@@ -40,7 +40,7 @@ async function getTrainingSessionData(
 
   const sessionData = sessionDoc.data()!;
   return {
-    groupId: sessionData.groupId,
+    groupId: sessionData.groupId ?? null,
     maxParticipants: sessionData.maxParticipants,
     status: sessionData.status || "scheduled",
     startTime: sessionData.startTime,
@@ -138,16 +138,19 @@ export const joinTrainingSession = functions.region('europe-west6').https.onCall
     }
 
     // ============================================================================
-    // 4. Group Membership Validation
+    // 4. Group Membership Validation (group sessions only)
     // ============================================================================
 
-    const isMember = await isGroupMember(db, sessionData.groupId, userId);
+    // Standalone sessions (groupId absent) skip group membership check.
+    if (sessionData.groupId) {
+      const isMember = await isGroupMember(db, sessionData.groupId, userId);
 
-    if (!isMember) {
-      throw new functions.https.HttpsError(
-        "permission-denied",
-        "You must be a member of the group to join this training session"
-      );
+      if (!isMember) {
+        throw new functions.https.HttpsError(
+          "permission-denied",
+          "You must be a member of the group to join this training session"
+        );
+      }
     }
 
     // ============================================================================

--- a/lib/core/data/models/training_session_model.dart
+++ b/lib/core/data/models/training_session_model.dart
@@ -3,20 +3,24 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:play_with_me/core/data/converters/timestamp_converter.dart';
 
+import 'activity_context_type.dart';
 import 'game_model.dart'; // For GameLocation reuse
 import 'recurrence_rule_model.dart';
 
 part 'training_session_model.freezed.dart';
 part 'training_session_model.g.dart';
 
-/// Represents a training session within a group
-/// Training sessions are practice events that do not affect ELO ratings
-/// They are bound to groups and participants are resolved via group membership only
+/// Represents a training session.
+/// Training sessions are practice events that do not affect ELO ratings.
+/// Since Story 31.5, groupId is nullable: group sessions set it, standalone
+/// practice sessions (pickup/championship) leave it null.
 @freezed
 class TrainingSessionModel with _$TrainingSessionModel {
   const factory TrainingSessionModel({
     required String id,
-    required String groupId,
+    // Nullable since Story 31.5: group sessions set this; standalone sessions leave it null.
+    String? groupId,
+    @Default(ActivityContextType.group) ActivityContextType contextType,
     required String title,
     String? description,
     required GameLocation location,

--- a/lib/core/data/models/training_session_model.freezed.dart
+++ b/lib/core/data/models/training_session_model.freezed.dart
@@ -21,8 +21,10 @@ TrainingSessionModel _$TrainingSessionModelFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$TrainingSessionModel {
-  String get id => throw _privateConstructorUsedError;
-  String get groupId => throw _privateConstructorUsedError;
+  String get id =>
+      throw _privateConstructorUsedError; // Nullable since Story 31.5: group sessions set this; standalone sessions leave it null.
+  String? get groupId => throw _privateConstructorUsedError;
+  ActivityContextType get contextType => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   String? get description => throw _privateConstructorUsedError;
   GameLocation get location => throw _privateConstructorUsedError;
@@ -71,7 +73,8 @@ abstract class $TrainingSessionModelCopyWith<$Res> {
   @useResult
   $Res call({
     String id,
-    String groupId,
+    String? groupId,
+    ActivityContextType contextType,
     String title,
     String? description,
     GameLocation location,
@@ -114,7 +117,8 @@ class _$TrainingSessionModelCopyWithImpl<
   @override
   $Res call({
     Object? id = null,
-    Object? groupId = null,
+    Object? groupId = freezed,
+    Object? contextType = null,
     Object? title = null,
     Object? description = freezed,
     Object? location = null,
@@ -139,10 +143,14 @@ class _$TrainingSessionModelCopyWithImpl<
                 ? _value.id
                 : id // ignore: cast_nullable_to_non_nullable
                       as String,
-            groupId: null == groupId
+            groupId: freezed == groupId
                 ? _value.groupId
                 : groupId // ignore: cast_nullable_to_non_nullable
-                      as String,
+                      as String?,
+            contextType: null == contextType
+                ? _value.contextType
+                : contextType // ignore: cast_nullable_to_non_nullable
+                      as ActivityContextType,
             title: null == title
                 ? _value.title
                 : title // ignore: cast_nullable_to_non_nullable
@@ -252,7 +260,8 @@ abstract class _$$TrainingSessionModelImplCopyWith<$Res>
   @useResult
   $Res call({
     String id,
-    String groupId,
+    String? groupId,
+    ActivityContextType contextType,
     String title,
     String? description,
     GameLocation location,
@@ -293,7 +302,8 @@ class __$$TrainingSessionModelImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = null,
-    Object? groupId = null,
+    Object? groupId = freezed,
+    Object? contextType = null,
     Object? title = null,
     Object? description = freezed,
     Object? location = null,
@@ -318,10 +328,14 @@ class __$$TrainingSessionModelImplCopyWithImpl<$Res>
             ? _value.id
             : id // ignore: cast_nullable_to_non_nullable
                   as String,
-        groupId: null == groupId
+        groupId: freezed == groupId
             ? _value.groupId
             : groupId // ignore: cast_nullable_to_non_nullable
-                  as String,
+                  as String?,
+        contextType: null == contextType
+            ? _value.contextType
+            : contextType // ignore: cast_nullable_to_non_nullable
+                  as ActivityContextType,
         title: null == title
             ? _value.title
             : title // ignore: cast_nullable_to_non_nullable
@@ -400,7 +414,8 @@ class __$$TrainingSessionModelImplCopyWithImpl<$Res>
 class _$TrainingSessionModelImpl extends _TrainingSessionModel {
   const _$TrainingSessionModelImpl({
     required this.id,
-    required this.groupId,
+    this.groupId,
+    this.contextType = ActivityContextType.group,
     required this.title,
     this.description,
     required this.location,
@@ -426,8 +441,12 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
 
   @override
   final String id;
+  // Nullable since Story 31.5: group sessions set this; standalone sessions leave it null.
   @override
-  final String groupId;
+  final String? groupId;
+  @override
+  @JsonKey()
+  final ActivityContextType contextType;
   @override
   final String title;
   @override
@@ -486,7 +505,7 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
 
   @override
   String toString() {
-    return 'TrainingSessionModel(id: $id, groupId: $groupId, title: $title, description: $description, location: $location, startTime: $startTime, endTime: $endTime, minParticipants: $minParticipants, maxParticipants: $maxParticipants, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, recurrenceRule: $recurrenceRule, parentSessionId: $parentSessionId, status: $status, participantIds: $participantIds, notes: $notes, cancelledBy: $cancelledBy, cancelledAt: $cancelledAt)';
+    return 'TrainingSessionModel(id: $id, groupId: $groupId, contextType: $contextType, title: $title, description: $description, location: $location, startTime: $startTime, endTime: $endTime, minParticipants: $minParticipants, maxParticipants: $maxParticipants, createdBy: $createdBy, createdAt: $createdAt, updatedAt: $updatedAt, recurrenceRule: $recurrenceRule, parentSessionId: $parentSessionId, status: $status, participantIds: $participantIds, notes: $notes, cancelledBy: $cancelledBy, cancelledAt: $cancelledAt)';
   }
 
   @override
@@ -496,6 +515,8 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
             other is _$TrainingSessionModelImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.contextType, contextType) ||
+                other.contextType == contextType) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
                 other.description == description) &&
@@ -536,6 +557,7 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
     runtimeType,
     id,
     groupId,
+    contextType,
     title,
     description,
     location,
@@ -576,7 +598,8 @@ class _$TrainingSessionModelImpl extends _TrainingSessionModel {
 abstract class _TrainingSessionModel extends TrainingSessionModel {
   const factory _TrainingSessionModel({
     required final String id,
-    required final String groupId,
+    final String? groupId,
+    final ActivityContextType contextType,
     required final String title,
     final String? description,
     required final GameLocation location,
@@ -601,9 +624,11 @@ abstract class _TrainingSessionModel extends TrainingSessionModel {
       _$TrainingSessionModelImpl.fromJson;
 
   @override
-  String get id;
+  String get id; // Nullable since Story 31.5: group sessions set this; standalone sessions leave it null.
   @override
-  String get groupId;
+  String? get groupId;
+  @override
+  ActivityContextType get contextType;
   @override
   String get title;
   @override

--- a/lib/core/data/models/training_session_model.g.dart
+++ b/lib/core/data/models/training_session_model.g.dart
@@ -10,7 +10,10 @@ _$TrainingSessionModelImpl _$$TrainingSessionModelImplFromJson(
   Map<String, dynamic> json,
 ) => _$TrainingSessionModelImpl(
   id: json['id'] as String,
-  groupId: json['groupId'] as String,
+  groupId: json['groupId'] as String?,
+  contextType:
+      $enumDecodeNullable(_$ActivityContextTypeEnumMap, json['contextType']) ??
+      ActivityContextType.group,
   title: json['title'] as String,
   description: json['description'] as String?,
   location: GameLocation.fromJson(json['location'] as Map<String, dynamic>),
@@ -45,6 +48,7 @@ Map<String, dynamic> _$$TrainingSessionModelImplToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'groupId': instance.groupId,
+  'contextType': _$ActivityContextTypeEnumMap[instance.contextType]!,
   'title': instance.title,
   'description': instance.description,
   'location': instance.location,
@@ -64,6 +68,12 @@ Map<String, dynamic> _$$TrainingSessionModelImplToJson(
   'cancelledAt': const NullableTimestampConverter().toJson(
     instance.cancelledAt,
   ),
+};
+
+const _$ActivityContextTypeEnumMap = {
+  ActivityContextType.group: 'group',
+  ActivityContextType.pickup: 'pickup',
+  ActivityContextType.championship: 'championship',
 };
 
 const _$TrainingStatusEnumMap = {

--- a/lib/core/data/repositories/firestore_training_session_repository.dart
+++ b/lib/core/data/repositories/firestore_training_session_repository.dart
@@ -671,15 +671,18 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
         );
       }
 
-      // Validate user is a member of the group
-      final groupMembers = await _groupRepository.getGroupMembers(
-        currentSession.groupId,
-      );
-      if (!groupMembers.contains(userId)) {
-        throw TrainingSessionException(
-          'User is not a member of the group',
-          code: 'permission-denied',
+      // Validate user is a member of the group (group sessions only).
+      // Standalone sessions (groupId null) are open to any authenticated user.
+      if (currentSession.groupId != null) {
+        final groupMembers = await _groupRepository.getGroupMembers(
+          currentSession.groupId!,
         );
+        if (!groupMembers.contains(userId)) {
+          throw TrainingSessionException(
+            'User is not a member of the group',
+            code: 'permission-denied',
+          );
+        }
       }
 
       // Check if session is full
@@ -944,11 +947,13 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
       final session = await getTrainingSessionById(sessionId);
       if (session == null) return false;
 
-      // Check if user is a member of the group
-      final groupMembers = await _groupRepository.getGroupMembers(
-        session.groupId,
-      );
-      if (!groupMembers.contains(userId)) return false;
+      // Group membership check only applies when groupId is set.
+      if (session.groupId != null) {
+        final groupMembers = await _groupRepository.getGroupMembers(
+          session.groupId!,
+        );
+        if (!groupMembers.contains(userId)) return false;
+      }
 
       return session.canUserJoin(userId);
     } on TrainingSessionException {


### PR DESCRIPTION
## Summary

- `TrainingSessionModel.groupId` is now nullable — standalone sessions (pickup/championship) leave it `null`
- Added `contextType: ActivityContextType` field (reusing the enum from Story 31.4)
- `createTrainingSession` Cloud Function: `groupId` is optional; group membership validation is skipped when absent
- `joinTrainingSession` Cloud Function: group membership check is skipped for standalone sessions
- Firestore rules: use `isGameGroupMember()` helper (returns `false` when `groupId` is `null`) + `participantIds` fallback so standalone participants can still read/update their sessions
- Repository: null guards added before `getGroupMembers()` calls at join/canJoin validation points

## Test plan

- [x] `flutter analyze` — 0 warnings
- [x] `flutter test test/unit/` — 2693 tests passed
- [x] `npm test` (functions) — 541 tests passed