### PR TITLE
feat(championships): match result submission by one team (Story 30.6)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -30,6 +30,7 @@ export {createChampionship} from "./createChampionship"; // Story 30.2 (Champion
 export {createChampionshipTeam} from "./createChampionshipTeam"; // Story 30.3 (Team Registration)
 export {leaveChampionshipTeam} from "./leaveChampionshipTeam"; // Story 30.3 (Team Registration)
 export {startChampionship} from "./startChampionship"; // Story 30.4 (Fixture Generation)
+export {submitChampionshipMatchResult} from "./submitChampionshipMatchResult"; // Story 30.6 (Result Submission)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)

--- a/functions/src/scoreValidation.ts
+++ b/functions/src/scoreValidation.ts
@@ -1,0 +1,115 @@
+// Pure score-validation helpers for championship match results (Story 30.6).
+// Exported separately so they can be unit-tested without Firebase.
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SetInput {
+  teamAPoints: number;
+  teamBPoints: number;
+  setNumber: number;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// ============================================================================
+// Set validation (mirrors MatchSetScore.isValid in Dart)
+// ============================================================================
+
+/**
+ * Validates a single set score.
+ * Regular sets (1 & 2): first to 21, win by 2, no cap.
+ * Decider set (3):      first to 15, win by 2, no cap.
+ */
+export function isSetValid(set: SetInput, isDeciderSet: boolean): boolean {
+  const target = isDeciderSet ? 15 : 21;
+  const maxPts = Math.max(set.teamAPoints, set.teamBPoints);
+  const minPts = Math.min(set.teamAPoints, set.teamBPoints);
+
+  // One side must reach the target
+  if (maxPts < target) return false;
+
+  // At exactly target: loser must be at most target − 2 (standard win)
+  if (maxPts === target) return minPts <= target - 2;
+
+  // Extended play: gap must be exactly 2
+  return maxPts - minPts === 2;
+}
+
+// ============================================================================
+// Full match result validation
+// ============================================================================
+
+/**
+ * Validates a complete match result (2 or 3 sets).
+ * Rules:
+ *   - Exactly 2 or 3 sets
+ *   - Set numbers must be [1, 2] or [1, 2, 3] (no duplicates, no gaps)
+ *   - Each set score is valid per the rules above
+ *   - Exactly one team wins 2 sets
+ */
+export function validateMatchResult(sets: SetInput[]): ValidationResult {
+  if (!Array.isArray(sets) || (sets.length !== 2 && sets.length !== 3)) {
+    return { valid: false, error: "Result must have exactly 2 or 3 sets" };
+  }
+
+  const sortedSetNumbers = sets.map((s) => s.setNumber).sort((a, b) => a - b);
+  const expectedSetNumbers = sets.length === 2 ? [1, 2] : [1, 2, 3];
+  if (!expectedSetNumbers.every((n, i) => n === sortedSetNumbers[i])) {
+    return {
+      valid: false,
+      error: "Set numbers must be 1 and 2 (plus 3 for a deciding set)",
+    };
+  }
+
+  for (const set of sets) {
+    const isDecider = set.setNumber === 3;
+    if (!isSetValid(set, isDecider)) {
+      return { valid: false, error: `Invalid score for set ${set.setNumber}` };
+    }
+  }
+
+  const teamASetWins = sets.filter((s) => s.teamAPoints > s.teamBPoints).length;
+  const teamBSetWins = sets.filter((s) => s.teamBPoints > s.teamAPoints).length;
+
+  if (teamASetWins !== 2 && teamBSetWins !== 2) {
+    return { valid: false, error: "One team must win exactly 2 sets" };
+  }
+
+  return { valid: true };
+}
+
+// ============================================================================
+// Points calculation
+// ============================================================================
+
+/**
+ * Returns championship points for both teams.
+ * 2-0 win: winner 3 pts, loser 0 pts.
+ * 2-1 win: winner 2 pts, loser 1 pt.
+ * Assumes the result has already been validated.
+ */
+export function computeChampionshipPoints(sets: SetInput[]): {
+  teamAPoints: number;
+  teamBPoints: number;
+  winner: "teamA" | "teamB";
+} {
+  const teamASetWins = sets.filter((s) => s.teamAPoints > s.teamBPoints).length;
+  const totalSets = sets.length;
+
+  const teamAWins = teamASetWins === 2;
+  const isStraightSets = totalSets === 2;
+
+  const teamAPoints = teamAWins ? (isStraightSets ? 3 : 2) : (isStraightSets ? 0 : 1);
+  const teamBPoints = teamAWins ? (isStraightSets ? 0 : 1) : (isStraightSets ? 3 : 2);
+
+  return {
+    teamAPoints,
+    teamBPoints,
+    winner: teamAWins ? "teamA" : "teamB",
+  };
+}

--- a/functions/src/submitChampionshipMatchResult.ts
+++ b/functions/src/submitChampionshipMatchResult.ts
@@ -1,0 +1,174 @@
+// Cloud Function to submit a championship match result by one team (Story 30.6).
+// Result is stored pending verification by the opposing team (Story 30.7).
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { SetInput, validateMatchResult, computeChampionshipPoints } from "./scoreValidation";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface SubmitMatchResultRequest {
+  championshipId: string;
+  matchId: string;
+  sets: SetInput[];
+}
+
+interface SubmitMatchResultResponse {
+  matchId: string;
+  pendingVerification: true;
+}
+
+// ============================================================================
+// Inner Handler (exported for unit tests)
+// ============================================================================
+
+export async function submitChampionshipMatchResultHandler(
+  data: SubmitMatchResultRequest,
+  context: functions.https.CallableContext
+): Promise<SubmitMatchResultResponse> {
+  // ── 1. Auth ────────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to submit a match result"
+    );
+  }
+
+  const callerId = context.auth.uid;
+  functions.logger.info("[submitChampionshipMatchResult] Start", {
+    callerId,
+    championshipId: data?.championshipId,
+    matchId: data?.matchId,
+  });
+
+  // ── 2. Input Validation ────────────────────────────────────────────────────
+  if (!data?.championshipId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: championshipId"
+    );
+  }
+
+  if (!data?.matchId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: matchId"
+    );
+  }
+
+  if (!Array.isArray(data?.sets) || data.sets.length === 0) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: sets"
+    );
+  }
+
+  // ── 3. Validate Set Scores ─────────────────────────────────────────────────
+  const scoreValidation = validateMatchResult(data.sets);
+  if (!scoreValidation.valid) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      scoreValidation.error ?? "Invalid match result"
+    );
+  }
+
+  const db = admin.firestore();
+  const matchRef = db
+    .collection("championships")
+    .doc(data.championshipId)
+    .collection("matches")
+    .doc(data.matchId);
+
+  // ── 4. Load Match ──────────────────────────────────────────────────────────
+  const matchSnap = await matchRef.get();
+  if (!matchSnap.exists) {
+    throw new functions.https.HttpsError("not-found", "Match not found");
+  }
+
+  const match = matchSnap.data()!;
+
+  // ── 5. Status Check ────────────────────────────────────────────────────────
+  const submittableStatuses = ["pending", "scheduled"];
+  if (!submittableStatuses.includes(match.status)) {
+    throw new functions.https.HttpsError(
+      "failed-precondition",
+      `Match already has a result (status: ${match.status})`
+    );
+  }
+
+  // ── 6. Permission Check: caller must be in teamA or teamB ─────────────────
+  const champRef = db.collection("championships").doc(data.championshipId);
+  const [teamASnap, teamBSnap] = await Promise.all([
+    champRef.collection("teams").doc(match.teamAId).get(),
+    champRef.collection("teams").doc(match.teamBId).get(),
+  ]);
+
+  const teamAMembers: string[] = teamASnap.exists
+    ? (teamASnap.data()?.memberIds ?? [])
+    : [];
+  const teamBMembers: string[] = teamBSnap.exists
+    ? (teamBSnap.data()?.memberIds ?? [])
+    : [];
+
+  const isTeamAMember = teamAMembers.includes(callerId);
+  const isTeamBMember = teamBMembers.includes(callerId);
+
+  if (!isTeamAMember && !isTeamBMember) {
+    functions.logger.warn("[submitChampionshipMatchResult] Permission denied", {
+      callerId,
+      matchId: data.matchId,
+    });
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Only members of the competing teams can submit a result"
+    );
+  }
+
+  const submittedByTeamId = isTeamAMember ? match.teamAId : match.teamBId;
+
+  // ── 7. Compute Result ──────────────────────────────────────────────────────
+  const { teamAPoints, teamBPoints, winner } = computeChampionshipPoints(data.sets);
+
+  // ── 8. Write Result ────────────────────────────────────────────────────────
+  try {
+    await matchRef.update({
+      status: "played",
+      result: {
+        sets: data.sets,
+        winner,
+        teamAPoints,
+        teamBPoints,
+      },
+      submittedByTeamId,
+      submittedByUserId: callerId,
+    });
+  } catch (err) {
+    functions.logger.error("[submitChampionshipMatchResult] Write failed", {
+      err,
+    });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to save match result. Please try again."
+    );
+  }
+
+  functions.logger.info("[submitChampionshipMatchResult] Result submitted", {
+    matchId: data.matchId,
+    winner,
+    teamAPoints,
+    teamBPoints,
+    submittedByTeamId,
+  });
+
+  return { matchId: data.matchId, pendingVerification: true };
+}
+
+// ============================================================================
+// Cloud Function export
+// ============================================================================
+
+export const submitChampionshipMatchResult = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 30, memory: "256MB" })
+  .https.onCall(submitChampionshipMatchResultHandler);

