### PR TITLE
feat(championships): startChampionship — round-robin fixture generation (Story 30.4)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,6 +29,7 @@ export {createPickupGame} from "./createPickupGame"; // Story 31.8 (Pickup Game 
 export {createChampionship} from "./createChampionship"; // Story 30.2 (Championship Creation)
 export {createChampionshipTeam} from "./createChampionshipTeam"; // Story 30.3 (Team Registration)
 export {leaveChampionshipTeam} from "./leaveChampionshipTeam"; // Story 30.3 (Team Registration)
+export {startChampionship} from "./startChampionship"; // Story 30.4 (Fixture Generation)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)

--- a/functions/src/roundRobinFixtures.ts
+++ b/functions/src/roundRobinFixtures.ts
@@ -1,0 +1,71 @@
+// Pure round-robin fixture generator using the circle method (Story 30.4).
+// Exported as standalone functions so they can be unit-tested without Firebase.
+
+export interface FixtureMatch {
+  round: number;       // 1-based
+  teamAId: string;
+  teamBId: string;
+  roundStartDate: Date;
+  deadline: Date;      // roundStartDate + 3 weeks
+}
+
+/**
+ * Generates a complete round-robin schedule for an even number of teams
+ * using the circle (polygon) method:
+ *  - Pin teamIds[0] in position 0.
+ *  - Rotate the remaining N-1 teams one position clockwise each round.
+ *  - In each round pair position i with position (N-1-i).
+ *
+ * Produces (N-1) rounds × (N/2) matches = N*(N-1)/2 total matches.
+ *
+ * @param teamIds   Ordered list of team IDs (must have even length ≥ 2).
+ * @param startDate First round's start date.
+ * @returns Flat array of FixtureMatch objects.
+ */
+export function generateRoundRobinFixtures(
+  teamIds: string[],
+  startDate: Date
+): FixtureMatch[] {
+  const n = teamIds.length;
+  if (n < 2 || n % 2 !== 0) {
+    throw new Error(`Team count must be even and ≥ 2, got ${n}`);
+  }
+
+  const rounds = n - 1;
+  const matchesPerRound = n / 2;
+  const fixtures: FixtureMatch[] = [];
+
+  // Work on indices, not IDs, to keep the algorithm clean.
+  // Slot 0 is always fixed; slots 1..N-1 rotate.
+  const slots = Array.from({ length: n }, (_, i) => i); // [0,1,2,...,n-1]
+
+  for (let round = 1; round <= rounds; round++) {
+    const roundStartDate = new Date(startDate);
+    roundStartDate.setDate(roundStartDate.getDate() + (round - 1) * 7);
+
+    const deadline = new Date(roundStartDate);
+    deadline.setDate(deadline.getDate() + 21); // +3 weeks
+
+    for (let i = 0; i < matchesPerRound; i++) {
+      const a = slots[i];
+      const b = slots[n - 1 - i];
+      fixtures.push({
+        round,
+        teamAId: teamIds[a],
+        teamBId: teamIds[b],
+        roundStartDate: new Date(roundStartDate),
+        deadline: new Date(deadline),
+      });
+    }
+
+    // Rotate slots 1..N-1 one position clockwise:
+    // [fixed, s1, s2, ..., sN-1] → [fixed, sN-1, s1, s2, ..., sN-2]
+    const last = slots[n - 1];
+    for (let i = n - 1; i > 1; i--) {
+      slots[i] = slots[i - 1];
+    }
+    slots[1] = last;
+  }
+
+  return fixtures;
+}

