### PR TITLE
feat(championships): createChampionship admin-only callable Cloud Function (Story 30.2)

### DIFF
--- a/functions/src/createChampionship.ts
+++ b/functions/src/createChampionship.ts
@@ -1,0 +1,180 @@
+// Cloud Function for creating championships — admin-only callable (Story 30.2)
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface CreateChampionshipRequest {
+  title: string;
+  registrationDeadline: string; // ISO 8601 date
+  country?: string; // ISO 3166-1 alpha-2
+  region?: string;
+}
+
+interface CreateChampionshipResponse {
+  championshipId: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Checks whether the given uid is a platform admin.
+ * Looks up the `platform_admins/{uid}` document — if it exists the caller is an admin.
+ */
+async function isPlatformAdmin(uid: string): Promise<boolean> {
+  const db = admin.firestore();
+  const adminDoc = await db.collection("platform_admins").doc(uid).get();
+  return adminDoc.exists;
+}
+
+/**
+ * Validates the championship title.
+ */
+function validateTitle(title: string): string | null {
+  if (!title || title.trim().length === 0) {
+    return "Title is required";
+  }
+  if (title.trim().length < 3) {
+    return "Title must be at least 3 characters";
+  }
+  if (title.trim().length > 100) {
+    return "Title must be less than 100 characters";
+  }
+  return null;
+}
+
+/**
+ * Validates the registration deadline — must be a valid ISO 8601 date in the future.
+ */
+function validateDeadline(registrationDeadline: string): { date: Date; error: string | null } {
+  const date = new Date(registrationDeadline);
+  if (isNaN(date.getTime())) {
+    return { date, error: "registrationDeadline must be a valid ISO 8601 date" };
+  }
+  if (date <= new Date()) {
+    return { date, error: "registrationDeadline must be in the future" };
+  }
+  return { date, error: null };
+}
+
+// ============================================================================
+// Main Cloud Function
+// ============================================================================
+
+/**
+ * Inner handler — exported separately so unit tests can call it directly
+ * without needing the full Firebase Functions wrapper.
+ */
+export async function createChampionshipHandler(
+  data: CreateChampionshipRequest,
+  context: functions.https.CallableContext
+): Promise<CreateChampionshipResponse> {
+  // ========================================
+  // 1. Authentication Check
+  // ========================================
+  if (!context.auth) {
+    functions.logger.warn("Unauthenticated attempt to create championship");
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to create a championship"
+    );
+  }
+
+  const userId = context.auth.uid;
+
+  functions.logger.info("createChampionship called", {
+    userId,
+    title: data?.title,
+  });
+
+  // ========================================
+  // 2. Admin Permission Check
+  // ========================================
+  const adminCheck = await isPlatformAdmin(userId);
+  if (!adminCheck) {
+    functions.logger.warn("Non-admin attempted to create championship", { userId });
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Only platform admins can create championships"
+    );
+  }
+
+  // ========================================
+  // 3. Input Validation
+  // ========================================
+  if (!data || !data.title || !data.registrationDeadline) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required fields: title, registrationDeadline"
+    );
+  }
+
+  const titleError = validateTitle(data.title);
+  if (titleError) {
+    throw new functions.https.HttpsError("invalid-argument", titleError);
+  }
+
+  const { date: deadline, error: deadlineError } = validateDeadline(data.registrationDeadline);
+  if (deadlineError) {
+    throw new functions.https.HttpsError("invalid-argument", deadlineError);
+  }
+
+  // ========================================
+  // 4. Create Championship Document
+  // ========================================
+  const db = admin.firestore();
+
+  try {
+    const championshipData = {
+      title: data.title.trim(),
+      status: "registration",
+      maxTeams: 10,
+      teamSize: 2,
+      adminIds: [userId],
+      currentRound: 0,
+      totalRounds: 9,
+      teamsCount: 0,
+      registrationDeadline: admin.firestore.Timestamp.fromDate(deadline),
+      country: data.country?.toUpperCase() ?? null,
+      region: data.region?.trim() ?? null,
+      createdBy: userId,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+
+    const docRef = await db.collection("championships").add(championshipData);
+
+    functions.logger.info("Championship created successfully", {
+      championshipId: docRef.id,
+      userId,
+    });
+
+    return { championshipId: docRef.id };
+  } catch (error) {
+    functions.logger.error("Failed to create championship", { userId, error });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to create championship. Please try again."
+    );
+  }
+}
+
+/**
+ * Creates a new championship. Only platform admins may call this function.
+ *
+ * Security:
+ * - Validates authentication
+ * - Validates caller is a platform admin (platform_admins/{uid} doc must exist)
+ * - Validates all input parameters
+ * - Uses Admin SDK to write to Firestore (bypasses security rules)
+ */
+export const createChampionship = functions
+  .region("europe-west6")
+  .runWith({
+    timeoutSeconds: 30,
+    memory: "256MB",
+  })
+  .https.onCall(createChampionshipHandler);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,6 +26,7 @@ export {getHeadToHeadStats} from "./getHeadToHeadStats"; // Story 301.8
 export {calculateUserRanking} from "./calculateUserRanking"; // Story 302.2
 export {createTrainingSession} from "./createTrainingSession"; // Story 15.1 (Epic 15: Training Sessions)
 export {createPickupGame} from "./createPickupGame"; // Story 31.8 (Pickup Game Creation)