--- a/functions/test/unit/scoreValidation.test.ts
+++ b/functions/test/unit/scoreValidation.test.ts
@@ -1,0 +1,194 @@
+// Unit tests for pure score-validation helpers (Story 30.6).
+import { isSetValid, validateMatchResult, computeChampionshipPoints } from "../../src/scoreValidation";
+
+describe("isSetValid", () => {
+  describe("regular set (isDeciderSet: false)", () => {
+    it("accepts 21-15 (standard win)", () => {
+      expect(isSetValid({ teamAPoints: 21, teamBPoints: 15, setNumber: 1 }, false)).toBe(true);
+    });
+
+    it("accepts 22-20 (extended play)", () => {
+      expect(isSetValid({ teamAPoints: 22, teamBPoints: 20, setNumber: 1 }, false)).toBe(true);
+    });
+
+    it("accepts 25-23 (extended play)", () => {
+      expect(isSetValid({ teamAPoints: 25, teamBPoints: 23, setNumber: 1 }, false)).toBe(true);
+    });
+
+    it("rejects 21-20 (only 1 point gap)", () => {
+      expect(isSetValid({ teamAPoints: 21, teamBPoints: 20, setNumber: 1 }, false)).toBe(false);
+    });
+
+    it("rejects 19-15 (winner did not reach 21)", () => {
+      expect(isSetValid({ teamAPoints: 19, teamBPoints: 15, setNumber: 1 }, false)).toBe(false);
+    });
+
+    it("rejects 20-20 (tied)", () => {
+      expect(isSetValid({ teamAPoints: 20, teamBPoints: 20, setNumber: 1 }, false)).toBe(false);
+    });
+
+    it("accepts 21-0 (shutout)", () => {
+      expect(isSetValid({ teamAPoints: 21, teamBPoints: 0, setNumber: 1 }, false)).toBe(true);
+    });
+  });
+
+  describe("decider set (isDeciderSet: true)", () => {
+    it("accepts 15-10 (standard win)", () => {
+      expect(isSetValid({ teamAPoints: 15, teamBPoints: 10, setNumber: 3 }, true)).toBe(true);
+    });
+
+    it("accepts 16-14 (extended play)", () => {
+      expect(isSetValid({ teamAPoints: 16, teamBPoints: 14, setNumber: 3 }, true)).toBe(true);
+    });
+
+    it("rejects 15-14 (only 1 point gap)", () => {
+      expect(isSetValid({ teamAPoints: 15, teamBPoints: 14, setNumber: 3 }, true)).toBe(false);
+    });
+
+    it("rejects 21-15 in decider (must reach 15, not 21)", () => {
+      // 21 > 15, extended play check: 21 - 15 = 6 ≠ 2 → invalid
+      expect(isSetValid({ teamAPoints: 21, teamBPoints: 15, setNumber: 3 }, true)).toBe(false);
+    });
+
+    it("rejects 12-8 (winner did not reach 15)", () => {
+      expect(isSetValid({ teamAPoints: 12, teamBPoints: 8, setNumber: 3 }, true)).toBe(false);
+    });
+  });
+});
+
+describe("validateMatchResult", () => {
+  it("accepts valid 2-0 result [21-15, 21-18]", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 2 },
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts valid 2-1 result [21-18, 17-21, 15-12]", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 1 },
+      { teamAPoints: 17, teamBPoints: 21, setNumber: 2 },
+      { teamAPoints: 15, teamBPoints: 12, setNumber: 3 },
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects empty array", () => {
+    expect(validateMatchResult([]).valid).toBe(false);
+  });
+
+  it("rejects 1 set only", () => {
+    expect(
+      validateMatchResult([{ teamAPoints: 21, teamBPoints: 15, setNumber: 1 }]).valid
+    ).toBe(false);
+  });
+
+  it("rejects 4 sets", () => {
+    const set = { teamAPoints: 21, teamBPoints: 15, setNumber: 1 };
+    expect(validateMatchResult([set, set, set, set]).valid).toBe(false);
+  });
+
+  it("rejects sets with wrong set numbers (e.g. 1 and 3 only)", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 3 },
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects duplicate set numbers", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects invalid set 1 score (21-20, only 1 gap)", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 20, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 2 },
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects when set 1 score doesn't reach target (19-15)", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 19, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 2 },
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects invalid decider set score (21-10 in set 3 — too far above 15)", () => {
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 1 },
+      { teamAPoints: 17, teamBPoints: 21, setNumber: 2 },
+      { teamAPoints: 21, teamBPoints: 10, setNumber: 3 },
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects when no team wins 2 sets (both win 1)", () => {
+    // Can't happen with valid scores and 2 sets, but test the guard explicitly
+    const result = validateMatchResult([
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 15, teamBPoints: 21, setNumber: 2 },
+    ]);
+    // Neither team won 2 sets → invalid
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects non-array input", () => {
+    expect(validateMatchResult(null as any).valid).toBe(false);
+  });
+});
+
+describe("computeChampionshipPoints", () => {
+  it("2-0 win: winner gets 3 pts, loser gets 0 pts", () => {
+    const sets = [
+      { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 2 },
+    ];
+    const result = computeChampionshipPoints(sets);
+    expect(result.winner).toBe("teamA");
+    expect(result.teamAPoints).toBe(3);
+    expect(result.teamBPoints).toBe(0);
+  });
+
+  it("2-0 win by teamB: winner gets 3 pts, loser gets 0 pts", () => {
+    const sets = [
+      { teamAPoints: 15, teamBPoints: 21, setNumber: 1 },
+      { teamAPoints: 18, teamBPoints: 21, setNumber: 2 },
+    ];
+    const result = computeChampionshipPoints(sets);
+    expect(result.winner).toBe("teamB");
+    expect(result.teamBPoints).toBe(3);
+    expect(result.teamAPoints).toBe(0);
+  });
+
+  it("2-1 win by teamA: winner gets 2 pts, loser gets 1 pt", () => {
+    const sets = [
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 1 },
+      { teamAPoints: 17, teamBPoints: 21, setNumber: 2 },
+      { teamAPoints: 15, teamBPoints: 12, setNumber: 3 },
+    ];
+    const result = computeChampionshipPoints(sets);
+    expect(result.winner).toBe("teamA");
+    expect(result.teamAPoints).toBe(2);
+    expect(result.teamBPoints).toBe(1);
+  });
+
+  it("2-1 win by teamB: winner gets 2 pts, loser gets 1 pt", () => {
+    const sets = [
+      { teamAPoints: 18, teamBPoints: 21, setNumber: 1 },
+      { teamAPoints: 21, teamBPoints: 18, setNumber: 2 },
+      { teamAPoints: 12, teamBPoints: 15, setNumber: 3 },
+    ];
+    const result = computeChampionshipPoints(sets);
+    expect(result.winner).toBe("teamB");
+    expect(result.teamBPoints).toBe(2);
+    expect(result.teamAPoints).toBe(1);
+  });
+});

