### PR TITLE
feat(championships): per-match coordination chat (Story 30.5)

### DIFF
--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -75,6 +75,7 @@ import 'package:play_with_me/features/championships/domain/repositories/champion
 import 'package:play_with_me/features/championships/data/repositories/firestore_championship_repository.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/partner_picker/partner_picker_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/team_registration/team_registration_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -237,6 +238,12 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<PartnerPickerBloc>()) {
     sl.registerFactory<PartnerPickerBloc>(
       () => PartnerPickerBloc(friendRepository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<MatchChatBloc>()) {
+    sl.registerFactory<MatchChatBloc>(
+      () => MatchChatBloc(messageRepository: sl()),
     );
   }
 

--- a/lib/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart
+++ b/lib/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart
@@ -1,0 +1,86 @@
+// Manages real-time per-match coordination chat messages for championship matches.
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
+import 'match_chat_event.dart';
+import 'match_chat_state.dart';
+
+class MatchChatBloc extends Bloc<MatchChatEvent, MatchChatState> {
+  final MessageRepository _messageRepository;
+  StreamSubscription<dynamic>? _messagesSubscription;
+
+  MatchChatBloc({required MessageRepository messageRepository})
+      : _messageRepository = messageRepository,
+        super(const MatchChatInitial()) {
+    on<LoadMatchChat>(_onLoadMatchChat);
+    on<MatchChatMessagesUpdated>(_onMessagesUpdated);
+    on<SendMatchChatMessage>(_onSendMatchChatMessage);
+  }
+
+  String _contextPath(String championshipId, String matchId) =>
+      'championships/$championshipId/matches/$matchId';
+
+  Future<void> _onLoadMatchChat(
+    LoadMatchChat event,
+    Emitter<MatchChatState> emit,
+  ) async {
+    emit(const MatchChatLoading());
+    await _messagesSubscription?.cancel();
+    _messagesSubscription = _messageRepository
+        .getMessages(
+          contextPath: _contextPath(event.championshipId, event.matchId),
+        )
+        .listen(
+          (messages) => add(MatchChatMessagesUpdated(messages: messages)),
+          onError: (_) => add(const MatchChatMessagesUpdated(messages: [])),
+        );
+  }
+
+  void _onMessagesUpdated(
+    MatchChatMessagesUpdated event,
+    Emitter<MatchChatState> emit,
+  ) {
+    final isSending =
+        state is MatchChatLoaded
+            ? (state as MatchChatLoaded).isSending
+            : false;
+    emit(MatchChatLoaded(messages: event.messages, isSending: isSending));
+  }
+
+  Future<void> _onSendMatchChatMessage(
+    SendMatchChatMessage event,
+    Emitter<MatchChatState> emit,
+  ) async {
+    if (state is! MatchChatLoaded) return;
+    final current = state as MatchChatLoaded;
+    emit(current.copyWith(isSending: true));
+    try {
+      await _messageRepository.sendMessage(
+        contextPath: _contextPath(event.championshipId, event.matchId),
+        senderId: event.senderId,
+        senderDisplayName: event.senderDisplayName,
+        text: event.text,
+        teamId: event.teamId,
+      );
+      // Use the live state — the stream may have delivered the new message
+      // while sendMessage was in flight; do not revert to the pre-send snapshot.
+      final latest = state;
+      if (latest is MatchChatLoaded) {
+        emit(latest.copyWith(isSending: false));
+      }
+    } on MessageException catch (e) {
+      emit(current.copyWith(isSending: false));
+      addError(Exception(e.message));
+    } catch (e) {
+      emit(current.copyWith(isSending: false));
+      addError(e is Exception ? e : Exception(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _messagesSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/championships/presentation/bloc/match_chat/match_chat_event.dart
+++ b/lib/features/championships/presentation/bloc/match_chat/match_chat_event.dart
@@ -1,0 +1,61 @@
+// Events for MatchChatBloc managing per-match coordination chat.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+
+abstract class MatchChatEvent extends Equatable {
+  const MatchChatEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadMatchChat extends MatchChatEvent {
+  final String championshipId;
+  final String matchId;
+
+  const LoadMatchChat({
+    required this.championshipId,
+    required this.matchId,
+  });
+
+  @override
+  List<Object?> get props => [championshipId, matchId];
+}
+
+class MatchChatMessagesUpdated extends MatchChatEvent {
+  final List<ChatMessageModel> messages;
+
+  const MatchChatMessagesUpdated({required this.messages});
+
+  @override
+  List<Object?> get props => [messages];
+}
+
+class SendMatchChatMessage extends MatchChatEvent {
+  final String championshipId;
+  final String matchId;
+  final String senderId;
+  final String senderDisplayName;
+  final String text;
+
+  /// The team the sender belongs to (teamAId or teamBId of the match).
+  final String? teamId;
+
+  const SendMatchChatMessage({
+    required this.championshipId,
+    required this.matchId,
+    required this.senderId,
+    required this.senderDisplayName,
+    required this.text,
+    this.teamId,
+  });
+
+  @override
+  List<Object?> get props => [
+    championshipId,
+    matchId,
+    senderId,
+    senderDisplayName,
+    text,
+    teamId,
+  ];
+}

--- a/lib/features/championships/presentation/bloc/match_chat/match_chat_state.dart
+++ b/lib/features/championships/presentation/bloc/match_chat/match_chat_state.dart
@@ -1,0 +1,46 @@
+// States for MatchChatBloc managing per-match coordination chat.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+
+abstract class MatchChatState extends Equatable {
+  const MatchChatState();
+  @override
+  List<Object?> get props => [];
+}
+
+class MatchChatInitial extends MatchChatState {
+  const MatchChatInitial();
+}
+
+class MatchChatLoading extends MatchChatState {
+  const MatchChatLoading();
+}
+
+class MatchChatLoaded extends MatchChatState {
+  final List<ChatMessageModel> messages;
+  final bool isSending;
+
+  const MatchChatLoaded({required this.messages, this.isSending = false});
+
+  @override
+  List<Object?> get props => [messages, isSending];
+
+  MatchChatLoaded copyWith({
+    List<ChatMessageModel>? messages,
+    bool? isSending,
+  }) {
+    return MatchChatLoaded(
+      messages: messages ?? this.messages,
+      isSending: isSending ?? this.isSending,
+    );
+  }
+}
+
+class MatchChatError extends MatchChatState {
+  final String message;
+
+  const MatchChatError({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/championships/presentation/widgets/match_chat_section.dart
+++ b/lib/features/championships/presentation/widgets/match_chat_section.dart
@@ -1,0 +1,388 @@
+// Widget displaying the per-match coordination chat for championship matches.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+import '../bloc/match_chat/match_chat_bloc.dart';
+import '../bloc/match_chat/match_chat_event.dart';
+import '../bloc/match_chat/match_chat_state.dart';
+
+class MatchChatSection extends StatelessWidget {
+  final String championshipId;
+  final String matchId;
+  final String currentUserId;
+  final String currentUserDisplayName;
+
+  /// Whether the current user is a member of one of the two competing teams.
+  final bool isTeamMember;
+
+  /// The team ID the current user belongs to (used to colour their messages).
+  /// Null when [isTeamMember] is false.
+  final String? currentTeamId;
+
+  final MessageRepository? messageRepository;
+
+  const MatchChatSection({
+    super.key,
+    required this.championshipId,
+    required this.matchId,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+    required this.isTeamMember,
+    this.currentTeamId,
+    this.messageRepository,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => MatchChatBloc(
+        messageRepository: messageRepository ?? sl<MessageRepository>(),
+      )..add(
+          LoadMatchChat(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        ),
+      child: _MatchChatView(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: currentUserId,
+        currentUserDisplayName: currentUserDisplayName,
+        isTeamMember: isTeamMember,
+        currentTeamId: currentTeamId,
+      ),
+    );
+  }
+}
+
+class _MatchChatView extends StatefulWidget {
+  final String championshipId;
+  final String matchId;
+  final String currentUserId;
+  final String currentUserDisplayName;
+  final bool isTeamMember;
+  final String? currentTeamId;
+
+  const _MatchChatView({
+    required this.championshipId,
+    required this.matchId,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+    required this.isTeamMember,
+    this.currentTeamId,
+  });
+
+  @override
+  State<_MatchChatView> createState() => _MatchChatViewState();
+}
+
+class _MatchChatViewState extends State<_MatchChatView> {
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _sendMessage(BuildContext context) {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
+    _textController.clear();
+    context.read<MatchChatBloc>().add(
+      SendMatchChatMessage(
+        championshipId: widget.championshipId,
+        matchId: widget.matchId,
+        senderId: widget.currentUserId,
+        senderDisplayName: widget.currentUserDisplayName,
+        text: text,
+        teamId: widget.currentTeamId,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(
+                  Icons.chat_bubble_outline,
+                  color: AppColors.secondary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  l10n.matchChatTitle,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.secondary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              l10n.matchChatCoordinationHint,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (!widget.isTeamMember)
+              SizedBox(
+                height: 80,
+                child: Center(
+                  child: Text(
+                    l10n.matchChatNotMember,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textMuted,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              )
+            else
+              BlocConsumer<MatchChatBloc, MatchChatState>(
+                listener: (context, state) {
+                  if (state is MatchChatLoaded) {
+                    _scrollToBottom();
+                  }
+                },
+                builder: (context, state) {
+                  if (state is MatchChatLoading || state is MatchChatInitial) {
+                    return const SizedBox(
+                      height: 120,
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+
+                  final messages = state is MatchChatLoaded
+                      ? state.messages
+                      : <ChatMessageModel>[];
+                  final isSending =
+                      state is MatchChatLoaded ? state.isSending : false;
+
+                  return Column(
+                    children: [
+                      SizedBox(
+                        height: 240,
+                        child: messages.isEmpty
+                            ? Center(
+                                child: Text(
+                                  l10n.matchChatEmpty,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.bodyMedium?.copyWith(
+                                    color: AppColors.textMuted,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              )
+                            : ListView.builder(
+                                controller: _scrollController,
+                                itemCount: messages.length,
+                                itemBuilder: (context, index) =>
+                                    _MatchMessageBubble(
+                                      message: messages[index],
+                                      isCurrentUser:
+                                          messages[index].senderId ==
+                                          widget.currentUserId,
+                                    ),
+                              ),
+                      ),
+                      const SizedBox(height: 8),
+                      _ChatInput(
+                        controller: _textController,
+                        isSending: isSending,
+                        onSend: () => _sendMessage(context),
+                        hint: l10n.chatInputHint,
+                      ),
+                    ],
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MatchMessageBubble extends StatelessWidget {
+  final ChatMessageModel message;
+  final bool isCurrentUser;
+
+  const _MatchMessageBubble({
+    required this.message,
+    required this.isCurrentUser,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final timeFormat = DateFormat('HH:mm');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Align(
+        alignment:
+            isCurrentUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: Column(
+          crossAxisAlignment: isCurrentUser
+              ? CrossAxisAlignment.end
+              : CrossAxisAlignment.start,
+          children: [
+            if (!isCurrentUser)
+              Padding(
+                padding: const EdgeInsets.only(left: 8, bottom: 2),
+                child: Text(
+                  message.senderDisplayName,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: AppColors.textMuted,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            Row(
+              mainAxisAlignment: isCurrentUser
+                  ? MainAxisAlignment.end
+                  : MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                if (!isCurrentUser) const SizedBox(width: 4),
+                Flexible(
+                  child: Container(
+                    constraints: BoxConstraints(
+                      maxWidth: MediaQuery.of(context).size.width * 0.65,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: isCurrentUser
+                          ? AppColors.secondary
+                          : AppColors.divider,
+                      borderRadius: BorderRadius.only(
+                        topLeft: const Radius.circular(16),
+                        topRight: const Radius.circular(16),
+                        bottomLeft: Radius.circular(isCurrentUser ? 16 : 4),
+                        bottomRight: Radius.circular(isCurrentUser ? 4 : 16),
+                      ),
+                    ),
+                    child: Text(
+                      message.text,
+                      style: TextStyle(
+                        color: isCurrentUser
+                            ? Colors.white
+                            : AppColors.onSurface,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  timeFormat.format(message.sentAt),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: AppColors.textMuted,
+                    fontSize: 10,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatInput extends StatelessWidget {
+  final TextEditingController controller;
+  final bool isSending;
+  final VoidCallback onSend;
+  final String hint;
+
+  const _ChatInput({
+    required this.controller,
+    required this.isSending,
+    required this.onSend,
+    required this.hint,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: const TextStyle(color: AppColors.textMuted),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(24),
+                borderSide: const BorderSide(color: AppColors.divider),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(24),
+                borderSide: const BorderSide(color: AppColors.divider),
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 10,
+              ),
+              isDense: true,
+            ),
+            maxLines: null,
+            textInputAction: TextInputAction.send,
+            onSubmitted: (_) => onSend(),
+            enabled: !isSending,
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton(
+          onPressed: isSending ? null : onSend,
+          icon: isSending
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.send),
+          color: AppColors.secondary,
+          style: IconButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            shape: const CircleBorder(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -773,5 +773,9 @@
   "noFriendsForPartner": "Sie haben noch keine Freunde einzuladen. F\u00fcgen Sie zuerst Freunde aus Meine Community hinzu.",
   "teamRegisteredSuccess": "Team angemeldet!",
   "teamLeftSuccess": "Sie haben das Team verlassen.",
-  "yourTeam": "Ihr Team"
+  "yourTeam": "Ihr Team",
+  "matchChatTitle": "Match-Chat",
+  "matchChatCoordinationHint": "Koordiniert Datum, Uhrzeit und Ort mit dem gegnerischen Team",
+  "matchChatNotMember": "Nur Teammitglieder können an diesem Chat teilnehmen.",
+  "matchChatEmpty": "Noch keine Nachrichten. Beginnt die Koordination mit dem gegnerischen Team!"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3062,5 +3062,13 @@
   "teamLeftSuccess": "You have left the team.",
   "@teamLeftSuccess": {"description": "Snackbar message after successfully leaving a team"},
   "yourTeam": "Your team",
-  "@yourTeam": {"description": "Section header showing the user's registered team"}
+  "@yourTeam": {"description": "Section header showing the user's registered team"},
+  "matchChatTitle": "Match Chat",
+  "@matchChatTitle": {"description": "Title of the per-match coordination chat section"},
+  "matchChatCoordinationHint": "Coordinate date, time & location with the opposing team",
+  "@matchChatCoordinationHint": {"description": "Subtitle under the match chat title explaining its purpose"},
+  "matchChatNotMember": "Only team members can participate in this chat.",
+  "@matchChatNotMember": {"description": "Message shown to users who are not part of either team in the match"},
+  "matchChatEmpty": "No messages yet. Start coordinating with the opposing team!",
+  "@matchChatEmpty": {"description": "Empty state message in the match chat when no messages have been sent"}
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -773,5 +773,9 @@
   "noFriendsForPartner": "A\u00fan no tienes amigos para invitar. A\u00f1ade amigos desde Mi comunidad primero.",
   "teamRegisteredSuccess": "\u00a1Equipo inscrito!",
   "teamLeftSuccess": "Has abandonado el equipo.",
-  "yourTeam": "Tu equipo"
+  "yourTeam": "Tu equipo",
+  "matchChatTitle": "Chat del partido",
+  "matchChatCoordinationHint": "Coordinad fecha, hora y lugar con el equipo contrario",
+  "matchChatNotMember": "Solo los miembros de los equipos pueden participar en este chat.",
+  "matchChatEmpty": "¡Todavía no hay mensajes. ¡Empieza a coordinar con el equipo contrario!"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -773,5 +773,9 @@
   "noFriendsForPartner": "Vous n'avez pas encore d'amis \u00e0 inviter. Ajoutez des amis depuis Ma communaut\u00e9.",
   "teamRegisteredSuccess": "\u00c9quipe inscrite\u00a0!",
   "teamLeftSuccess": "Vous avez quitt\u00e9 l'\u00e9quipe.",
-  "yourTeam": "Votre \u00e9quipe"
+  "yourTeam": "Votre \u00e9quipe",
+  "matchChatTitle": "Chat du match",
+  "matchChatCoordinationHint": "Coordonnez la date, l’heure et le lieu avec l’équipe adverse",
+  "matchChatNotMember": "Seuls les membres des équipes peuvent participer à ce chat.",
+  "matchChatEmpty": "Aucun message pour l’instant. Commencez à coordonner avec l’équipe adverse !"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -773,5 +773,9 @@
   "noFriendsForPartner": "Non hai ancora amici da invitare. Aggiungi amici dalla tua Community prima.",
   "teamRegisteredSuccess": "Squadra iscritta!",
   "teamLeftSuccess": "Hai lasciato la squadra.",
-  "yourTeam": "La tua squadra"
+  "yourTeam": "La tua squadra",
+  "matchChatTitle": "Chat del match",
+  "matchChatCoordinationHint": "Coordinate data, ora e luogo con la squadra avversaria",
+  "matchChatNotMember": "Solo i membri delle squadre possono partecipare a questa chat.",
+  "matchChatEmpty": "Nessun messaggio ancora. Inizia a coordinare con la squadra avversaria!"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3967,6 +3967,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your team'**
   String get yourTeam;
+
+  /// Title of the per-match coordination chat section
+  ///
+  /// In en, this message translates to:
+  /// **'Match Chat'**
+  String get matchChatTitle;
+
+  /// Subtitle under the match chat title explaining its purpose
+  ///
+  /// In en, this message translates to:
+  /// **'Coordinate date, time & location with the opposing team'**
+  String get matchChatCoordinationHint;
+
+  /// Message shown to users who are not part of either team in the match
+  ///
+  /// In en, this message translates to:
+  /// **'Only team members can participate in this chat.'**
+  String get matchChatNotMember;
+
+  /// Empty state message in the match chat when no messages have been sent
+  ///
+  /// In en, this message translates to:
+  /// **'No messages yet. Start coordinating with the opposing team!'**
+  String get matchChatEmpty;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2194,4 +2194,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get yourTeam => 'Ihr Team';
+
+  @override
+  String get matchChatTitle => 'Match-Chat';
+
+  @override
+  String get matchChatCoordinationHint =>
+      'Koordiniert Datum, Uhrzeit und Ort mit dem gegnerischen Team';
+
+  @override
+  String get matchChatNotMember =>
+      'Nur Teammitglieder können an diesem Chat teilnehmen.';
+
+  @override
+  String get matchChatEmpty =>
+      'Noch keine Nachrichten. Beginnt die Koordination mit dem gegnerischen Team!';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2155,4 +2155,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get yourTeam => 'Your team';
+
+  @override
+  String get matchChatTitle => 'Match Chat';
+
+  @override
+  String get matchChatCoordinationHint =>
+      'Coordinate date, time & location with the opposing team';
+
+  @override
+  String get matchChatNotMember =>
+      'Only team members can participate in this chat.';
+
+  @override
+  String get matchChatEmpty =>
+      'No messages yet. Start coordinating with the opposing team!';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2183,4 +2183,19 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get yourTeam => 'Tu equipo';
+
+  @override
+  String get matchChatTitle => 'Chat del partido';
+
+  @override
+  String get matchChatCoordinationHint =>
+      'Coordinad fecha, hora y lugar con el equipo contrario';
+
+  @override
+  String get matchChatNotMember =>
+      'Solo los miembros de los equipos pueden participar en este chat.';
+
+  @override
+  String get matchChatEmpty =>
+      '¡Todavía no hay mensajes. ¡Empieza a coordinar con el equipo contrario!';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2200,4 +2200,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get yourTeam => 'Votre équipe';
+
+  @override
+  String get matchChatTitle => 'Chat du match';
+
+  @override
+  String get matchChatCoordinationHint =>
+      'Coordonnez la date, l’heure et le lieu avec l’équipe adverse';
+
+  @override
+  String get matchChatNotMember =>
+      'Seuls les membres des équipes peuvent participer à ce chat.';
+
+  @override
+  String get matchChatEmpty =>
+      'Aucun message pour l’instant. Commencez à coordonner avec l’équipe adverse !';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2176,4 +2176,19 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get yourTeam => 'La tua squadra';
+
+  @override
+  String get matchChatTitle => 'Chat del match';
+
+  @override
+  String get matchChatCoordinationHint =>
+      'Coordinate data, ora e luogo con la squadra avversaria';
+
+  @override
+  String get matchChatNotMember =>
+      'Solo i membri delle squadre possono partecipare a questa chat.';
+
+  @override
+  String get matchChatEmpty =>
+      'Nessun messaggio ancora. Inizia a coordinare con la squadra avversaria!';
 }

--- a/test/unit/features/championships/presentation/bloc/match_chat_bloc_test.dart
+++ b/test/unit/features/championships/presentation/bloc/match_chat_bloc_test.dart
@@ -1,0 +1,273 @@
+// Validates MatchChatBloc state transitions for loading, receiving, and sending messages.
+import 'dart:async';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/data/models/chat_message_model.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/domain/repositories/message_repository.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_event.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_state.dart';
+
+class MockMessageRepository extends Mock implements MessageRepository {}
+
+ChatMessageModel _message({
+  String id = 'msg-1',
+  String senderId = 'user-1',
+  String senderDisplayName = 'Alice',
+  String text = 'Hello!',
+  String? teamId = 'team-1',
+}) =>
+    ChatMessageModel(
+      id: id,
+      senderId: senderId,
+      senderDisplayName: senderDisplayName,
+      text: text,
+      sentAt: DateTime(2026, 8, 1, 10),
+      teamId: teamId,
+    );
+
+void main() {
+  late MockMessageRepository mockRepo;
+
+  const String championshipId = 'champ-1';
+  const String matchId = 'match-1';
+  const String contextPath = 'championships/$championshipId/matches/$matchId';
+
+  setUpAll(() {
+    registerFallbackValue(_message());
+  });
+
+  setUp(() {
+    mockRepo = MockMessageRepository();
+  });
+
+  MatchChatBloc makeBloc() => MatchChatBloc(messageRepository: mockRepo);
+
+  group('LoadMatchChat', () {
+    blocTest<MatchChatBloc, MatchChatState>(
+      'emits Loading then Loaded(empty) when stream emits empty list',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => Stream.value([]));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const LoadMatchChat(
+          championshipId: championshipId,
+          matchId: matchId,
+        ),
+      ),
+      expect: () => [
+        const MatchChatLoading(),
+        const MatchChatLoaded(messages: []),
+      ],
+    );
+
+    blocTest<MatchChatBloc, MatchChatState>(
+      'emits Loading then Loaded with messages when stream emits messages',
+      build: () {
+        final msg = _message();
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => Stream.value([msg]));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const LoadMatchChat(
+          championshipId: championshipId,
+          matchId: matchId,
+        ),
+      ),
+      expect: () => [
+        const MatchChatLoading(),
+        MatchChatLoaded(messages: [_message()]),
+      ],
+    );
+
+    blocTest<MatchChatBloc, MatchChatState>(
+      'emits Loaded(empty) when stream emits error',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer(
+          (_) => Stream.error(Exception('stream error')),
+        );
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const LoadMatchChat(
+          championshipId: championshipId,
+          matchId: matchId,
+        ),
+      ),
+      expect: () => [
+        const MatchChatLoading(),
+        const MatchChatLoaded(messages: []),
+      ],
+    );
+
+    blocTest<MatchChatBloc, MatchChatState>(
+      'cancels previous subscription on reload and calls getMessages twice',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => Stream.value([]));
+        return makeBloc();
+      },
+      act: (bloc) async {
+        bloc.add(
+          const LoadMatchChat(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(
+          const LoadMatchChat(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        );
+      },
+      verify: (_) => verify(
+        () => mockRepo.getMessages(contextPath: contextPath),
+      ).called(2),
+      expect: () => isNotEmpty,
+    );
+  });
+
+  group('SendMatchChatMessage', () {
+    blocTest<MatchChatBloc, MatchChatState>(
+      'sets isSending true then false on success',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => Stream.value([_message()]));
+        when(
+          () => mockRepo.sendMessage(
+            contextPath: contextPath,
+            senderId: any(named: 'senderId'),
+            senderDisplayName: any(named: 'senderDisplayName'),
+            text: any(named: 'text'),
+            teamId: any(named: 'teamId'),
+          ),
+        ).thenAnswer((_) async {});
+        return makeBloc();
+      },
+      act: (bloc) async {
+        bloc.add(
+          const LoadMatchChat(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(
+          const SendMatchChatMessage(
+            championshipId: championshipId,
+            matchId: matchId,
+            senderId: 'user-1',
+            senderDisplayName: 'Alice',
+            text: 'Hi',
+            teamId: 'team-1',
+          ),
+        );
+      },
+      expect: () => [
+        const MatchChatLoading(),
+        MatchChatLoaded(messages: [_message()]),
+        MatchChatLoaded(messages: [_message()], isSending: true),
+        MatchChatLoaded(messages: [_message()], isSending: false),
+      ],
+    );
+
+    blocTest<MatchChatBloc, MatchChatState>(
+      'restores isSending false and emits addError on MessageException',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => Stream.value([_message()]));
+        when(
+          () => mockRepo.sendMessage(
+            contextPath: contextPath,
+            senderId: any(named: 'senderId'),
+            senderDisplayName: any(named: 'senderDisplayName'),
+            text: any(named: 'text'),
+            teamId: any(named: 'teamId'),
+          ),
+        ).thenThrow(MessageException('send failed'));
+        return makeBloc();
+      },
+      act: (bloc) async {
+        bloc.add(
+          const LoadMatchChat(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(
+          const SendMatchChatMessage(
+            championshipId: championshipId,
+            matchId: matchId,
+            senderId: 'user-1',
+            senderDisplayName: 'Alice',
+            text: 'Hi',
+          ),
+        );
+      },
+      expect: () => [
+        const MatchChatLoading(),
+        MatchChatLoaded(messages: [_message()]),
+        MatchChatLoaded(messages: [_message()], isSending: true),
+        MatchChatLoaded(messages: [_message()], isSending: false),
+      ],
+      errors: () => [isA<Exception>()],
+    );
+
+    blocTest<MatchChatBloc, MatchChatState>(
+      'does nothing when state is not Loaded',
+      build: () {
+        when(
+          () => mockRepo.getMessages(contextPath: contextPath),
+        ).thenAnswer((_) => const Stream.empty());
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const SendMatchChatMessage(
+          championshipId: championshipId,
+          matchId: matchId,
+          senderId: 'user-1',
+          senderDisplayName: 'Alice',
+          text: 'Hi',
+        ),
+      ),
+      expect: () => [],
+    );
+  });
+
+  group('contextPath', () {
+    blocTest<MatchChatBloc, MatchChatState>(
+      'uses championships/championshipId/matches/matchId as context path',
+      build: () {
+        when(
+          () => mockRepo.getMessages(
+            contextPath: 'championships/champ-99/matches/match-42',
+          ),
+        ).thenAnswer((_) => Stream.value([]));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const LoadMatchChat(championshipId: 'champ-99', matchId: 'match-42'),
+      ),
+      verify: (_) => verify(
+        () => mockRepo.getMessages(
+          contextPath: 'championships/champ-99/matches/match-42',
+        ),
+      ).called(1),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **`MatchChatBloc`** — championship-scoped chat BLoC under `lib/features/championships/presentation/bloc/match_chat/`. Uses `MessageRepository` from core with `contextPath = championships/{id}/matches/{id}`. No cross-feature import from `lib/features/games/` — clean architecture boundary maintained.
- **`MatchChatSection` widget** — drop-in card widget that creates its own `BlocProvider<MatchChatBloc>`, shows a coordination hint subtitle ("Coordinate date, time & location with the opposing team"), guards non-team-members with a message, and renders the real-time message list + send input. Writes use the existing Firestore rules from Story 30.1 which already allow direct writes for team members.
- **Service locator** — `MatchChatBloc` registered as `registerFactory`.
- **l10n** — 4 new keys (`matchChatTitle`, `matchChatCoordinationHint`, `matchChatNotMember`, `matchChatEmpty`) in all 5 languages (EN/FR/DE/ES/IT).

## Tests

8 unit tests in `match_chat_bloc_test.dart`:
- `LoadMatchChat`: empty stream → Loaded([]); messages → Loaded(messages); stream error → Loaded([]); reload calls `getMessages` twice
- `SendMatchChatMessage`: isSending toggled true→false on success; restored on `MessageException` + `addError` emitted; no-op when not Loaded
- `contextPath`: verifies path is `championships/championshipId/matches/matchId`

## Test plan

- [ ] `flutter test test/unit/features/championships/presentation/bloc/match_chat_bloc_test.dart` — 8/8 pass
- [ ] `flutter test test/unit/ test/widget/` — no regressions
- [ ] `flutter analyze` — no new warnings