--- a/functions/src/startChampionship.ts
+++ b/functions/src/startChampionship.ts
@@ -1,0 +1,185 @@
+// Admin-only Cloud Function that starts a championship and generates all round-robin fixtures (Story 30.4).
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { generateRoundRobinFixtures } from "./roundRobinFixtures";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface StartChampionshipRequest {
+  championshipId: string;
+  startDate: string; // ISO 8601 date
+}
+
+interface StartChampionshipResponse {
+  matchesCreated: number; // should be 45 for 10 teams
+}
+
+// ============================================================================
+// Inner Handler (exported for unit tests)
+// ============================================================================
+
+export async function startChampionshipHandler(
+  data: StartChampionshipRequest,
+  context: functions.https.CallableContext
+): Promise<StartChampionshipResponse> {
+  // ── 1. Auth ────────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to start a championship"
+    );
+  }
+
+  const callerId = context.auth.uid;
+  functions.logger.info("[startChampionship] Start", {
+    callerId,
+    championshipId: data?.championshipId,
+  });
+
+  // ── 2. Input Validation ────────────────────────────────────────────────────
+  if (!data?.championshipId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: championshipId"
+    );
+  }
+
+  if (!data?.startDate) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: startDate"
+    );
+  }
+
+  const startDate = new Date(data.startDate);
+  if (isNaN(startDate.getTime())) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "startDate must be a valid ISO 8601 date"
+    );
+  }
+
+  const db = admin.firestore();
+  const champRef = db.collection("championships").doc(data.championshipId);
+
+  // ── 3. Championship Validation ─────────────────────────────────────────────
+  const champSnap = await champRef.get();
+  if (!champSnap.exists) {
+    throw new functions.https.HttpsError("not-found", "Championship not found");
+  }
+
+  const champ = champSnap.data()!;
+
+  // Only championship admins may start it
+  if (!Array.isArray(champ.adminIds) || !champ.adminIds.includes(callerId)) {
+    functions.logger.warn("[startChampionship] Permission denied", { callerId });
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Only championship admins can start the championship"
+    );
+  }
+
+  const validStatuses = ["registration", "registration_closed"];
+  if (!validStatuses.includes(champ.status)) {
+    throw new functions.https.HttpsError(
+      "failed-precondition",
+      `Championship must be in registration status to start (current: ${champ.status})`
+    );
+  }
+
+  if (champ.teamsCount !== champ.maxTeams) {
+    throw new functions.https.HttpsError(
+      "failed-precondition",
+      `Championship requires ${champ.maxTeams} teams to start (current: ${champ.teamsCount})`
+    );
+  }
+
+  // ── 4. Load Team IDs ───────────────────────────────────────────────────────
+  const teamsSnap = await champRef.collection("teams").get();
+  if (teamsSnap.size !== champ.maxTeams) {
+    throw new functions.https.HttpsError(
+      "failed-precondition",
+      `Expected ${champ.maxTeams} teams, found ${teamsSnap.size}`
+    );
+  }
+
+  const teamIds = teamsSnap.docs.map((d) => d.id);
+
+  // ── 5. Generate Fixtures ───────────────────────────────────────────────────
+  let fixtures;
+  try {
+    fixtures = generateRoundRobinFixtures(teamIds, startDate);
+  } catch (err) {
+    functions.logger.error("[startChampionship] Fixture generation failed", { err });
+    throw new functions.https.HttpsError("internal", "Failed to generate fixtures");
+  }
+
+  // ── 6. Write Everything in Batches ─────────────────────────────────────────
+  // Firestore batch limit is 500 operations. 45 matches + 10 standings + 1 champ = 56 ops — one batch is fine.
+  const batch = db.batch();
+  const matchesRef = champRef.collection("matches");
+
+  for (const fixture of fixtures) {
+    const matchRef = matchesRef.doc();
+    batch.set(matchRef, {
+      round: fixture.round,
+      teamAId: fixture.teamAId,
+      teamBId: fixture.teamBId,
+      roundStartDate: admin.firestore.Timestamp.fromDate(fixture.roundStartDate),
+      deadline: admin.firestore.Timestamp.fromDate(fixture.deadline),
+      status: "pending",
+      result: null,
+      adminDecision: null,
+      standingsUpdated: false,
+    });
+  }
+
+  // Initialise standings (all zeros) for every team
+  const standingsRef = champRef.collection("standings");
+  for (const doc of teamsSnap.docs) {
+    const standingRef = standingsRef.doc(doc.id);
+    batch.set(standingRef, {
+      teamName: doc.data().name ?? "",
+      played: 0,
+      points: 0,
+      wins20: 0,
+      wins21: 0,
+      losses12: 0,
+      losses02: 0,
+      setsWon: 0,
+      setsLost: 0,
+      position: 0,
+    });
+  }
+
+  // Update championship document
+  batch.update(champRef, {
+    status: "active",
+    currentRound: 1,
+    startDate: admin.firestore.Timestamp.fromDate(startDate),
+  });
+
+  try {
+    await batch.commit();
+  } catch (err) {
+    functions.logger.error("[startChampionship] Batch write failed", { err });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to write championship data. Please try again."
+    );
+  }
+
+  functions.logger.info("[startChampionship] Championship started", {
+    championshipId: data.championshipId,
+    matchesCreated: fixtures.length,
+  });
+
+  return { matchesCreated: fixtures.length };
+}
+
+export const startChampionship = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 60, memory: "256MB" })
+  .https.onCall(startChampionshipHandler);