--- a/functions/test/unit/submitChampionshipMatchResult.test.ts
+++ b/functions/test/unit/submitChampionshipMatchResult.test.ts
@@ -1,0 +1,365 @@
+// Unit tests for submitChampionshipMatchResult Cloud Function (Story 30.6).
+import { submitChampionshipMatchResultHandler } from "../../src/submitChampionshipMatchResult";
+import type * as functionsTypes from "firebase-functions";
+
+// ── Mock firebase-functions ───────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    https: {
+      HttpsError: class HttpsError extends Error {
+        code: string;
+        constructor(code: string, message: string) {
+          super(message);
+          this.code = code;
+          this.name = "HttpsError";
+        }
+      },
+      onCall: jest.fn((h: any) => h),
+    },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  };
+  fn.region = jest.fn(() => fn);
+  fn.runWith = jest.fn(() => fn);
+  return fn;
+});
+
+// ── Mock scoreValidation (spy on real implementation) ────────────────────────
+
+jest.mock("../../src/scoreValidation", () => {
+  const actual = jest.requireActual("../../src/scoreValidation");
+  return {
+    ...actual,
+    validateMatchResult: jest.fn(actual.validateMatchResult),
+    computeChampionshipPoints: jest.fn(actual.computeChampionshipPoints),
+  };
+});
+
+// ── Mock firebase-admin ───────────────────────────────────────────────────────
+
+const mockMatchUpdate = jest.fn();
+const mockMatchGet = jest.fn();
+const mockTeamAGet = jest.fn();
+const mockTeamBGet = jest.fn();
+
+const matchRef = {
+  get: mockMatchGet,
+  update: mockMatchUpdate,
+};
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn(() => ({
+          doc: jest.fn((champId: string) => ({
+            collection: jest.fn((col: string) => ({
+              doc: jest.fn((id: string) => {
+                if (col === "matches") return matchRef;
+                if (col === "teams") {
+                  if (id === "team-a") return { get: mockTeamAGet };
+                  if (id === "team-b") return { get: mockTeamBGet };
+                }
+                return { get: jest.fn() };
+              }),
+            })),
+          })),
+        })),
+      })),
+      {
+        FieldValue: { serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP") },
+      }
+    ),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeContext(uid: string | null = "user-team-a"): functionsTypes.https.CallableContext {
+  return uid ? ({ auth: { uid, token: {} as any } } as any) : ({ auth: undefined } as any);
+}
+
+const validSets2_0 = [
+  { teamAPoints: 21, teamBPoints: 15, setNumber: 1 },
+  { teamAPoints: 21, teamBPoints: 18, setNumber: 2 },
+];
+
+const validSets2_1 = [
+  { teamAPoints: 21, teamBPoints: 18, setNumber: 1 },
+  { teamAPoints: 17, teamBPoints: 21, setNumber: 2 },
+  { teamAPoints: 15, teamBPoints: 12, setNumber: 3 },
+];
+
+const pendingMatch = {
+  status: "pending",
+  teamAId: "team-a",
+  teamBId: "team-b",
+};
+
+function makeTeamDoc(memberIds: string[]) {
+  return { exists: true, data: () => ({ memberIds }) };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("submitChampionshipMatchResult", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMatchGet.mockResolvedValue({ exists: true, data: () => pendingMatch });
+    mockTeamAGet.mockResolvedValue(makeTeamDoc(["user-team-a", "user-team-a-2"]));
+    mockTeamBGet.mockResolvedValue(makeTeamDoc(["user-team-b", "user-team-b-2"]));
+    mockMatchUpdate.mockResolvedValue(undefined);
+  });
+
+  // ── Authentication ──────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("throws unauthenticated when no auth", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext(null)
+        )
+      ).rejects.toMatchObject({ code: "unauthenticated" });
+    });
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  describe("input validation", () => {
+    it("throws invalid-argument when championshipId is missing", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "", matchId: "match-1", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when matchId is missing", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument when sets is missing", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: [] },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument for invalid set scores (21-20 gap)", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          {
+            championshipId: "champ-1",
+            matchId: "match-1",
+            sets: [
+              { teamAPoints: 21, teamBPoints: 20, setNumber: 1 },
+              { teamAPoints: 21, teamBPoints: 15, setNumber: 2 },
+            ],
+          },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+
+    it("throws invalid-argument for score not reaching target (19-15)", async () => {
+      await expect(
+        submitChampionshipMatchResultHandler(
+          {
+            championshipId: "champ-1",
+            matchId: "match-1",
+            sets: [
+              { teamAPoints: 19, teamBPoints: 15, setNumber: 1 },
+              { teamAPoints: 21, teamBPoints: 15, setNumber: 2 },
+            ],
+          },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "invalid-argument" });
+    });
+  });
+
+  // ── Match validation ────────────────────────────────────────────────────────
+
+  describe("match validation", () => {
+    it("throws not-found when match does not exist", async () => {
+      mockMatchGet.mockResolvedValue({ exists: false });
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "not-found" });
+    });
+
+    it("throws failed-precondition when match is already played", async () => {
+      mockMatchGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...pendingMatch, status: "played" }),
+      });
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "failed-precondition" });
+    });
+
+    it("throws failed-precondition when match is verified", async () => {
+      mockMatchGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...pendingMatch, status: "verified" }),
+      });
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "failed-precondition" });
+    });
+
+    it("allows submission when match is scheduled", async () => {
+      mockMatchGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ ...pendingMatch, status: "scheduled" }),
+      });
+      const result = await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext()
+      );
+      expect(result.pendingVerification).toBe(true);
+    });
+  });
+
+  // ── Permission check ────────────────────────────────────────────────────────
+
+  describe("permission check", () => {
+    it("throws permission-denied when caller is not in either team", async () => {
+      mockTeamAGet.mockResolvedValue(makeTeamDoc(["other-user-1", "other-user-2"]));
+      mockTeamBGet.mockResolvedValue(makeTeamDoc(["other-user-3", "other-user-4"]));
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext("not-a-member")
+        )
+      ).rejects.toMatchObject({ code: "permission-denied" });
+    });
+
+    it("allows submission by teamB member", async () => {
+      const result = await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext("user-team-b")
+      );
+      expect(result.pendingVerification).toBe(true);
+    });
+  });
+
+  // ── Successful submission ───────────────────────────────────────────────────
+
+  describe("successful submission", () => {
+    it("returns { matchId, pendingVerification: true } for 2-0 result", async () => {
+      const result = await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext()
+      );
+      expect(result).toEqual({ matchId: "match-1", pendingVerification: true });
+    });
+
+    it("returns { matchId, pendingVerification: true } for 2-1 result", async () => {
+      const result = await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_1 },
+        makeContext()
+      );
+      expect(result).toEqual({ matchId: "match-1", pendingVerification: true });
+    });
+
+    it("updates match status to 'played'", async () => {
+      await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext()
+      );
+      expect(mockMatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "played" })
+      );
+    });
+
+    it("stores submittedByTeamId and submittedByUserId", async () => {
+      await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext("user-team-a")
+      );
+      expect(mockMatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          submittedByTeamId: "team-a",
+          submittedByUserId: "user-team-a",
+        })
+      );
+    });
+
+    it("stores correct result for 2-0 win by teamA (3 pts vs 0 pts)", async () => {
+      await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext()
+      );
+      expect(mockMatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            winner: "teamA",
+            teamAPoints: 3,
+            teamBPoints: 0,
+          }),
+        })
+      );
+    });
+
+    it("stores correct result for 2-1 win by teamA (2 pts vs 1 pt)", async () => {
+      await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_1 },
+        makeContext()
+      );
+      expect(mockMatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            winner: "teamA",
+            teamAPoints: 2,
+            teamBPoints: 1,
+          }),
+        })
+      );
+    });
+
+    it("submittedByTeamId is teamB when submitted by teamB member", async () => {
+      await submitChampionshipMatchResultHandler(
+        { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+        makeContext("user-team-b")
+      );
+      expect(mockMatchUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ submittedByTeamId: "team-b" })
+      );
+    });
+  });
+
+  // ── Error handling ──────────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("throws internal when match update fails", async () => {
+      mockMatchUpdate.mockRejectedValue(new Error("Firestore unavailable"));
+      await expect(
+        submitChampionshipMatchResultHandler(
+          { championshipId: "champ-1", matchId: "match-1", sets: validSets2_0 },
+          makeContext()
+        )
+      ).rejects.toMatchObject({ code: "internal" });
+    });
+  });
+});

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -76,6 +76,7 @@ import 'package:play_with_me/features/championships/data/repositories/firestore_
 import 'package:play_with_me/features/championships/presentation/bloc/partner_picker/partner_picker_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/team_registration/team_registration_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/result_submission/result_submission_bloc.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -244,6 +245,12 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<MatchChatBloc>()) {
     sl.registerFactory<MatchChatBloc>(
       () => MatchChatBloc(messageRepository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<ResultSubmissionBloc>()) {
+    sl.registerFactory<ResultSubmissionBloc>(
+      () => ResultSubmissionBloc(championshipRepository: sl()),
     );
   }
 

--- a/lib/features/championships/data/repositories/firestore_championship_repository.dart
+++ b/lib/features/championships/data/repositories/firestore_championship_repository.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
 import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
@@ -119,6 +120,29 @@ class FirestoreChampionshipRepository implements ChampionshipRepository {
       throw ChampionshipException(e.message ?? 'Failed to start championship', code: e.code);
     } catch (e) {
       throw ChampionshipException('Failed to start championship: $e');
+    }
+  }
+
+  @override
+  Future<void> submitMatchResult({
+    required String championshipId,
+    required String matchId,
+    required List<MatchSetScore> sets,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('submitChampionshipMatchResult');
+      await callable.call({
+        'championshipId': championshipId,
+        'matchId': matchId,
+        'sets': sets.map((s) => s.toJson()).toList(),
+      });
+    } on FirebaseFunctionsException catch (e) {
+      throw ChampionshipException(
+        e.message ?? 'Failed to submit match result',
+        code: e.code,
+      );
+    } catch (e) {
+      throw ChampionshipException('Failed to submit match result: $e');
     }
   }
 }

