### PR TITLE
feat(chat): extract MessageRepository from GameRepository (Story 31.7)

### DIFF
--- a/lib/core/data/models/chat_message_model.dart
+++ b/lib/core/data/models/chat_message_model.dart
@@ -14,6 +14,7 @@ class ChatMessageModel with _$ChatMessageModel {
     required String senderDisplayName,
     required String text,
     @TimestampConverter() required DateTime sentAt,
+    String? teamId,
   }) = _ChatMessageModel;
 
   const ChatMessageModel._();

--- a/lib/core/data/models/chat_message_model.freezed.dart
+++ b/lib/core/data/models/chat_message_model.freezed.dart
@@ -27,6 +27,7 @@ mixin _$ChatMessageModel {
   String get text => throw _privateConstructorUsedError;
   @TimestampConverter()
   DateTime get sentAt => throw _privateConstructorUsedError;
+  String? get teamId => throw _privateConstructorUsedError;
 
   /// Serializes this ChatMessageModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -51,6 +52,7 @@ abstract class $ChatMessageModelCopyWith<$Res> {
     String senderDisplayName,
     String text,
     @TimestampConverter() DateTime sentAt,
+    String? teamId,
   });
 }
 
@@ -74,6 +76,7 @@ class _$ChatMessageModelCopyWithImpl<$Res, $Val extends ChatMessageModel>
     Object? senderDisplayName = null,
     Object? text = null,
     Object? sentAt = null,
+    Object? teamId = freezed,
   }) {
     return _then(
       _value.copyWith(
@@ -97,6 +100,10 @@ class _$ChatMessageModelCopyWithImpl<$Res, $Val extends ChatMessageModel>
                 ? _value.sentAt
                 : sentAt // ignore: cast_nullable_to_non_nullable
                       as DateTime,
+            teamId: freezed == teamId
+                ? _value.teamId
+                : teamId // ignore: cast_nullable_to_non_nullable
+                      as String?,
           )
           as $Val,
     );
@@ -118,6 +125,7 @@ abstract class _$$ChatMessageModelImplCopyWith<$Res>
     String senderDisplayName,
     String text,
     @TimestampConverter() DateTime sentAt,
+    String? teamId,
   });
 }
 
@@ -140,6 +148,7 @@ class __$$ChatMessageModelImplCopyWithImpl<$Res>
     Object? senderDisplayName = null,
     Object? text = null,
     Object? sentAt = null,
+    Object? teamId = freezed,
   }) {
     return _then(
       _$ChatMessageModelImpl(
@@ -163,6 +172,10 @@ class __$$ChatMessageModelImplCopyWithImpl<$Res>
             ? _value.sentAt
             : sentAt // ignore: cast_nullable_to_non_nullable
                   as DateTime,
+        teamId: freezed == teamId
+            ? _value.teamId
+            : teamId // ignore: cast_nullable_to_non_nullable
+                  as String?,
       ),
     );
   }
@@ -177,6 +190,7 @@ class _$ChatMessageModelImpl extends _ChatMessageModel {
     required this.senderDisplayName,
     required this.text,
     @TimestampConverter() required this.sentAt,
+    this.teamId,
   }) : super._();
 
   factory _$ChatMessageModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -193,10 +207,12 @@ class _$ChatMessageModelImpl extends _ChatMessageModel {
   @override
   @TimestampConverter()
   final DateTime sentAt;
+  @override
+  final String? teamId;
 
   @override
   String toString() {
-    return 'ChatMessageModel(id: $id, senderId: $senderId, senderDisplayName: $senderDisplayName, text: $text, sentAt: $sentAt)';
+    return 'ChatMessageModel(id: $id, senderId: $senderId, senderDisplayName: $senderDisplayName, text: $text, sentAt: $sentAt, teamId: $teamId)';
   }
 
   @override
@@ -210,13 +226,21 @@ class _$ChatMessageModelImpl extends _ChatMessageModel {
             (identical(other.senderDisplayName, senderDisplayName) ||
                 other.senderDisplayName == senderDisplayName) &&
             (identical(other.text, text) || other.text == text) &&
-            (identical(other.sentAt, sentAt) || other.sentAt == sentAt));
+            (identical(other.sentAt, sentAt) || other.sentAt == sentAt) &&
+            (identical(other.teamId, teamId) || other.teamId == teamId));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, senderId, senderDisplayName, text, sentAt);
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    senderId,
+    senderDisplayName,
+    text,
+    sentAt,
+    teamId,
+  );
 
   /// Create a copy of ChatMessageModel
   /// with the given fields replaced by the non-null parameter values.