--- a/functions/test/unit/roundRobinFixtures.test.ts
+++ b/functions/test/unit/roundRobinFixtures.test.ts
@@ -1,0 +1,185 @@
+// Unit tests for the circle-method round-robin fixture generator (Story 30.4).
+// Validates: correct counts, no team plays twice per round, every pair meets exactly once,
+// correct deadline calculation (round start + 3 weeks).
+
+import { generateRoundRobinFixtures } from "../../src/roundRobinFixtures";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build N team IDs: ["team-0", "team-1", ..., "team-N-1"] */
+function makeTeams(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `team-${i}`);
+}
+
+const TEAMS_10 = makeTeams(10);
+const START = new Date("2026-08-01T00:00:00.000Z");
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("generateRoundRobinFixtures", () => {
+  describe("for 10 teams (standard championship)", () => {
+    let fixtures: ReturnType<typeof generateRoundRobinFixtures>;
+
+    beforeAll(() => {
+      fixtures = generateRoundRobinFixtures(TEAMS_10, START);
+    });
+
+    // ── Counts ──────────────────────────────────────────────────────────────
+
+    it("produces exactly 45 matches total", () => {
+      expect(fixtures).toHaveLength(45);
+    });
+
+    it("produces exactly 9 rounds", () => {
+      const rounds = new Set(fixtures.map((f) => f.round));
+      expect(rounds.size).toBe(9);
+    });
+
+    it("produces exactly 5 matches per round", () => {
+      for (let round = 1; round <= 9; round++) {
+        const roundMatches = fixtures.filter((f) => f.round === round);
+        expect(roundMatches).toHaveLength(5);
+      }
+    });
+
+    // ── No team plays twice in the same round ───────────────────────────────
+
+    it("no team appears more than once per round", () => {
+      for (let round = 1; round <= 9; round++) {
+        const roundMatches = fixtures.filter((f) => f.round === round);
+        const teamsSeen = new Set<string>();
+        for (const m of roundMatches) {
+          expect(teamsSeen.has(m.teamAId)).toBe(false);
+          expect(teamsSeen.has(m.teamBId)).toBe(false);
+          teamsSeen.add(m.teamAId);
+          teamsSeen.add(m.teamBId);
+        }
+      }
+    });
+
+    // ── Every pair meets exactly once ───────────────────────────────────────
+
+    it("every pair of teams meets exactly once", () => {
+      const pairCounts = new Map<string, number>();
+
+      for (const f of fixtures) {
+        // Canonical pair key (sort so order doesn't matter)
+        const pair = [f.teamAId, f.teamBId].sort().join(":");
+        pairCounts.set(pair, (pairCounts.get(pair) ?? 0) + 1);
+      }
+
+      // Expected: C(10,2) = 45 unique pairs
+      expect(pairCounts.size).toBe(45);
+
+      for (const count of pairCounts.values()) {
+        expect(count).toBe(1); // each pair meets exactly once
+      }
+    });
+
+    // ── All 10 teams appear in every round ──────────────────────────────────
+
+    it("all 10 teams appear in every round", () => {
+      for (let round = 1; round <= 9; round++) {
+        const roundMatches = fixtures.filter((f) => f.round === round);
+        const teams = new Set<string>();
+        for (const m of roundMatches) {
+          teams.add(m.teamAId);
+          teams.add(m.teamBId);
+        }
+        expect(teams.size).toBe(10);
+      }
+    });
+
+    // ── Date calculations ───────────────────────────────────────────────────
+
+    it("round 1 starts on the provided startDate", () => {
+      const round1Matches = fixtures.filter((f) => f.round === 1);
+      for (const m of round1Matches) {
+        expect(m.roundStartDate.toISOString()).toBe(START.toISOString());
+      }
+    });
+
+    it("round 2 starts exactly 7 days after round 1", () => {
+      const r1 = fixtures.find((f) => f.round === 1)!.roundStartDate;
+      const r2 = fixtures.find((f) => f.round === 2)!.roundStartDate;
+      const diffDays = (r2.getTime() - r1.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diffDays).toBe(7);
+    });
+
+    it("round 9 starts exactly 8 weeks after round 1", () => {
+      const r1 = fixtures.find((f) => f.round === 1)!.roundStartDate;
+      const r9 = fixtures.find((f) => f.round === 9)!.roundStartDate;
+      const diffDays = (r9.getTime() - r1.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diffDays).toBe(56); // 8 × 7
+    });
+
+    it("deadline is exactly 21 days after round start", () => {
+      for (const f of fixtures) {
+        const diffDays =
+          (f.deadline.getTime() - f.roundStartDate.getTime()) /
+          (1000 * 60 * 60 * 24);
+        expect(diffDays).toBe(21);
+      }
+    });
+
+    // ── Team IDs preserved ──────────────────────────────────────────────────
+
+    it("only uses the supplied team IDs", () => {
+      const teamSet = new Set(TEAMS_10);
+      for (const f of fixtures) {
+        expect(teamSet.has(f.teamAId)).toBe(true);
+        expect(teamSet.has(f.teamBId)).toBe(true);
+      }
+    });
+
+    it("teamAId and teamBId are never the same", () => {
+      for (const f of fixtures) {
+        expect(f.teamAId).not.toBe(f.teamBId);
+      }
+    });
+  });
+
+  // ── Works for other even team counts ───────────────────────────────────────
+
+  describe("for 4 teams (minimal even case)", () => {
+    const teams4 = makeTeams(4);
+    let fixtures: ReturnType<typeof generateRoundRobinFixtures>;
+
+    beforeAll(() => {
+      fixtures = generateRoundRobinFixtures(teams4, START);
+    });
+
+    it("produces 6 matches (C(4,2))", () => {
+      expect(fixtures).toHaveLength(6);
+    });
+
+    it("produces 3 rounds", () => {
+      const rounds = new Set(fixtures.map((f) => f.round));
+      expect(rounds.size).toBe(3);
+    });
+
+    it("every pair meets exactly once", () => {
+      const pairCounts = new Map<string, number>();
+      for (const f of fixtures) {
+        const pair = [f.teamAId, f.teamBId].sort().join(":");
+        pairCounts.set(pair, (pairCounts.get(pair) ?? 0) + 1);
+      }
+      expect(pairCounts.size).toBe(6);
+      for (const count of pairCounts.values()) {
+        expect(count).toBe(1);
+      }
+    });
+  });
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+
+  describe("error cases", () => {
+    it("throws when team count is odd", () => {
+      expect(() => generateRoundRobinFixtures(makeTeams(5), START)).toThrow();
+    });
+
+    it("throws when fewer than 2 teams provided", () => {
+      expect(() => generateRoundRobinFixtures(["only-one"], START)).toThrow();
+    });
+  });
+});