--- a/lib/features/championships/domain/repositories/championship_repository.dart
+++ b/lib/features/championships/domain/repositories/championship_repository.dart
@@ -1,4 +1,5 @@
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
 
@@ -39,5 +40,14 @@ abstract class ChampionshipRepository {
   Future<int> startChampionship({
     required String championshipId,
     required DateTime startDate,
+  });
+
+  /// Submits a match result via Cloud Function.
+  /// [sets] must contain 2 or 3 [MatchSetScore] items.
+  /// Throws [ChampionshipException] on error.
+  Future<void> submitMatchResult({
+    required String championshipId,
+    required String matchId,
+    required List<MatchSetScore> sets,
   });
 }

--- a/lib/features/championships/presentation/bloc/result_submission/result_submission_bloc.dart
+++ b/lib/features/championships/presentation/bloc/result_submission/result_submission_bloc.dart
@@ -1,0 +1,38 @@
+// Manages championship match result submission flow.
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
+import 'result_submission_event.dart';
+import 'result_submission_state.dart';
+
+class ResultSubmissionBloc
+    extends Bloc<ResultSubmissionEvent, ResultSubmissionState> {
+  final ChampionshipRepository _championshipRepository;
+
+  ResultSubmissionBloc({required ChampionshipRepository championshipRepository})
+      : _championshipRepository = championshipRepository,
+        super(const ResultSubmissionInitial()) {
+    on<SubmitMatchResult>(_onSubmitMatchResult);
+  }
+
+  Future<void> _onSubmitMatchResult(
+    SubmitMatchResult event,
+    Emitter<ResultSubmissionState> emit,
+  ) async {
+    emit(const ResultSubmissionSubmitting());
+    try {
+      await _championshipRepository.submitMatchResult(
+        championshipId: event.championshipId,
+        matchId: event.matchId,
+        sets: event.sets,
+      );
+      emit(const ResultSubmissionSuccess());
+    } on ChampionshipException catch (e) {
+      emit(ResultSubmissionError(message: e.message, errorCode: e.code));
+    } catch (e) {
+      emit(
+        ResultSubmissionError(message: 'Failed to submit result: ${e.toString()}'),
+      );
+    }
+  }
+}