@@ -242,6 +266,7 @@ abstract class _ChatMessageModel extends ChatMessageModel {
     required final String senderDisplayName,
     required final String text,
     @TimestampConverter() required final DateTime sentAt,
+    final String? teamId,
   }) = _$ChatMessageModelImpl;
   const _ChatMessageModel._() : super._();
 
@@ -259,6 +284,8 @@ abstract class _ChatMessageModel extends ChatMessageModel {
   @override
   @TimestampConverter()
   DateTime get sentAt;
+  @override
+  String? get teamId;
 
   /// Create a copy of ChatMessageModel
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/core/data/models/chat_message_model.g.dart
+++ b/lib/core/data/models/chat_message_model.g.dart
@@ -14,6 +14,7 @@ _$ChatMessageModelImpl _$$ChatMessageModelImplFromJson(
   senderDisplayName: json['senderDisplayName'] as String,
   text: json['text'] as String,
   sentAt: const TimestampConverter().fromJson(json['sentAt'] as Object),
+  teamId: json['teamId'] as String?,
 );
 
 Map<String, dynamic> _$$ChatMessageModelImplToJson(
@@ -24,4 +25,5 @@ Map<String, dynamic> _$$ChatMessageModelImplToJson(
   'senderDisplayName': instance.senderDisplayName,
   'text': instance.text,
   'sentAt': const TimestampConverter().toJson(instance.sentAt),
+  'teamId': instance.teamId,
 };

--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -8,7 +8,6 @@ import 'package:cloud_functions/cloud_functions.dart';
 
 import '../../domain/exceptions/repository_exceptions.dart';
 import '../../domain/repositories/game_repository.dart';
-import '../models/chat_message_model.dart';
 import '../models/game_model.dart';
 
 class FirestoreGameRepository implements GameRepository {
@@ -1614,67 +1613,4 @@ class FirestoreGameRepository implements GameRepository {
     }
   }
 
-  @override
-  Stream<List<ChatMessageModel>> getMessages(String gameId) {
-    try {
-      return _firestore
-          .collection(_collection)
-          .doc(gameId)
-          .collection('messages')
-          .orderBy('sentAt', descending: false)
-          .snapshots()
-          .map(
-            (snapshot) => snapshot.docs
-                .map((doc) => ChatMessageModel.fromFirestore(doc))
-                .toList(),
-          )
-          .handleError((error) {
-            if (error is FirebaseException) {
-              throw GameException(
-                'Failed to stream messages: ${error.message}',
-                code: error.code,
-              );
-            }
-            throw GameException(
-              'Failed to stream messages: $error',
-              code: 'stream-error',
-            );
-          });
-    } catch (e) {
-      throw GameException(
-        'Failed to stream messages: $e',
-        code: 'stream-error',
-      );
-    }
-  }
-
-  @override
-  Future<void> sendMessage({
-    required String gameId,
-    required String senderId,
-    required String senderDisplayName,
-    required String text,
-  }) async {
-    try {
-      final message = ChatMessageModel(
-        id: '',
-        senderId: senderId,
-        senderDisplayName: senderDisplayName,
-        text: text,
-        sentAt: DateTime.now(),
-      );
-      await _firestore
-          .collection(_collection)
-          .doc(gameId)
-          .collection('messages')
-          .add(message.toFirestore());
-    } on FirebaseException catch (e) {
-      throw GameException(
-        'Failed to send message: ${e.message}',
-        code: e.code,
-      );
-    } catch (e) {
-      throw GameException('Failed to send message: $e');
-    }
-  }
 }

--- a/lib/core/data/repositories/firestore_message_repository.dart
+++ b/lib/core/data/repositories/firestore_message_repository.dart
@@ -1,0 +1,75 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
+
+class FirestoreMessageRepository implements MessageRepository {
+  final FirebaseFirestore _firestore;
+
+  FirestoreMessageRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath}) {
+    try {
+      return _firestore
+          .doc(contextPath)
+          .collection('messages')
+          .orderBy('sentAt', descending: false)
+          .snapshots()
+          .map(
+            (snapshot) => snapshot.docs
+                .map((doc) => ChatMessageModel.fromFirestore(doc))
+                .toList(),
+          )
+          .handleError((error) {
+            if (error is FirebaseException) {
+              throw MessageException(
+                'Failed to stream messages: ${error.message}',
+                code: error.code,
+              );
+            }
+            throw MessageException(
+              'Failed to stream messages: $error',
+              code: 'stream-error',
+            );
+          });
+    } catch (e) {
+      throw MessageException(
+        'Failed to stream messages: $e',
+        code: 'stream-error',
+      );
+    }
+  }
+
+  @override
+  Future<void> sendMessage({
+    required String contextPath,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+    String? teamId,
+  }) async {
+    try {
+      final message = ChatMessageModel(
+        id: '',
+        senderId: senderId,
+        senderDisplayName: senderDisplayName,
+        text: text,
+        sentAt: DateTime.now(),
+        teamId: teamId,
+      );
+      await _firestore
+          .doc(contextPath)
+          .collection('messages')
+          .add(message.toFirestore());
+    } on FirebaseException catch (e) {
+      throw MessageException(
+        'Failed to send message: ${e.message}',
+        code: e.code,
+      );
+    } catch (e) {
+      throw MessageException('Failed to send message: $e');
+    }
+  }
+}