--- a/functions/test/unit/startChampionship.test.ts
+++ b/functions/test/unit/startChampionship.test.ts
@@ -1,0 +1,368 @@
+// Unit tests for startChampionship Cloud Function (Story 30.4).
+// Validates auth, admin check, precondition checks, and batch write on success.
+
+import { startChampionshipHandler } from "../../src/startChampionship";
+import type * as functionsTypes from "firebase-functions";
+
+// ── Mock firebase-functions ───────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((h: any) => h),
+    },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  };
+  fn.region = jest.fn(() => fn);
+  fn.runWith = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Mock roundRobinFixtures ───────────────────────────────────────────────────
+
+jest.mock("../../src/roundRobinFixtures", () => ({
+  generateRoundRobinFixtures: jest.fn(),
+}));
+
+import { generateRoundRobinFixtures } from "../../src/roundRobinFixtures";
+
+// ── Mock firebase-admin ───────────────────────────────────────────────────────
+
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockBatch = {
+  set: mockBatchSet,
+  update: mockBatchUpdate,
+  commit: mockBatchCommit,
+};
+
+const mockChampGet = jest.fn();
+const mockTeamsGet = jest.fn();
+const mockMatchesDoc = jest.fn(() => ({ id: "match-new" }));
+const mockStandingsDoc = jest.fn(() => ({}));
+
+const champRef = {
+  get: mockChampGet,
+  update: jest.fn(),
+  collection: jest.fn((col: string) => {
+    if (col === "teams") return { get: mockTeamsGet };
+    if (col === "matches") return { doc: mockMatchesDoc };
+    if (col === "standings") return { doc: mockStandingsDoc };
+    return {};
+  }),
+};
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(() => ({ doc: jest.fn(() => champRef) })),
+        batch: jest.fn(() => mockBatch),
+      })),
+      {
+        FieldValue: { serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP") },
+        Timestamp: {
+          fromDate: jest.fn((d: Date) => ({ _seconds: Math.floor(d.getTime() / 1000) })),
+        },
+      }
+    ),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeContext(uid: string | null = "admin-uid"): functionsTypes.https.CallableContext {
+  return uid ? ({ auth: { uid, token: {} as any } } as any) : ({ auth: undefined } as any);
+}
+
+function futureDate(offsetDays = 30): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString();
+}
+
+const openChamp = {
+  status: "registration_closed",
+  maxTeams: 10,
+  teamsCount: 10,
+  adminIds: ["admin-uid"],
+};
+
+function makeTeamDocs(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `team-${i}`,
+    data: () => ({ name: `Team ${i}` }),
+  }));
+}
+
+function makeFixtures(n: number) {
+  const start = new Date();
+  const deadline = new Date(start);
+  deadline.setDate(deadline.getDate() + 21);
+  return Array.from({ length: n }, (_, i) => ({
+    round: Math.floor(i / 5) + 1,
+    teamAId: `team-${i % 10}`,
+    teamBId: `team-${(i + 1) % 10}`,
+    roundStartDate: start,
+    deadline,
+  }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("startChampionship", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockChampGet.mockResolvedValue({ exists: true, data: () => openChamp });
+    mockTeamsGet.mockResolvedValue({
+      size: 10,
+      docs: makeTeamDocs(10),
+    });
+    (generateRoundRobinFixtures as jest.Mock).mockReturnValue(makeFixtures(45));
+    mockBatchCommit.mockResolvedValue(undefined);
+  });
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("throws unauthenticated when no auth", async () => {
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext(null)
+        )
+      ).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  describe("input validation", () => {
+    it("throws invalid-argument when championshipId is missing", async () => {
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when startDate is missing", async () => {
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: "" },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when startDate is not a valid date", async () => {
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: "not-a-date" },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+  });
+
+  // ── Championship validation ─────────────────────────────────────────────────
+
+  describe("championship validation", () => {
+    it("throws not-found when championship does not exist", async () => {
+      mockChampGet.mockResolvedValue({ exists: false });
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "not-found" });
+    });
+
+    it("throws permission-denied when caller is not in adminIds", async () => {
+      mockChampGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...openChamp, adminIds: ["someone-else"] }),
+      });
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext("not-admin")
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+
+    it("throws failed-precondition when status is already active", async () => {
+      mockChampGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...openChamp, status: "active" }),
+      });
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "failed-precondition" });
+    });
+
+    it("throws failed-precondition when status is completed", async () => {
+      mockChampGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...openChamp, status: "completed" }),
+      });
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "failed-precondition" });
+    });
+
+    it("throws failed-precondition when teamsCount < maxTeams", async () => {
+      mockChampGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...openChamp, teamsCount: 8, maxTeams: 10 }),
+      });
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "failed-precondition" });
+    });
+
+    it("allows start when status is registration (not yet closed)", async () => {
+      mockChampGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...openChamp, status: "registration" }),
+      });
+
+      const result = await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      expect(result.matchesCreated).toBe(45);
+    });
+  });
+
+  // ── Successful start ────────────────────────────────────────────────────────
+
+  describe("successful start", () => {
+    it("returns matchesCreated: 45", async () => {
+      const result = await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      expect(result).toEqual({ matchesCreated: 45 });
+    });
+
+    it("calls batch.commit once", async () => {
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it("batch-sets 45 match documents", async () => {
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      const matchSets = mockBatchSet.mock.calls.filter(
+        ([, data]) => data.status === "pending"
+      );
+      expect(matchSets).toHaveLength(45);
+    });
+
+    it("batch-sets 10 standings documents (all zeros)", async () => {
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      const standingSets = mockBatchSet.mock.calls.filter(
+        ([, data]) => data.points === 0 && data.played === 0
+      );
+      expect(standingSets).toHaveLength(10);
+    });
+
+    it("batch-updates championship to status active with currentRound 1", async () => {
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      expect(mockBatchUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ status: "active", currentRound: 1 })
+      );
+    });
+
+    it("passes startDate to generateRoundRobinFixtures", async () => {
+      const dateStr = "2026-09-01T00:00:00.000Z";
+
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: dateStr },
+        makeContext()
+      );
+
+      expect(generateRoundRobinFixtures).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ toISOString: expect.any(Function) })
+      );
+      const callArgs = (generateRoundRobinFixtures as jest.Mock).mock.calls[0];
+      expect((callArgs[1] as Date).toISOString()).toBe(dateStr);
+    });
+
+    it("each match document has standingsUpdated: false", async () => {
+      await startChampionshipHandler(
+        { championshipId: "champ-1", startDate: futureDate() },
+        makeContext()
+      );
+
+      const matchSets = mockBatchSet.mock.calls.filter(
+        ([, data]) => data.status === "pending"
+      );
+      for (const [, data] of matchSets) {
+        expect(data.standingsUpdated).toBe(false);
+      }
+    });
+  });
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("throws internal when batch.commit fails", async () => {
+      mockBatchCommit.mockRejectedValue(new Error("Firestore unavailable"));
+
+      await expect(
+        startChampionshipHandler(
+          { championshipId: "champ-1", startDate: futureDate() },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "internal" });
+    });
+  });
+});