--- a/lib/features/championships/presentation/bloc/result_submission/result_submission_event.dart
+++ b/lib/features/championships/presentation/bloc/result_submission/result_submission_event.dart
@@ -1,0 +1,24 @@
+// Events for ResultSubmissionBloc handling championship match result submission.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+
+abstract class ResultSubmissionEvent extends Equatable {
+  const ResultSubmissionEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class SubmitMatchResult extends ResultSubmissionEvent {
+  final String championshipId;
+  final String matchId;
+  final List<MatchSetScore> sets;
+
+  const SubmitMatchResult({
+    required this.championshipId,
+    required this.matchId,
+    required this.sets,
+  });
+
+  @override
+  List<Object?> get props => [championshipId, matchId, sets];
+}

--- a/lib/features/championships/presentation/bloc/result_submission/result_submission_state.dart
+++ b/lib/features/championships/presentation/bloc/result_submission/result_submission_state.dart
@@ -1,0 +1,30 @@
+// States for ResultSubmissionBloc handling championship match result submission.
+import 'package:equatable/equatable.dart';
+
+abstract class ResultSubmissionState extends Equatable {
+  const ResultSubmissionState();
+  @override
+  List<Object?> get props => [];
+}
+
+class ResultSubmissionInitial extends ResultSubmissionState {
+  const ResultSubmissionInitial();
+}
+
+class ResultSubmissionSubmitting extends ResultSubmissionState {
+  const ResultSubmissionSubmitting();
+}
+
+class ResultSubmissionSuccess extends ResultSubmissionState {
+  const ResultSubmissionSuccess();
+}
+
+class ResultSubmissionError extends ResultSubmissionState {
+  final String message;
+  final String? errorCode;
+
+  const ResultSubmissionError({required this.message, this.errorCode});
+
+  @override
+  List<Object?> get props => [message, errorCode];
+}

--- a/lib/features/championships/presentation/widgets/match_result_entry_widget.dart
+++ b/lib/features/championships/presentation/widgets/match_result_entry_widget.dart
@@ -1,0 +1,387 @@
+// Widget for entering and submitting a championship match result.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+import '../bloc/result_submission/result_submission_bloc.dart';
+import '../bloc/result_submission/result_submission_event.dart';
+import '../bloc/result_submission/result_submission_state.dart';
+
+class MatchResultEntryWidget extends StatelessWidget {
+  final String championshipId;
+  final String matchId;
+  final String teamAName;
+  final String teamBName;
+  final ChampionshipRepository? championshipRepository;
+
+  const MatchResultEntryWidget({
+    super.key,
+    required this.championshipId,
+    required this.matchId,
+    required this.teamAName,
+    required this.teamBName,
+    this.championshipRepository,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => ResultSubmissionBloc(
+        championshipRepository:
+            championshipRepository ?? sl<ChampionshipRepository>(),
+      ),
+      child: _MatchResultEntryView(
+        championshipId: championshipId,
+        matchId: matchId,
+        teamAName: teamAName,
+        teamBName: teamBName,
+      ),
+    );
+  }
+}
+
+class _MatchResultEntryView extends StatefulWidget {
+  final String championshipId;
+  final String matchId;
+  final String teamAName;
+  final String teamBName;
+
+  const _MatchResultEntryView({
+    required this.championshipId,
+    required this.matchId,
+    required this.teamAName,
+    required this.teamBName,
+  });
+
+  @override
+  State<_MatchResultEntryView> createState() => _MatchResultEntryViewState();
+}
+
+class _MatchResultEntryViewState extends State<_MatchResultEntryView> {
+  // Controllers for set 1, set 2 (always present), and optional set 3
+  final _set1TeamA = TextEditingController();
+  final _set1TeamB = TextEditingController();
+  final _set2TeamA = TextEditingController();
+  final _set2TeamB = TextEditingController();
+  final _set3TeamA = TextEditingController();
+  final _set3TeamB = TextEditingController();
+
+  bool _hasSet3 = false;
+  String? _validationError;
+
+  @override
+  void dispose() {
+    _set1TeamA.dispose();
+    _set1TeamB.dispose();
+    _set2TeamA.dispose();
+    _set2TeamB.dispose();
+    _set3TeamA.dispose();
+    _set3TeamB.dispose();
+    super.dispose();
+  }
+
+  int? _parse(TextEditingController c) => int.tryParse(c.text.trim());
+
+  /// Builds and validates the sets from the form inputs.
+  /// Returns the list on success, or sets [_validationError] and returns null.
+  List<MatchSetScore>? _buildSets(AppLocalizations l10n) {
+    final s1a = _parse(_set1TeamA);
+    final s1b = _parse(_set1TeamB);
+    final s2a = _parse(_set2TeamA);
+    final s2b = _parse(_set2TeamB);
+
+    if (s1a == null || s1b == null || s2a == null || s2b == null) {
+      return null;
+    }
+
+    final sets = [
+      MatchSetScore(teamAPoints: s1a, teamBPoints: s1b, setNumber: 1),
+      MatchSetScore(teamAPoints: s2a, teamBPoints: s2b, setNumber: 2),
+    ];
+
+    if (_hasSet3) {
+      final s3a = _parse(_set3TeamA);
+      final s3b = _parse(_set3TeamB);
+      if (s3a == null || s3b == null) return null;
+      sets.add(MatchSetScore(teamAPoints: s3a, teamBPoints: s3b, setNumber: 3));
+    }
+
+    // Local validation using the existing MatchSetScore.isValid logic
+    for (final set in sets) {
+      final isDecider = set.setNumber == 3;
+      if (!set.isValid(isDeciderSet: isDecider)) {
+        setState(() => _validationError =
+            '${l10n.submitResultInvalidSetScore} (${l10n.submitResultSet(set.setNumber)})');
+        return null;
+      }
+    }
+
+    // Validate a winner exists with 2 sets
+    final teamAWins = sets.where((s) => s.teamAPoints > s.teamBPoints).length;
+    final teamBWins = sets.where((s) => s.teamBPoints > s.teamAPoints).length;
+    if (teamAWins != 2 && teamBWins != 2) {
+      setState(() => _validationError = l10n.submitResultNoWinner);
+      return null;
+    }
+
+    setState(() => _validationError = null);
+    return sets;
+  }
+
+  void _submit(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final sets = _buildSets(l10n);
+    if (sets == null) return;
+
+    context.read<ResultSubmissionBloc>().add(
+      SubmitMatchResult(
+        championshipId: widget.championshipId,
+        matchId: widget.matchId,
+        sets: sets,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return BlocConsumer<ResultSubmissionBloc, ResultSubmissionState>(
+      listener: (context, state) {
+        if (state is ResultSubmissionError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.message)),
+          );
+        }
+      },
+      builder: (context, state) {
+        if (state is ResultSubmissionSuccess) {
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.check_circle, color: Colors.green, size: 48),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.submitResultAwaitingVerification,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          );
+        }
+
+        final isSubmitting = state is ResultSubmissionSubmitting;
+
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.submitResultTitle,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.secondary,
+                ),
+              ),
+              const SizedBox(height: 16),
+              // Column headers
+              _TeamHeader(
+                teamAName: widget.teamAName,
+                teamBName: widget.teamBName,
+              ),
+              const SizedBox(height: 8),
+              // Set 1
+              _SetRow(
+                label: l10n.submitResultSet(1),
+                controllerA: _set1TeamA,
+                controllerB: _set1TeamB,
+                enabled: !isSubmitting,
+              ),
+              const SizedBox(height: 8),
+              // Set 2
+              _SetRow(
+                label: l10n.submitResultSet(2),
+                controllerA: _set2TeamA,
+                controllerB: _set2TeamB,
+                enabled: !isSubmitting,
+              ),
+              // Set 3 toggle
+              const SizedBox(height: 8),
+              if (_hasSet3) ...[
+                _SetRow(
+                  label: l10n.submitResultSet(3),
+                  controllerA: _set3TeamA,
+                  controllerB: _set3TeamB,
+                  enabled: !isSubmitting,
+                ),
+                const SizedBox(height: 4),
+                TextButton(
+                  onPressed: isSubmitting
+                      ? null
+                      : () => setState(() {
+                            _hasSet3 = false;
+                            _set3TeamA.clear();
+                            _set3TeamB.clear();
+                          }),
+                  child: Text(l10n.submitResultRemoveSet3),
+                ),
+              ] else
+                TextButton(
+                  onPressed: isSubmitting
+                      ? null
+                      : () => setState(() => _hasSet3 = true),
+                  child: Text(l10n.submitResultAddSet3),
+                ),
+              // Validation error
+              if (_validationError != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _validationError!,
+                  style: const TextStyle(color: Colors.red, fontSize: 13),
+                ),
+              ],
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: isSubmitting ? null : () => _submit(context),
+                  child: isSubmitting
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : Text(l10n.submitResultSubmitButton),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TeamHeader extends StatelessWidget {
+  final String teamAName;
+  final String teamBName;
+
+  const _TeamHeader({required this.teamAName, required this.teamBName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const SizedBox(width: 64),
+        Expanded(
+          child: Text(
+            teamAName,
+            style: const TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 13,
+            ),
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            teamBName,
+            style: const TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 13,
+            ),
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SetRow extends StatelessWidget {
+  final String label;
+  final TextEditingController controllerA;
+  final TextEditingController controllerB;
+  final bool enabled;
+
+  const _SetRow({
+    required this.label,
+    required this.controllerA,
+    required this.controllerB,
+    required this.enabled,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 56,
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _PointsInput(controller: controllerA, enabled: enabled),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8),
+          child: Text('–', style: TextStyle(fontWeight: FontWeight.bold)),
+        ),
+        Expanded(
+          child: _PointsInput(controller: controllerB, enabled: enabled),
+        ),
+      ],
+    );
+  }
+}
+
+class _PointsInput extends StatelessWidget {
+  final TextEditingController controller;
+  final bool enabled;
+
+  const _PointsInput({required this.controller, required this.enabled});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      enabled: enabled,
+      keyboardType: TextInputType.number,
+      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+      textAlign: TextAlign.center,
+      decoration: InputDecoration(
+        isDense: true,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 8,
+          vertical: 10,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -777,5 +777,13 @@
   "matchChatTitle": "Match-Chat",
   "matchChatCoordinationHint": "Koordiniert Datum, Uhrzeit und Ort mit dem gegnerischen Team",
   "matchChatNotMember": "Nur Teammitglieder können an diesem Chat teilnehmen.",
-  "matchChatEmpty": "Noch keine Nachrichten. Beginnt die Koordination mit dem gegnerischen Team!"
+  "matchChatEmpty": "Noch keine Nachrichten. Beginnt die Koordination mit dem gegnerischen Team!",
+  "submitResultTitle": "Ergebnis einreichen",
+  "submitResultSet": "Satz {number}",
+  "submitResultAddSet3": "+ Entscheidungssatz hinzufügen (Satz 3)",
+  "submitResultRemoveSet3": "Satz 3 entfernen",
+  "submitResultSubmitButton": "Einreichen",
+  "submitResultAwaitingVerification": "Ergebnis eingereicht. Warte auf Bestätigung des gegnerischen Teams.",
+  "submitResultInvalidSetScore": "Ungültiger Score",
+  "submitResultNoWinner": "Ein Team muss 2 Sätze gewinnen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3070,5 +3070,21 @@
   "matchChatNotMember": "Only team members can participate in this chat.",
   "@matchChatNotMember": {"description": "Message shown to users who are not part of either team in the match"},
   "matchChatEmpty": "No messages yet. Start coordinating with the opposing team!",
-  "@matchChatEmpty": {"description": "Empty state message in the match chat when no messages have been sent"}
+  "@matchChatEmpty": {"description": "Empty state message in the match chat when no messages have been sent"},
+  "submitResultTitle": "Submit Result",
+  "@submitResultTitle": {"description": "Title of the match result entry form"},
+  "submitResultSet": "Set {number}",
+  "@submitResultSet": {"description": "Label for a set row in the result form", "placeholders": {"number": {"type": "int"}}},
+  "submitResultAddSet3": "+ Add deciding set (set 3)",
+  "@submitResultAddSet3": {"description": "Button to add the optional deciding set to the result form"},
+  "submitResultRemoveSet3": "Remove set 3",
+  "@submitResultRemoveSet3": {"description": "Button to remove the deciding set from the result form"},
+  "submitResultSubmitButton": "Submit Result",
+  "@submitResultSubmitButton": {"description": "Submit button label on the result entry form"},
+  "submitResultAwaitingVerification": "Result submitted. Awaiting verification by the opposing team.",
+  "@submitResultAwaitingVerification": {"description": "Success message shown after result submission, before verification"},
+  "submitResultInvalidSetScore": "Invalid score",
+  "@submitResultInvalidSetScore": {"description": "Error prefix shown when a set score fails validation"},
+  "submitResultNoWinner": "One team must win 2 sets.",
+  "@submitResultNoWinner": {"description": "Validation error when the sets entered don't produce a clear winner"}
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -777,5 +777,13 @@
   "matchChatTitle": "Chat del partido",
   "matchChatCoordinationHint": "Coordinad fecha, hora y lugar con el equipo contrario",
   "matchChatNotMember": "Solo los miembros de los equipos pueden participar en este chat.",
-  "matchChatEmpty": "¡Todavía no hay mensajes. ¡Empieza a coordinar con el equipo contrario!"
+  "matchChatEmpty": "¡Todavía no hay mensajes. ¡Empieza a coordinar con el equipo contrario!",
+  "submitResultTitle": "Enviar resultado",
+  "submitResultSet": "Set {number}",
+  "submitResultAddSet3": "+ Añadir set decisivo (set 3)",
+  "submitResultRemoveSet3": "Eliminar set 3",
+  "submitResultSubmitButton": "Enviar resultado",
+  "submitResultAwaitingVerification": "Resultado enviado. Esperando verificación del equipo contrario.",
+  "submitResultInvalidSetScore": "Puntuación inválida",
+  "submitResultNoWinner": "Un equipo debe ganar 2 sets."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -777,5 +777,13 @@
   "matchChatTitle": "Chat du match",
   "matchChatCoordinationHint": "Coordonnez la date, l’heure et le lieu avec l’équipe adverse",
   "matchChatNotMember": "Seuls les membres des équipes peuvent participer à ce chat.",
-  "matchChatEmpty": "Aucun message pour l’instant. Commencez à coordonner avec l’équipe adverse !"
+  "matchChatEmpty": "Aucun message pour l’instant. Commencez à coordonner avec l’équipe adverse !",
+  "submitResultTitle": "Soumettre le résultat",
+  "submitResultSet": "Set {number}",
+  "submitResultAddSet3": "+ Ajouter le set décisif (set 3)",
+  "submitResultRemoveSet3": "Supprimer le set 3",
+  "submitResultSubmitButton": "Soumettre",
+  "submitResultAwaitingVerification": "Résultat soumis. En attente de vérification par l'équipe adverse.",
+  "submitResultInvalidSetScore": "Score invalide",
+  "submitResultNoWinner": "Une équipe doit gagner 2 sets."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -777,5 +777,13 @@
   "matchChatTitle": "Chat del match",
   "matchChatCoordinationHint": "Coordinate data, ora e luogo con la squadra avversaria",
   "matchChatNotMember": "Solo i membri delle squadre possono partecipare a questa chat.",
-  "matchChatEmpty": "Nessun messaggio ancora. Inizia a coordinare con la squadra avversaria!"
+  "matchChatEmpty": "Nessun messaggio ancora. Inizia a coordinare con la squadra avversaria!",
+  "submitResultTitle": "Invia risultato",
+  "submitResultSet": "Set {number}",
+  "submitResultAddSet3": "+ Aggiungi set decisivo (set 3)",
+  "submitResultRemoveSet3": "Rimuovi set 3",
+  "submitResultSubmitButton": "Invia",
+  "submitResultAwaitingVerification": "Risultato inviato. In attesa di verifica dalla squadra avversaria.",
+  "submitResultInvalidSetScore": "Punteggio non valido",
+  "submitResultNoWinner": "Una squadra deve vincere 2 set."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3991,6 +3991,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No messages yet. Start coordinating with the opposing team!'**
   String get matchChatEmpty;
+
+  /// Title of the match result entry form
+  ///
+  /// In en, this message translates to:
+  /// **'Submit Result'**
+  String get submitResultTitle;
+
+  /// Label for a set row in the result form
+  ///
+  /// In en, this message translates to:
+  /// **'Set {number}'**
+  String submitResultSet(int number);
+
+  /// Button to add the optional deciding set to the result form
+  ///
+  /// In en, this message translates to:
+  /// **'+ Add deciding set (set 3)'**
+  String get submitResultAddSet3;
+
+  /// Button to remove the deciding set from the result form
+  ///
+  /// In en, this message translates to:
+  /// **'Remove set 3'**
+  String get submitResultRemoveSet3;
+
+  /// Submit button label on the result entry form
+  ///
+  /// In en, this message translates to:
+  /// **'Submit Result'**
+  String get submitResultSubmitButton;
+
+  /// Success message shown after result submission, before verification
+  ///
+  /// In en, this message translates to:
+  /// **'Result submitted. Awaiting verification by the opposing team.'**
+  String get submitResultAwaitingVerification;
+
+  /// Error prefix shown when a set score fails validation
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid score'**
+  String get submitResultInvalidSetScore;
+
+  /// Validation error when the sets entered don't produce a clear winner
+  ///
+  /// In en, this message translates to:
+  /// **'One team must win 2 sets.'**
+  String get submitResultNoWinner;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2209,4 +2209,31 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get matchChatEmpty =>
       'Noch keine Nachrichten. Beginnt die Koordination mit dem gegnerischen Team!';
+
+  @override
+  String get submitResultTitle => 'Ergebnis einreichen';
+
+  @override
+  String submitResultSet(int number) {
+    return 'Satz $number';
+  }
+
+  @override
+  String get submitResultAddSet3 => '+ Entscheidungssatz hinzufügen (Satz 3)';
+
+  @override
+  String get submitResultRemoveSet3 => 'Satz 3 entfernen';
+
+  @override
+  String get submitResultSubmitButton => 'Einreichen';
+
+  @override
+  String get submitResultAwaitingVerification =>
+      'Ergebnis eingereicht. Warte auf Bestätigung des gegnerischen Teams.';
+
+  @override
+  String get submitResultInvalidSetScore => 'Ungültiger Score';
+
+  @override
+  String get submitResultNoWinner => 'Ein Team muss 2 Sätze gewinnen.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2170,4 +2170,31 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get matchChatEmpty =>
       'No messages yet. Start coordinating with the opposing team!';
+
+  @override
+  String get submitResultTitle => 'Submit Result';
+
+  @override
+  String submitResultSet(int number) {
+    return 'Set $number';
+  }
+
+  @override
+  String get submitResultAddSet3 => '+ Add deciding set (set 3)';
+
+  @override
+  String get submitResultRemoveSet3 => 'Remove set 3';
+
+  @override
+  String get submitResultSubmitButton => 'Submit Result';
+
+  @override
+  String get submitResultAwaitingVerification =>
+      'Result submitted. Awaiting verification by the opposing team.';
+
+  @override
+  String get submitResultInvalidSetScore => 'Invalid score';
+
+  @override
+  String get submitResultNoWinner => 'One team must win 2 sets.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2198,4 +2198,31 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get matchChatEmpty =>
       '¡Todavía no hay mensajes. ¡Empieza a coordinar con el equipo contrario!';
+
+  @override
+  String get submitResultTitle => 'Enviar resultado';
+
+  @override
+  String submitResultSet(int number) {
+    return 'Set $number';
+  }
+
+  @override
+  String get submitResultAddSet3 => '+ Añadir set decisivo (set 3)';
+
+  @override
+  String get submitResultRemoveSet3 => 'Eliminar set 3';
+
+  @override
+  String get submitResultSubmitButton => 'Enviar resultado';
+
+  @override
+  String get submitResultAwaitingVerification =>
+      'Resultado enviado. Esperando verificación del equipo contrario.';
+
+  @override
+  String get submitResultInvalidSetScore => 'Puntuación inválida';
+
+  @override
+  String get submitResultNoWinner => 'Un equipo debe ganar 2 sets.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2215,4 +2215,31 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get matchChatEmpty =>
       'Aucun message pour l’instant. Commencez à coordonner avec l’équipe adverse !';
+
+  @override
+  String get submitResultTitle => 'Soumettre le résultat';
+
+  @override
+  String submitResultSet(int number) {
+    return 'Set $number';
+  }
+
+  @override
+  String get submitResultAddSet3 => '+ Ajouter le set décisif (set 3)';
+
+  @override
+  String get submitResultRemoveSet3 => 'Supprimer le set 3';
+
+  @override
+  String get submitResultSubmitButton => 'Soumettre';
+
+  @override
+  String get submitResultAwaitingVerification =>
+      'Résultat soumis. En attente de vérification par l\'équipe adverse.';
+
+  @override
+  String get submitResultInvalidSetScore => 'Score invalide';
+
+  @override
+  String get submitResultNoWinner => 'Une équipe doit gagner 2 sets.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2191,4 +2191,31 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get matchChatEmpty =>
       'Nessun messaggio ancora. Inizia a coordinare con la squadra avversaria!';
+
+  @override
+  String get submitResultTitle => 'Invia risultato';
+
+  @override
+  String submitResultSet(int number) {
+    return 'Set $number';
+  }
+
+  @override
+  String get submitResultAddSet3 => '+ Aggiungi set decisivo (set 3)';
+
+  @override
+  String get submitResultRemoveSet3 => 'Rimuovi set 3';
+
+  @override
+  String get submitResultSubmitButton => 'Invia';
+
+  @override
+  String get submitResultAwaitingVerification =>
+      'Risultato inviato. In attesa di verifica dalla squadra avversaria.';
+
+  @override
+  String get submitResultInvalidSetScore => 'Punteggio non valido';
+
+  @override
+  String get submitResultNoWinner => 'Una squadra deve vincere 2 set.';
 }

--- a/test/unit/features/championships/presentation/bloc/result_submission_bloc_test.dart
+++ b/test/unit/features/championships/presentation/bloc/result_submission_bloc_test.dart
@@ -1,0 +1,148 @@
+// Validates ResultSubmissionBloc state transitions for match result submission.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/result_submission/result_submission_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/result_submission/result_submission_event.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/result_submission/result_submission_state.dart';
+
+class MockChampionshipRepository extends Mock implements ChampionshipRepository {}
+
+void main() {
+  late MockChampionshipRepository mockRepo;
+
+  const sets2_0 = [
+    MatchSetScore(teamAPoints: 21, teamBPoints: 15, setNumber: 1),
+    MatchSetScore(teamAPoints: 21, teamBPoints: 18, setNumber: 2),
+  ];
+
+  setUpAll(() {
+    registerFallbackValue(sets2_0);
+  });
+
+  setUp(() {
+    mockRepo = MockChampionshipRepository();
+  });
+
+  ResultSubmissionBloc makeBloc() =>
+      ResultSubmissionBloc(championshipRepository: mockRepo);
+
+  group('SubmitMatchResult', () {
+    blocTest<ResultSubmissionBloc, ResultSubmissionState>(
+      'emits Submitting then Success on successful submission',
+      build: () {
+        when(
+          () => mockRepo.submitMatchResult(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            sets: any(named: 'sets'),
+          ),
+        ).thenAnswer((_) async {});
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const SubmitMatchResult(
+          championshipId: 'champ-1',
+          matchId: 'match-1',
+          sets: sets2_0,
+        ),
+      ),
+      expect: () => [
+        const ResultSubmissionSubmitting(),
+        const ResultSubmissionSuccess(),
+      ],
+    );
+
+    blocTest<ResultSubmissionBloc, ResultSubmissionState>(
+      'emits Submitting then Error with message on ChampionshipException',
+      build: () {
+        when(
+          () => mockRepo.submitMatchResult(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            sets: any(named: 'sets'),
+          ),
+        ).thenThrow(ChampionshipException('permission-denied', code: 'PERMISSION_DENIED'));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const SubmitMatchResult(
+          championshipId: 'champ-1',
+          matchId: 'match-1',
+          sets: sets2_0,
+        ),
+      ),
+      expect: () => [
+        const ResultSubmissionSubmitting(),
+        const ResultSubmissionError(
+          message: 'permission-denied',
+          errorCode: 'PERMISSION_DENIED',
+        ),
+      ],
+    );
+
+    blocTest<ResultSubmissionBloc, ResultSubmissionState>(
+      'emits Submitting then Error on generic exception',
+      build: () {
+        when(
+          () => mockRepo.submitMatchResult(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            sets: any(named: 'sets'),
+          ),
+        ).thenThrow(Exception('network error'));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const SubmitMatchResult(
+          championshipId: 'champ-1',
+          matchId: 'match-1',
+          sets: sets2_0,
+        ),
+      ),
+      expect: () => [
+        const ResultSubmissionSubmitting(),
+        isA<ResultSubmissionError>(),
+      ],
+    );
+
+    blocTest<ResultSubmissionBloc, ResultSubmissionState>(
+      'passes correct championshipId, matchId, and sets to repository',
+      build: () {
+        when(
+          () => mockRepo.submitMatchResult(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            sets: any(named: 'sets'),
+          ),
+        ).thenAnswer((_) async {});
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(
+        const SubmitMatchResult(
+          championshipId: 'champ-99',
+          matchId: 'match-42',
+          sets: sets2_0,
+        ),
+      ),
+      verify: (_) => verify(
+        () => mockRepo.submitMatchResult(
+          championshipId: 'champ-99',
+          matchId: 'match-42',
+          sets: sets2_0,
+        ),
+      ).called(1),
+    );
+
+    blocTest<ResultSubmissionBloc, ResultSubmissionState>(
+      'initial state is ResultSubmissionInitial',
+      build: makeBloc,
+      act: (_) {},
+      expect: () => [],
+      verify: (bloc) => expect(bloc.state, const ResultSubmissionInitial()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

### Cloud Functions
- **`scoreValidation.ts`** — Pure helpers: `isSetValid` (mirrors Dart `MatchSetScore.isValid`), `validateMatchResult` (2–3 sets, correct set numbers, each set valid, one team wins 2 sets), `computeChampionshipPoints` (2-0 → 3/0 pts; 2-1 → 2/1 pts).
- **`submitChampionshipMatchResult`** — Callable CF: auth → input validation → score validation → match exists & status in `[pending, scheduled]` → caller in teamA or teamB (parallel team fetches) → writes `result`, `submittedByTeamId`, `submittedByUserId`, `status: 'played'`. Does NOT update standings — that happens after verification (Story 30.7).

### Flutter
- **`ChampionshipRepository`** — New `submitMatchResult({championshipId, matchId, sets})`.
- **`FirestoreChampionshipRepository`** — Implements via `httpsCallable('submitChampionshipMatchResult')`, serialising `List<MatchSetScore>` to JSON.
- **`ResultSubmissionBloc`** — `SubmitMatchResult` event → `Submitting → Success | Error`.
- **`MatchResultEntryWidget`** — Score entry form: set 1 & 2 always shown, set 3 toggleable; local validation via `MatchSetScore.isValid`; submit button triggers BLoC; success view shows "Awaiting verification" message.
- **Service locator** — `ResultSubmissionBloc` as factory.
- **l10n** — 8 keys in EN/FR/DE/ES/IT.

## Tests
- **`scoreValidation.test.ts`** (24 tests): `isSetValid` edge cases (standard wins, extended play, reject invalid gaps), `validateMatchResult` (valid 2-0 and 2-1, various invalid inputs), `computeChampionshipPoints` (all 4 outcomes).
- **`submitChampionshipMatchResult.test.ts`** (24 tests): auth, input validation, match not-found, wrong status, permission denied, successful submission (status, result object, points, submittedBy fields), Firestore write failure.
- **`result_submission_bloc_test.dart`** (5 tests): state transitions, error propagation, repo call arguments.

## Test plan
- [ ] `cd functions && npm test` — 682 tests pass
- [ ] `flutter test test/unit/ test/widget/` — no regressions
- [ ] `flutter analyze` — no new warnings