--- a/lib/core/domain/exceptions/repository_exceptions.dart
+++ b/lib/core/domain/exceptions/repository_exceptions.dart
@@ -99,3 +99,14 @@ class GameInvitationException implements Exception {
   @override
   String toString() => message;
 }
+
+/// Exception thrown by MessageRepository operations (Story 31.7).
+class MessageException implements Exception {
+  final String message;
+  final String? code;
+
+  MessageException(this.message, {this.code});
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/domain/repositories/game_repository.dart
+++ b/lib/core/domain/repositories/game_repository.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-import '../../data/models/chat_message_model.dart';
 import '../../data/models/game_model.dart';
 
 abstract class GameRepository {
@@ -189,16 +188,6 @@ abstract class GameRepository {
     DocumentSnapshot? lastDocument,
   });
 
-  /// Stream real-time messages for a game (ordered by sentAt ascending)
-  Stream<List<ChatMessageModel>> getMessages(String gameId);
-
-  /// Send a message to the game chat
-  Future<void> sendMessage({
-    required String gameId,
-    required String senderId,
-    required String senderDisplayName,
-    required String text,
-  });
 }
 
 /// Container for paginated game history results

--- a/lib/core/domain/repositories/message_repository.dart
+++ b/lib/core/domain/repositories/message_repository.dart
@@ -1,0 +1,16 @@
+import '../../data/models/chat_message_model.dart';
+
+abstract class MessageRepository {
+  /// Stream messages from [contextPath]/messages (ordered by sentAt ascending).
+  /// [contextPath] is a Firestore document path, e.g. 'games/gameId'.
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath});
+
+  /// Send a message to [contextPath]/messages.
+  Future<void> sendMessage({
+    required String contextPath,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+    String? teamId,
+  });
+}

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -22,6 +22,7 @@ import 'package:play_with_me/core/domain/repositories/image_storage_repository.d
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
 import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
 import 'package:play_with_me/core/domain/repositories/group_invite_link_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_user_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_group_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_game_repository.dart';
@@ -32,6 +33,7 @@ import 'package:play_with_me/core/data/repositories/firebase_image_storage_repos
 import 'package:play_with_me/core/data/repositories/firestore_invitation_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_friend_repository.dart';
 import 'package:play_with_me/core/data/repositories/firestore_group_invite_link_repository.dart';
+import 'package:play_with_me/core/data/repositories/firestore_message_repository.dart';
 import 'package:play_with_me/core/services/image_picker_service.dart';
 import 'package:play_with_me/core/presentation/bloc/user/user_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/group/group_bloc.dart';