--- a/lib/features/championships/data/repositories/firestore_championship_repository.dart
+++ b/lib/features/championships/data/repositories/firestore_championship_repository.dart
@@ -102,4 +102,23 @@ class FirestoreChampionshipRepository implements ChampionshipRepository {
       throw ChampionshipException('Failed to leave team: $e');
     }
   }
+
+  @override
+  Future<int> startChampionship({
+    required String championshipId,
+    required DateTime startDate,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('startChampionship');
+      final result = await callable.call({
+        'championshipId': championshipId,
+        'startDate': startDate.toIso8601String(),
+      });
+      return result.data['matchesCreated'] as int;
+    } on FirebaseFunctionsException catch (e) {
+      throw ChampionshipException(e.message ?? 'Failed to start championship', code: e.code);
+    } catch (e) {
+      throw ChampionshipException('Failed to start championship: $e');
+    }
+  }
 }

--- a/lib/features/championships/domain/repositories/championship_repository.dart
+++ b/lib/features/championships/domain/repositories/championship_repository.dart
@@ -32,4 +32,12 @@ abstract class ChampionshipRepository {
     required String championshipId,
     required String teamId,
   });
+
+  /// Starts the championship and generates all round-robin fixtures (admin only).
+  /// Returns the number of match documents created (45 for 10 teams).
+  /// Throws [ChampionshipException] on error.
+  Future<int> startChampionship({
+    required String championshipId,
+    required DateTime startDate,
+  });
 }