+export {createChampionship} from "./createChampionship"; // Story 30.2 (Championship Creation)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)

--- a/functions/test/unit/createChampionship.test.ts
+++ b/functions/test/unit/createChampionship.test.ts
@@ -1,0 +1,282 @@
+// Unit tests for createChampionship Cloud Function (Story 30.2).
+// Validates admin check, input validation, and successful document creation.
+
+import { createChampionshipHandler } from "../../src/createChampionship";
+import type * as functionsTypes from "firebase-functions";
+
+// ── Mock firebase-functions ───────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((handler: any) => handler),
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+  fn.region = jest.fn(() => fn);
+  fn.runWith = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Mock firebase-admin ───────────────────────────────────────────────────────
+
+const mockAdd = jest.fn();
+const mockAdminDocGet = jest.fn();
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn((col: string) => {
+          if (col === "platform_admins") {
+            return { doc: jest.fn(() => ({ get: mockAdminDocGet })) };
+          }
+          if (col === "championships") {
+            return { add: mockAdd };
+          }
+          return {};
+        }),
+      })),
+      {
+        FieldValue: {
+          serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+        },
+        Timestamp: {
+          fromDate: jest.fn((d: Date) => ({ _seconds: Math.floor(d.getTime() / 1000) })),
+        },
+      }
+    ),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeContext(uid: string | null = "admin-uid"): functionsTypes.https.CallableContext {
+  return uid ? ({ auth: { uid, token: {} as any } } as any) : ({ auth: undefined } as any);
+}
+
+function futureDate(offsetDays = 30): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("createChampionship", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: caller is a platform admin
+    mockAdminDocGet.mockResolvedValue({ exists: true });
+    // Default: Firestore add resolves with a doc id
+    mockAdd.mockResolvedValue({ id: "champ-123" });
+  });
+
+  // ── Authentication ─────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("throws unauthenticated when no auth context", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship", registrationDeadline: futureDate() },
+          makeContext(null)
+        )
+      ).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+  });
+
+  // ── Admin check ────────────────────────────────────────────────────────────
+
+  describe("admin permission", () => {
+    it("throws permission-denied when caller is not a platform admin", async () => {
+      mockAdminDocGet.mockResolvedValue({ exists: false });
+
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship", registrationDeadline: futureDate() },
+          makeContext("regular-user")
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+
+    it("proceeds when caller is a platform admin", async () => {
+      mockAdminDocGet.mockResolvedValue({ exists: true });
+
+      const result = await createChampionshipHandler(
+        { title: "Summer Championship", registrationDeadline: futureDate() },
+        makeContext("admin-uid")
+      );
+
+      expect(result).toEqual({ championshipId: "champ-123" });
+    });
+  });
+
+  // ── Input validation ───────────────────────────────────────────────────────
+
+  describe("input validation", () => {
+    it("throws invalid-argument when title is missing", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "", registrationDeadline: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when title is too short (< 3 chars)", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "AB", registrationDeadline: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when title exceeds 100 characters", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "A".repeat(101), registrationDeadline: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when registrationDeadline is missing", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship" } as any,
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when registrationDeadline is not a valid date", async () => {
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship", registrationDeadline: "not-a-date" },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when registrationDeadline is in the past", async () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 1);
+
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship", registrationDeadline: pastDate.toISOString() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+  });
+
+  // ── Successful creation ────────────────────────────────────────────────────
+
+  describe("successful creation", () => {
+    it("creates championship with required fields and correct defaults", async () => {
+      const deadline = futureDate(30);
+
+      await createChampionshipHandler(
+        { title: "Summer Championship 2026", registrationDeadline: deadline },
+        makeContext("admin-uid")
+      );
+
+      expect(mockAdd).toHaveBeenCalledTimes(1);
+      const [written] = mockAdd.mock.calls[0];
+      expect(written).toMatchObject({
+        title: "Summer Championship 2026",
+        status: "registration",
+        maxTeams: 10,
+        teamSize: 2,
+        adminIds: ["admin-uid"],
+        currentRound: 0,
+        totalRounds: 9,
+        teamsCount: 0,
+        createdBy: "admin-uid",
+      });
+    });
+
+    it("returns the new championship id", async () => {
+      mockAdd.mockResolvedValue({ id: "new-champ-id" });
+
+      const result = await createChampionshipHandler(
+        { title: "Winter Cup", registrationDeadline: futureDate() },
+        makeContext("admin-uid")
+      );
+
+      expect(result).toEqual({ championshipId: "new-champ-id" });
+    });
+
+    it("stores optional country in uppercase", async () => {
+      await createChampionshipHandler(
+        { title: "French Open", registrationDeadline: futureDate(), country: "fr" },
+        makeContext("admin-uid")
+      );
+
+      const [written] = mockAdd.mock.calls[0];
+      expect(written.country).toBe("FR");
+    });
+
+    it("stores optional region trimmed", async () => {
+      await createChampionshipHandler(
+        { title: "Alsace Cup", registrationDeadline: futureDate(), country: "FR", region: "  Alsace  " },
+        makeContext("admin-uid")
+      );
+
+      const [written] = mockAdd.mock.calls[0];
+      expect(written.region).toBe("Alsace");
+    });
+
+    it("sets country and region to null when not provided", async () => {
+      await createChampionshipHandler(
+        { title: "Open Championship", registrationDeadline: futureDate() },
+        makeContext("admin-uid")
+      );
+
+      const [written] = mockAdd.mock.calls[0];
+      expect(written.country).toBeNull();
+      expect(written.region).toBeNull();
+    });
+
+    it("trims leading and trailing whitespace from title", async () => {
+      await createChampionshipHandler(
+        { title: "  Beach Open  ", registrationDeadline: futureDate() },
+        makeContext("admin-uid")
+      );
+
+      const [written] = mockAdd.mock.calls[0];
+      expect(written.title).toBe("Beach Open");
+    });
+  });
+
+  // ── Firestore failure ──────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("throws internal when Firestore add fails", async () => {
+      mockAdd.mockRejectedValue(new Error("Firestore unavailable"));
+
+      await expect(
+        createChampionshipHandler(
+          { title: "Summer Championship", registrationDeadline: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "internal" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `createChampionship` callable Cloud Function in `europe-west6`
- Admin-only: caller must have a document in `platform_admins/{uid}` collection
- Creates `championships/{id}` with `status: 'registration'`, `maxTeams: 10`, `teamSize: 2`, `totalRounds: 9`, `teamsCount: 0`, `currentRound: 0`
- Accepts optional `country` (stored uppercase) and `region` (stored trimmed)
- Exports `createChampionshipHandler` separately so unit tests bypass the Functions wrapper

## Error codes
| Code | Condition |
|------|-----------|
| `unauthenticated` | Not logged in |
| `permission-denied` | Caller not in `platform_admins` collection |
| `invalid-argument` | Missing/invalid title or deadline in the past |
| `internal` | Firestore write failure |

## Test plan
- 16 unit tests — all passing (`npm test`)
- Covers: auth, admin check, all validation branches, successful creation (defaults, country uppercasing, region trimming, title trimming), Firestore failure
- Full suite: 569/569 ✓

Closes #745