@@ -142,6 +144,12 @@ Future<void> initializeDependencies() async {
 
   if (!sl.isRegistered<GameRepository>()) {
     sl.registerLazySingleton<GameRepository>(() => FirestoreGameRepository());
+  }
+
+  if (!sl.isRegistered<MessageRepository>()) {
+    sl.registerLazySingleton<MessageRepository>(
+      () => FirestoreMessageRepository(),
+    );
   }
 
   if (!sl.isRegistered<TrainingSessionRepository>()) {

--- a/lib/features/games/presentation/bloc/game_chat/game_chat_bloc.dart
+++ b/lib/features/games/presentation/bloc/game_chat/game_chat_bloc.dart
@@ -2,16 +2,16 @@
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
-import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'game_chat_event.dart';
 import 'game_chat_state.dart';
 
 class GameChatBloc extends Bloc<GameChatEvent, GameChatState> {
-  final GameRepository _gameRepository;
+  final MessageRepository _messageRepository;
   StreamSubscription<dynamic>? _messagesSubscription;
 
-  GameChatBloc({required GameRepository gameRepository})
-      : _gameRepository = gameRepository,
+  GameChatBloc({required MessageRepository messageRepository})
+      : _messageRepository = messageRepository,
         super(const GameChatInitial()) {
     on<LoadGameChat>(_onLoadGameChat);
     on<GameChatMessagesUpdated>(_onMessagesUpdated);
@@ -24,10 +24,12 @@ class GameChatBloc extends Bloc<GameChatEvent, GameChatState> {
   ) async {
     emit(const GameChatLoading());
     await _messagesSubscription?.cancel();
-    _messagesSubscription = _gameRepository.getMessages(event.gameId).listen(
-      (messages) => add(GameChatMessagesUpdated(messages: messages)),
-      onError: (_) => add(const GameChatMessagesUpdated(messages: [])),
-    );
+    _messagesSubscription = _messageRepository
+        .getMessages(contextPath: event.contextPath)
+        .listen(
+          (messages) => add(GameChatMessagesUpdated(messages: messages)),
+          onError: (_) => add(const GameChatMessagesUpdated(messages: [])),
+        );
   }
 
   void _onMessagesUpdated(
@@ -47,8 +49,8 @@ class GameChatBloc extends Bloc<GameChatEvent, GameChatState> {
     final current = state as GameChatLoaded;
     emit(current.copyWith(isSending: true));
     try {
-      await _gameRepository.sendMessage(
-        gameId: event.gameId,
+      await _messageRepository.sendMessage(
+        contextPath: event.contextPath,
         senderId: event.senderId,
         senderDisplayName: event.senderDisplayName,
         text: event.text,
@@ -60,7 +62,7 @@ class GameChatBloc extends Bloc<GameChatEvent, GameChatState> {
       if (latest is GameChatLoaded) {
         emit(latest.copyWith(isSending: false));
       }
-    } on GameException catch (e) {
+    } on MessageException catch (e) {
       emit(current.copyWith(isSending: false));
       // Don't emit error — just restore state (snackbar handled in widget)
       addError(Exception(e.message));

--- a/lib/features/games/presentation/bloc/game_chat/game_chat_event.dart
+++ b/lib/features/games/presentation/bloc/game_chat/game_chat_event.dart
@@ -9,10 +9,10 @@ abstract class GameChatEvent extends Equatable {
 }
 
 class LoadGameChat extends GameChatEvent {
-  final String gameId;
-  const LoadGameChat({required this.gameId});
+  final String contextPath;
+  const LoadGameChat({required this.contextPath});
   @override
-  List<Object?> get props => [gameId];
+  List<Object?> get props => [contextPath];
 }
 
 class GameChatMessagesUpdated extends GameChatEvent {
@@ -23,16 +23,16 @@ class GameChatMessagesUpdated extends GameChatEvent {
 }
 
 class SendChatMessage extends GameChatEvent {
-  final String gameId;
+  final String contextPath;
   final String senderId;
   final String senderDisplayName;
   final String text;
   const SendChatMessage({
-    required this.gameId,
+    required this.contextPath,
     required this.senderId,
     required this.senderDisplayName,
     required this.text,
   });
   @override
-  List<Object?> get props => [gameId, senderId, senderDisplayName, text];
+  List<Object?> get props => [contextPath, senderId, senderDisplayName, text];
 }

--- a/lib/features/games/presentation/widgets/game_chat_section.dart
+++ b/lib/features/games/presentation/widgets/game_chat_section.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:play_with_me/core/data/models/chat_message_model.dart';
-import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -16,7 +16,7 @@ class GameChatSection extends StatelessWidget {
   final String currentUserId;
   final String currentUserDisplayName;
   final bool isPlayer;
-  final GameRepository? gameRepository;
+  final MessageRepository? messageRepository;
 
   const GameChatSection({
     super.key,
@@ -24,17 +24,18 @@ class GameChatSection extends StatelessWidget {
     required this.currentUserId,
     required this.currentUserDisplayName,
     required this.isPlayer,
-    this.gameRepository,
+    this.messageRepository,
   });
 
   @override
   Widget build(BuildContext context) {
+    final contextPath = 'games/$gameId';
     return BlocProvider(
       create: (context) => GameChatBloc(
-        gameRepository: gameRepository ?? sl<GameRepository>(),
-      )..add(LoadGameChat(gameId: gameId)),
+        messageRepository: messageRepository ?? sl<MessageRepository>(),
+      )..add(LoadGameChat(contextPath: contextPath)),
       child: _GameChatView(
-        gameId: gameId,
+        contextPath: contextPath,
         currentUserId: currentUserId,
         currentUserDisplayName: currentUserDisplayName,
         isPlayer: isPlayer,
@@ -44,13 +45,13 @@ class GameChatSection extends StatelessWidget {
 }
 
 class _GameChatView extends StatefulWidget {
-  final String gameId;
+  final String contextPath;
   final String currentUserId;
   final String currentUserDisplayName;
   final bool isPlayer;
 
   const _GameChatView({
-    required this.gameId,
+    required this.contextPath,
     required this.currentUserId,
     required this.currentUserDisplayName,
     required this.isPlayer,
@@ -89,7 +90,7 @@ class _GameChatViewState extends State<_GameChatView> {
     _textController.clear();
     context.read<GameChatBloc>().add(
       SendChatMessage(
-        gameId: widget.gameId,
+        contextPath: widget.contextPath,
         senderId: widget.currentUserId,
         senderDisplayName: widget.currentUserDisplayName,
         text: text,

--- a/test/unit/core/data/repositories/mock_game_repository.dart
+++ b/test/unit/core/data/repositories/mock_game_repository.dart
@@ -2,7 +2,6 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart' as cloud_firestore;
-import 'package:play_with_me/core/data/models/chat_message_model.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
 
@@ -750,18 +749,6 @@ class MockGameRepository implements GameRepository {
     return controller.stream;
   }
 
-  @override
-  Stream<List<ChatMessageModel>> getMessages(String gameId) {
-    return Stream.value([]);
-  }
-
-  @override
-  Future<void> sendMessage({
-    required String gameId,
-    required String senderId,
-    required String senderDisplayName,
-    required String text,
-  }) async {}
 }
 
 // Test data helpers

--- a/test/unit/features/games/presentation/bloc/game_chat/game_chat_bloc_test.dart
+++ b/test/unit/features/games/presentation/bloc/game_chat/game_chat_bloc_test.dart
@@ -3,15 +3,17 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/chat_message_model.dart';
-import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_bloc.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_event.dart';
 import 'package:play_with_me/features/games/presentation/bloc/game_chat/game_chat_state.dart';
 
-class MockGameRepository extends Mock implements GameRepository {}
+class MockMessageRepository extends Mock implements MessageRepository {}
 
 void main() {
-  late MockGameRepository mockGameRepository;
+  late MockMessageRepository mockMessageRepository;
+
+  const testContextPath = 'games/game-1';
 
   final testMessage = ChatMessageModel(
     id: 'msg-1',
@@ -26,7 +28,7 @@ void main() {
   });
 
   setUp(() {
-    mockGameRepository = MockGameRepository();
+    mockMessageRepository = MockMessageRepository();
   });
 
   group('GameChatBloc', () {
@@ -34,11 +36,15 @@ void main() {
       blocTest<GameChatBloc, GameChatState>(
         'emits [loading, loaded] with messages from stream',
         build: () {
-          when(() => mockGameRepository.getMessages('game-1'))
-              .thenAnswer((_) => Stream.value([testMessage]));
-          return GameChatBloc(gameRepository: mockGameRepository);
+          when(
+            () => mockMessageRepository.getMessages(
+              contextPath: testContextPath,
+            ),
+          ).thenAnswer((_) => Stream.value([testMessage]));
+          return GameChatBloc(messageRepository: mockMessageRepository);
         },
-        act: (bloc) => bloc.add(const LoadGameChat(gameId: 'game-1')),
+        act: (bloc) =>
+            bloc.add(const LoadGameChat(contextPath: testContextPath)),
         expect: () => [
           const GameChatLoading(),
           GameChatLoaded(messages: [testMessage]),
@@ -48,11 +54,15 @@ void main() {
       blocTest<GameChatBloc, GameChatState>(
         'emits [loading, loaded with empty list] on stream error',
         build: () {
-          when(() => mockGameRepository.getMessages('game-1'))
-              .thenAnswer((_) => Stream.error(Exception('error')));
-          return GameChatBloc(gameRepository: mockGameRepository);
+          when(
+            () => mockMessageRepository.getMessages(
+              contextPath: testContextPath,
+            ),
+          ).thenAnswer((_) => Stream.error(Exception('error')));
+          return GameChatBloc(messageRepository: mockMessageRepository);
         },
-        act: (bloc) => bloc.add(const LoadGameChat(gameId: 'game-1')),
+        act: (bloc) =>
+            bloc.add(const LoadGameChat(contextPath: testContextPath)),
         expect: () => [
           const GameChatLoading(),
           const GameChatLoaded(messages: []),
@@ -64,22 +74,26 @@ void main() {
       blocTest<GameChatBloc, GameChatState>(
         'sends message and clears isSending flag',
         build: () {
-          when(() => mockGameRepository.getMessages('game-1'))
-              .thenAnswer((_) => Stream.value([testMessage]));
           when(
-            () => mockGameRepository.sendMessage(
-              gameId: any(named: 'gameId'),
+            () => mockMessageRepository.getMessages(
+              contextPath: testContextPath,
+            ),
+          ).thenAnswer((_) => Stream.value([testMessage]));
+          when(
+            () => mockMessageRepository.sendMessage(
+              contextPath: any(named: 'contextPath'),
               senderId: any(named: 'senderId'),
               senderDisplayName: any(named: 'senderDisplayName'),
               text: any(named: 'text'),
+              teamId: any(named: 'teamId'),
             ),
           ).thenAnswer((_) async {});
-          return GameChatBloc(gameRepository: mockGameRepository);
+          return GameChatBloc(messageRepository: mockMessageRepository);
         },
         seed: () => GameChatLoaded(messages: [testMessage]),
         act: (bloc) => bloc.add(
           const SendChatMessage(
-            gameId: 'game-1',
+            contextPath: testContextPath,
             senderId: 'user-1',
             senderDisplayName: 'Alice',
             text: 'Hello!',
@@ -93,10 +107,10 @@ void main() {
 
       blocTest<GameChatBloc, GameChatState>(
         'does nothing when state is not loaded',
-        build: () => GameChatBloc(gameRepository: mockGameRepository),
+        build: () => GameChatBloc(messageRepository: mockMessageRepository),
         act: (bloc) => bloc.add(
           const SendChatMessage(
-            gameId: 'game-1',
+            contextPath: testContextPath,
             senderId: 'user-1',
             senderDisplayName: 'Alice',
             text: 'Hello!',

--- a/test/widget/features/games/presentation/pages/game_details_page_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_page_test.dart
@@ -10,7 +10,9 @@ import 'package:play_with_me/core/data/models/user_model.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/features/auth/domain/entities/user_entity.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
@@ -30,6 +32,21 @@ class MockInvitationBloc extends Mock implements InvitationBloc {}
 class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 class MockInvitationRepository extends Mock implements InvitationRepository {}
+
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath}) =>
+      Stream.value([]);
+
+  @override
+  Future<void> sendMessage({
+    required String contextPath,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+    String? teamId,
+  }) async {}
+}
 
 void main() {
   late MockGameRepository mockGameRepository;
@@ -59,6 +76,7 @@ void main() {
     sl.registerLazySingleton<FirebaseAnalytics>(() => mockAnalytics);
     sl.registerLazySingleton<GameRepository>(() => mockGameRepository);
     sl.registerLazySingleton<InvitationRepository>(() => MockInvitationRepository());
+    sl.registerLazySingleton<MessageRepository>(() => _FakeMessageRepository());
     when(() => mockInvitationBloc.state).thenReturn(const InvitationInitial());
     when(
       () => mockInvitationBloc.stream,

--- a/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_result_entry_test.dart
@@ -9,7 +9,9 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
@@ -34,6 +36,21 @@ class MockInvitationBloc extends MockBloc<InvitationEvent, InvitationState>
 class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 class MockInvitationRepository extends Mock implements InvitationRepository {}
+
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath}) =>
+      Stream.value([]);
+
+  @override
+  Future<void> sendMessage({
+    required String contextPath,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+    String? teamId,
+  }) async {}
+}
 
 void main() {
   late MockGameRepository mockGameRepository;
@@ -88,6 +105,11 @@ void main() {
       sl.unregister<InvitationRepository>();
     }
     sl.registerSingleton<InvitationRepository>(MockInvitationRepository());
+
+    if (sl.isRegistered<MessageRepository>()) {
+      sl.unregister<MessageRepository>();
+    }
+    sl.registerSingleton<MessageRepository>(_FakeMessageRepository());
   });
 
   tearDown(() {

--- a/test/widget/features/games/presentation/pages/game_details_verification_test.dart
+++ b/test/widget/features/games/presentation/pages/game_details_verification_test.dart
@@ -9,7 +9,9 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
 import 'package:play_with_me/core/domain/repositories/invitation_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_event.dart';
 import 'package:play_with_me/core/presentation/bloc/invitation/invitation_state.dart';
@@ -32,6 +34,21 @@ class MockInvitationBloc extends MockBloc<InvitationEvent, InvitationState>
 class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 class MockInvitationRepository extends Mock implements InvitationRepository {}
+
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath}) =>
+      Stream.value([]);
+
+  @override
+  Future<void> sendMessage({
+    required String contextPath,
+    required String senderId,
+    required String senderDisplayName,
+    required String text,
+    String? teamId,
+  }) async {}
+}
 
 void main() {
   late MockGameRepository mockGameRepository;
@@ -83,6 +100,11 @@ void main() {
       sl.unregister<InvitationRepository>();
     }
     sl.registerSingleton<InvitationRepository>(MockInvitationRepository());
+
+    if (sl.isRegistered<MessageRepository>()) {
+      sl.unregister<MessageRepository>();
+    }
+    sl.registerSingleton<MessageRepository>(_FakeMessageRepository());
   });
 
   tearDown(() {

--- a/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
+++ b/test/widget/features/games/presentation/widgets/game_chat_section_test.dart
@@ -3,45 +3,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:play_with_me/core/data/models/chat_message_model.dart';
-import 'package:play_with_me/core/domain/repositories/game_repository.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 import 'package:play_with_me/features/games/presentation/widgets/game_chat_section.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
 // Minimal fake repository for widget tests — no streams, no Firebase.
-class _FakeGameRepository implements GameRepository {
+class _FakeMessageRepository implements MessageRepository {
   final List<ChatMessageModel> messages;
   final List<Map<String, String>> sentMessages = [];
 
-  _FakeGameRepository({this.messages = const []});
+  _FakeMessageRepository({this.messages = const []});
 
   @override
-  Stream<List<ChatMessageModel>> getMessages(String gameId) =>
+  Stream<List<ChatMessageModel>> getMessages({required String contextPath}) =>
       Stream.value(messages);
 
   @override
   Future<void> sendMessage({
-    required String gameId,
+    required String contextPath,
     required String senderId,
     required String senderDisplayName,
     required String text,
+    String? teamId,
   }) async {
     sentMessages.add({
-      'gameId': gameId,
+      'contextPath': contextPath,
       'senderId': senderId,
       'senderDisplayName': senderDisplayName,
       'text': text,
     });
   }
-
-  // All other methods throw UnimplementedError — they are not used by GameChatSection.
-  @override
-  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
-        '${invocation.memberName} is not implemented in _FakeGameRepository',
-      );
 }
 
 Widget _buildWidget({
-  required _FakeGameRepository repo,
+  required _FakeMessageRepository repo,
   bool isPlayer = true,
 }) {
   return MaterialApp(
@@ -59,7 +54,7 @@ Widget _buildWidget({
           currentUserId: 'current-user',
           currentUserDisplayName: 'Alice',
           isPlayer: isPlayer,
-          gameRepository: repo,
+          messageRepository: repo,
         ),
       ),
     ),
@@ -85,7 +80,7 @@ void main() {
 
   group('GameChatSection', () {
     testWidgets('shows empty message when no messages', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
       expect(
@@ -95,7 +90,7 @@ void main() {
     });
 
     testWidgets('renders other user messages', (tester) async {
-      final repo = _FakeGameRepository(messages: [messageFromOther]);
+      final repo = _FakeMessageRepository(messages: [messageFromOther]);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
       expect(find.text('Hello team!'), findsOneWidget);
@@ -103,7 +98,7 @@ void main() {
     });
 
     testWidgets('renders own messages without sender name', (tester) async {
-      final repo = _FakeGameRepository(messages: [messageFromSelf]);
+      final repo = _FakeMessageRepository(messages: [messageFromSelf]);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
       expect(find.text('Ready to play!'), findsOneWidget);
@@ -112,7 +107,7 @@ void main() {
     });
 
     testWidgets('shows input field for players', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo, isPlayer: true));
       await tester.pumpAndSettle();
       expect(find.byType(TextField), findsOneWidget);
@@ -120,7 +115,7 @@ void main() {
     });
 
     testWidgets('shows join-to-view message for non-players instead of chat', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo, isPlayer: false));
       await tester.pumpAndSettle();
       expect(find.byType(TextField), findsNothing);
@@ -129,7 +124,7 @@ void main() {
     });
 
     testWidgets('send button calls sendMessage on repository', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
 
@@ -140,20 +135,20 @@ void main() {
 
       expect(repo.sentMessages, hasLength(1));
       expect(repo.sentMessages.first['text'], 'Hello!');
-      expect(repo.sentMessages.first['gameId'], 'game-1');
+      expect(repo.sentMessages.first['contextPath'], 'games/game-1');
       expect(repo.sentMessages.first['senderId'], 'current-user');
       expect(repo.sentMessages.first['senderDisplayName'], 'Alice');
     });
 
     testWidgets('shows chat section title', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
       expect(find.text('Chat'), findsOneWidget);
     });
 
     testWidgets('clears text field after sending', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
 
@@ -167,7 +162,7 @@ void main() {
     });
 
     testWidgets('does not send empty message', (tester) async {
-      final repo = _FakeGameRepository(messages: []);
+      final repo = _FakeMessageRepository(messages: []);
       await tester.pumpWidget(_buildWidget(repo: repo));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

- Introduces `MessageRepository` abstract interface with a `contextPath`-based API, completely decoupling chat from the game domain. The context path (e.g. `games/{id}`) lets the same repository serve both game chat and any future chat context (championships, groups).
- `FirestoreMessageRepository` implements the interface by accessing `{contextPath}/messages` subcollections via `_firestore.doc(contextPath).collection('messages')`.
- Adds optional `teamId` to `ChatMessageModel` (freezed) — the single model for all chat contexts going forward; no `ChampionshipMessageModel` needed.
- `getMessages` / `sendMessage` removed from `GameRepository` and `FirestoreGameRepository`; those interfaces are now leaner.
- `GameChatBloc` and its events updated to use `MessageRepository` with `contextPath`; `GameChatSection` builds `'games/$gameId'` and passes it down.
- `MessageException` added to repository exceptions; `MessageRepository` registered in service locator.
- All affected unit and widget tests updated.

## Test plan

- [x] `flutter analyze lib/` — no issues
- [x] `flutter test test/unit/ test/widget/` — 0 failures (same baseline as `main`)
- [x] `GameChatBloc` unit tests verify stream subscription and send via `MockMessageRepository`
- [x] `GameChatSection` widget tests verify rendering and send via `_FakeMessageRepository`
- [x] `GameDetailsPage`, result-entry, and verification widget tests register `_FakeMessageRepository` in GetIt