### PR DESCRIPTION
## Summary

- **`roundRobinFixtures.ts`** — Pure circle-method round-robin generator: fixes slot 0, rotates slots 1..N-1 clockwise each round, pairs slot i with slot N-1-i. Produces C(n,2) matches across n-1 rounds; every pair meets exactly once; round start +7 days per round; deadline = round start +21 days.
- **`startChampionship.ts`** — Admin-only callable CF: validates auth → caller in `adminIds` → status in `[registration, registration_closed]` → `teamsCount == maxTeams` → generates fixtures → writes 45 match docs + 10 standings docs (all zeros) + championship update (`status: active`, `currentRound: 1`) in a single Firestore batch (56 ops, within 500 limit).
- **`ChampionshipRepository`** — Extended with `startChampionship({championshipId, startDate})` returning `int` (matches created).
- **`FirestoreChampionshipRepository`** — Implements `startChampionship` via `httpsCallable('startChampionship')`.

## Tests

35 new unit tests:
- **`roundRobinFixtures.test.ts`** (17): exact match/round counts, no team plays twice per round, every pair meets exactly once (45 unique pairs), all 10 teams in every round, date math (round spacing, deadline offset), team ID integrity, error cases (odd count, <2 teams)
- **`startChampionship.test.ts`** (18): unauthenticated, missing/invalid inputs, not-found, permission-denied (non-admin), failed-precondition (wrong status, insufficient teams), successful start (matchesCreated=45, batch.commit called once, 45 pending match docs, 10 standings with all zeros, championship updated with status:active + currentRound:1), internal error on batch failure

## Test plan

- [ ] `cd functions && npm test` — all CF tests pass
- [ ] `flutter test test/unit/ test/widget/` — no regressions
- [ ] `flutter analyze` — no warnings