### PR TITLE
feat(championships): standings recalculation trigger after verified result (Story 30.8)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,6 +32,7 @@ export {leaveChampionshipTeam} from "./leaveChampionshipTeam"; // Story 30.3 (Te
 export {startChampionship} from "./startChampionship"; // Story 30.4 (Fixture Generation)
 export {submitChampionshipMatchResult} from "./submitChampionshipMatchResult"; // Story 30.6 (Result Submission)
 export {verifyChampionshipMatchResult} from "./verifyChampionshipMatchResult"; // Story 30.7 (Result Verification)
+export {onChampionshipMatchVerified} from "./onChampionshipMatchVerified"; // Story 30.8 (Standings Recalculation)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)

--- a/functions/src/onChampionshipMatchVerified.ts
+++ b/functions/src/onChampionshipMatchVerified.ts
@@ -1,0 +1,214 @@
+// Firestore trigger: recalculates championship standings when a match is verified (Story 30.8).
+// Fires on championships/{championshipId}/matches/{matchId} when status → 'verified' or 'admin_decided'.
+// Idempotency guard: skips if standingsUpdated is already true on the match doc.
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import {
+  StandingsRow,
+  computeStandingsDeltas,
+  applyDelta,
+  recalculatePositions,
+  MatchResultData,
+} from "./standingsCalculation";
+
+// ============================================================================
+// Inner Handler (exported for unit tests)
+// ============================================================================
+
+export async function onChampionshipMatchVerifiedHandler(
+  before: admin.firestore.DocumentSnapshot,
+  after: admin.firestore.DocumentSnapshot,
+  params: { championshipId: string; matchId: string }
+): Promise<void> {
+  const afterData = after.data();
+  const beforeData = before.data();
+
+  // ── 1. Guard: only handle verified or admin_decided status ─────────────────
+  const relevantStatuses = ["verified", "admin_decided"];
+  if (!afterData || !relevantStatuses.includes(afterData.status)) {
+    return;
+  }
+
+  // ── 2. Idempotency: skip if standings already updated ─────────────────────
+  if (afterData.standingsUpdated === true) {
+    functions.logger.info(
+      "[onChampionshipMatchVerified] Already processed — skipping",
+      { matchId: params.matchId }
+    );
+    return;
+  }
+
+  // ── 3. Verify status actually changed (avoid processing non-status updates) ─
+  if (beforeData?.status === afterData.status && beforeData?.standingsUpdated === afterData.standingsUpdated) {
+    return;
+  }
+
+  const { championshipId, matchId } = params;
+
+  functions.logger.info("[onChampionshipMatchVerified] Processing match", {
+    championshipId,
+    matchId,
+    status: afterData.status,
+  });
+
+  // ── 4. Validate result data ────────────────────────────────────────────────
+  const result = afterData.result;
+  if (!result?.sets || !result?.winner) {
+    functions.logger.error(
+      "[onChampionshipMatchVerified] Match has no valid result — cannot update standings",
+      { matchId }
+    );
+    return;
+  }
+
+  const matchData: MatchResultData = {
+    teamAId: afterData.teamAId,
+    teamBId: afterData.teamBId,
+    result: {
+      sets: result.sets,
+      winner: result.winner,
+      teamAPoints: result.teamAPoints,
+      teamBPoints: result.teamBPoints,
+    },
+  };
+
+  const db = admin.firestore();
+  const champRef = db.collection("championships").doc(championshipId);
+  const matchRef = champRef.collection("matches").doc(matchId);
+
+  // ── 5. Load all standings and all completed matches (for H2H tiebreaker) ───
+  const [standingsSnap, matchesSnap] = await Promise.all([
+    champRef.collection("standings").get(),
+    champRef
+      .collection("matches")
+      .where("status", "in", ["verified", "admin_decided"])
+      .get(),
+  ]);
+
+  // ── 6. Build current standings map ────────────────────────────────────────
+  const standingsMap = new Map<string, StandingsRow>();
+  for (const doc of standingsSnap.docs) {
+    const d = doc.data();
+    standingsMap.set(doc.id, {
+      teamId: doc.id,
+      teamName: d.teamName ?? "",
+      played: d.played ?? 0,
+      points: d.points ?? 0,
+      wins20: d.wins20 ?? 0,
+      wins21: d.wins21 ?? 0,
+      losses12: d.losses12 ?? 0,
+      losses02: d.losses02 ?? 0,
+      setsWon: d.setsWon ?? 0,
+      setsLost: d.setsLost ?? 0,
+      position: d.position ?? 0,
+    });
+  }
+
+  // ── 7. Compute deltas and apply to teamA / teamB ───────────────────────────
+  const { teamA: deltaA, teamB: deltaB } = computeStandingsDeltas(matchData);
+
+  const rowA = standingsMap.get(matchData.teamAId);
+  const rowB = standingsMap.get(matchData.teamBId);
+
+  if (!rowA || !rowB) {
+    functions.logger.error(
+      "[onChampionshipMatchVerified] Standings rows missing for one or both teams",
+      { teamAId: matchData.teamAId, teamBId: matchData.teamBId }
+    );
+    return;
+  }
+
+  standingsMap.set(matchData.teamAId, applyDelta(rowA, deltaA));
+  standingsMap.set(matchData.teamBId, applyDelta(rowB, deltaB));
+
+  // ── 8. Build head-to-head lookup (includes this match via the updated map) ─
+  // We use completed matches from Firestore (not including current one yet)
+  // plus the current match's result for a fresh lookup.
+  const completedMatches = matchesSnap.docs
+    .filter((d) => d.id !== matchId) // exclude current match to avoid double-count
+    .map((d) => {
+      const md = d.data();
+      return {
+        teamAId: md.teamAId as string,
+        teamBId: md.teamBId as string,
+        winner: md.result?.winner as string | undefined,
+      };
+    })
+    .filter((m) => !!m.winner);
+
+  // Also include the current match being processed
+  completedMatches.push({
+    teamAId: matchData.teamAId,
+    teamBId: matchData.teamBId,
+    winner: matchData.result.winner === "teamA" ? matchData.teamAId : matchData.teamBId,
+  });
+
+  function headToHead(idA: string, idB: string): string | null {
+    const match = completedMatches.find(
+      (m) =>
+        (m.teamAId === idA && m.teamBId === idB) ||
+        (m.teamAId === idB && m.teamBId === idA)
+    );
+    return match?.winner ?? null;
+  }
+
+  // ── 9. Recalculate positions ───────────────────────────────────────────────
+  const updatedStandings = recalculatePositions(
+    Array.from(standingsMap.values()),
+    headToHead
+  );
+
+  // ── 10. Batch write all standings + set standingsUpdated flag ──────────────
+  const batch = db.batch();
+
+  for (const row of updatedStandings) {
+    const ref = champRef.collection("standings").doc(row.teamId);
+    batch.set(ref, {
+      teamName: row.teamName,
+      played: row.played,
+      points: row.points,
+      wins20: row.wins20,
+      wins21: row.wins21,
+      losses12: row.losses12,
+      losses02: row.losses02,
+      setsWon: row.setsWon,
+      setsLost: row.setsLost,
+      position: row.position,
+    });
+  }
+
+  batch.update(matchRef, { standingsUpdated: true });
+
+  try {
+    await batch.commit();
+    functions.logger.info(
+      "[onChampionshipMatchVerified] Standings updated successfully",
+      { championshipId, matchId, teamsUpdated: updatedStandings.length }
+    );
+  } catch (err) {
+    functions.logger.error(
+      "[onChampionshipMatchVerified] Batch write failed",
+      { err, championshipId, matchId }
+    );
+    throw err;
+  }
+}
+
+// ============================================================================
+// Cloud Function export
+// ============================================================================
+
+export const onChampionshipMatchVerified = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 60, memory: "256MB" })
+  .firestore.document("championships/{championshipId}/matches/{matchId}")
+  .onUpdate(async (change, context) => {
+    return onChampionshipMatchVerifiedHandler(
+      change.before,
+      change.after,
+      {
+        championshipId: context.params.championshipId,
+        matchId: context.params.matchId,
+      }
+    );
+  });

--- a/functions/src/standingsCalculation.ts
+++ b/functions/src/standingsCalculation.ts
@@ -1,0 +1,160 @@
+// Pure standings calculation helpers for championship standings recalculation (Story 30.8).
+// Exported separately so they can be unit-tested without Firebase.
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SetScore {
+  teamAPoints: number;
+  teamBPoints: number;
+}
+
+export interface MatchResultData {
+  teamAId: string;
+  teamBId: string;
+  result: {
+    sets: SetScore[];
+    /** 'teamA' or 'teamB' — the team that won 2 sets */
+    winner: "teamA" | "teamB";
+    /** Championship points earned by teamA (0, 1, 2 or 3) */
+    teamAPoints: number;
+    /** Championship points earned by teamB (0, 1, 2 or 3) */
+    teamBPoints: number;
+  };
+}
+
+export interface StandingsDelta {
+  played: number;
+  points: number;
+  wins20: number;
+  wins21: number;
+  losses12: number;
+  losses02: number;
+  setsWon: number;
+  setsLost: number;
+}
+
+export interface StandingsRow {
+  teamId: string;
+  teamName: string;
+  played: number;
+  points: number;
+  wins20: number;
+  wins21: number;
+  losses12: number;
+  losses02: number;
+  setsWon: number;
+  setsLost: number;
+  position: number;
+}
+
+// ============================================================================
+// Standings delta computation
+// ============================================================================
+
+/**
+ * Computes the standings delta (increments) for both teams from a single
+ * verified match result.
+ *
+ * Win/loss buckets:
+ *   wins20  — won 2-0 (3 pts for winner)
+ *   wins21  — won 2-1 (2 pts for winner)
+ *   losses12 — lost 1-2 (1 pt for loser)
+ *   losses02 — lost 0-2 (0 pts for loser)
+ */
+export function computeStandingsDeltas(match: MatchResultData): {
+  teamA: StandingsDelta;
+  teamB: StandingsDelta;
+} {
+  const { sets, winner, teamAPoints, teamBPoints } = match.result;
+
+  const teamASetsWon = sets.filter((s) => s.teamAPoints > s.teamBPoints).length;
+  const teamBSetsWon = sets.filter((s) => s.teamBPoints > s.teamAPoints).length;
+
+  // Classify win/loss bucket
+  // 2-0: winner earns 3 pts (straight sets), loser earns 0
+  // 2-1: winner earns 2 pts (deciding set), loser earns 1
+  const teamAWins = winner === "teamA";
+  const isStraightSets = sets.length === 2;
+
+  const teamADelta: StandingsDelta = {
+    played: 1,
+    points: teamAPoints,
+    wins20: teamAWins && isStraightSets ? 1 : 0,
+    wins21: teamAWins && !isStraightSets ? 1 : 0,
+    losses12: !teamAWins && !isStraightSets ? 1 : 0,
+    losses02: !teamAWins && isStraightSets ? 1 : 0,
+    setsWon: teamASetsWon,
+    setsLost: teamBSetsWon,
+  };
+
+  const teamBDelta: StandingsDelta = {
+    played: 1,
+    points: teamBPoints,
+    wins20: !teamAWins && isStraightSets ? 1 : 0,
+    wins21: !teamAWins && !isStraightSets ? 1 : 0,
+    losses12: teamAWins && !isStraightSets ? 1 : 0,
+    losses02: teamAWins && isStraightSets ? 1 : 0,
+    setsWon: teamBSetsWon,
+    setsLost: teamASetsWon,
+  };
+
+  return { teamA: teamADelta, teamB: teamBDelta };
+}
+
+// ============================================================================
+// Delta application
+// ============================================================================
+
+/** Returns a new StandingsRow with the delta added to the existing values. */
+export function applyDelta(row: StandingsRow, delta: StandingsDelta): StandingsRow {
+  return {
+    ...row,
+    played: row.played + delta.played,
+    points: row.points + delta.points,
+    wins20: row.wins20 + delta.wins20,
+    wins21: row.wins21 + delta.wins21,
+    losses12: row.losses12 + delta.losses12,
+    losses02: row.losses02 + delta.losses02,
+    setsWon: row.setsWon + delta.setsWon,
+    setsLost: row.setsLost + delta.setsLost,
+  };
+}
+
+// ============================================================================
+// Position recalculation
+// ============================================================================
+
+/**
+ * Recalculates `position` for all teams based on:
+ *   1. `points` descending
+ *   2. Head-to-head winner (for teams tied on points)
+ *   3. Set ratio (`setsWon - setsLost`) descending as final tiebreaker
+ *
+ * @param standings  Current standings rows (positions will be overwritten).
+ * @param headToHead Function returning the winning teamId for a pair of teams,
+ *                   or null if no completed match exists between them.
+ * @returns New array of standings rows with updated `position` (1-indexed).
+ */
+export function recalculatePositions(
+  standings: StandingsRow[],
+  headToHead: (teamAId: string, teamBId: string) => string | null
+): StandingsRow[] {
+  const sorted = [...standings].sort((a, b) => {
+    // 1. Points descending
+    if (b.points !== a.points) return b.points - a.points;
+
+    // 2. Head-to-head
+    const h2hWinner = headToHead(a.teamId, b.teamId);
+    if (h2hWinner === a.teamId) return -1; // a ranks higher
+    if (h2hWinner === b.teamId) return 1;  // b ranks higher
+
+    // 3. Set ratio descending
+    const ratioA = a.setsWon - a.setsLost;
+    const ratioB = b.setsWon - b.setsLost;
+    return ratioB - ratioA;
+  });
+
+  return sorted.map((row, index) => ({ ...row, position: index + 1 }));
+}

--- a/functions/test/unit/onChampionshipMatchVerified.test.ts
+++ b/functions/test/unit/onChampionshipMatchVerified.test.ts
@@ -1,0 +1,326 @@
+// Unit tests for onChampionshipMatchVerified Firestore trigger (Story 30.8).
+import { onChampionshipMatchVerifiedHandler } from "../../src/onChampionshipMatchVerified";
+
+// ── Mock firebase-functions ───────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  };
+  fn.region = jest.fn(() => fn);
+  fn.runWith = jest.fn(() => fn);
+  fn.firestore = {
+    document: jest.fn(() => ({
+      onUpdate: jest.fn(),
+    })),
+  };
+  return fn;
+});
+
+// ── Mock firebase-admin ───────────────────────────────────────────────────────
+
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockBatch = {
+  set: mockBatchSet,
+  update: mockBatchUpdate,
+  commit: mockBatchCommit,
+};
+
+const mockStandingsGet = jest.fn();
+const mockMatchesWhereGet = jest.fn();
+const mockMatchesWhere = jest.fn(() => ({ get: mockMatchesWhereGet }));
+
+// We need per-doc refs for standings and matches
+const mockStandingsDocRefs: Record<string, any> = {};
+const mockMatchDocRef = { update: jest.fn() };
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn((col: string) => {
+          if (col === "championships") {
+            return {
+              doc: jest.fn(() => ({
+                collection: jest.fn((subCol: string) => {
+                  if (subCol === "standings") {
+                    return {
+                      get: mockStandingsGet,
+                      doc: jest.fn((id: string) => {
+                        if (!mockStandingsDocRefs[id]) {
+                          mockStandingsDocRefs[id] = { id, set: jest.fn() };
+                        }
+                        return mockStandingsDocRefs[id];
+                      }),
+                    };
+                  }
+                  if (subCol === "matches") {
+                    return {
+                      where: mockMatchesWhere,
+                      doc: jest.fn(() => mockMatchDocRef),
+                    };
+                  }
+                  return {};
+                }),
+              })),
+            };
+          }
+          return {};
+        }),
+        batch: jest.fn(() => mockBatch),
+      })),
+      actual.firestore
+    ),
+    initializeApp: jest.fn(),
+  };
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSnapshot(data: Record<string, any> | null): any {
+  return {
+    data: () => data,
+    exists: data !== null,
+  };
+}
+
+function standingsDoc(
+  id: string,
+  overrides: Record<string, any> = {}
+): { id: string; data: () => Record<string, any> } {
+  return {
+    id,
+    data: () => ({
+      teamName: `Team ${id}`,
+      played: 0,
+      points: 0,
+      wins20: 0,
+      wins21: 0,
+      losses12: 0,
+      losses02: 0,
+      setsWon: 0,
+      setsLost: 0,
+      position: 0,
+      ...overrides,
+    }),
+  };
+}
+
+const defaultMatchData = {
+  teamAId: "team-a",
+  teamBId: "team-b",
+  status: "verified",
+  standingsUpdated: false,
+  result: {
+    sets: [
+      { teamAPoints: 21, teamBPoints: 15 },
+      { teamAPoints: 21, teamBPoints: 18 },
+    ],
+    winner: "teamA",
+    teamAPoints: 3,
+    teamBPoints: 0,
+  },
+};
+
+const defaultParams = { championshipId: "champ-1", matchId: "match-1" };
+
+function setupDefaultMocks(): void {
+  mockStandingsGet.mockResolvedValue({
+    docs: [standingsDoc("team-a"), standingsDoc("team-b")],
+  });
+  mockMatchesWhereGet.mockResolvedValue({ docs: [] });
+  mockBatchCommit.mockResolvedValue(undefined);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("onChampionshipMatchVerifiedHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Early return guards ────────────────────────────────────────────────────
+
+  test("returns early if status is not verified or admin_decided", async () => {
+    const before = makeSnapshot({ ...defaultMatchData, status: "played" });
+    const after = makeSnapshot({ ...defaultMatchData, status: "played" });
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockStandingsGet).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test("returns early if after data is null", async () => {
+    const before = makeSnapshot(defaultMatchData);
+    const after = makeSnapshot(null);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockStandingsGet).not.toHaveBeenCalled();
+  });
+
+  test("returns early if standingsUpdated is already true (idempotency)", async () => {
+    const before = makeSnapshot({ ...defaultMatchData, standingsUpdated: true });
+    const after = makeSnapshot({ ...defaultMatchData, standingsUpdated: true });
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockStandingsGet).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test("returns early if match result is missing", async () => {
+    const before = makeSnapshot({ ...defaultMatchData, result: undefined, status: "played" });
+    const after = makeSnapshot({ ...defaultMatchData, result: undefined });
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test("returns early if match result.winner is missing", async () => {
+    const noWinner = { ...defaultMatchData, result: { ...defaultMatchData.result, winner: undefined } };
+    const before = makeSnapshot({ ...noWinner, status: "played" });
+    const after = makeSnapshot(noWinner);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  // ── Happy path: 2-0 win ────────────────────────────────────────────────────
+
+  test("updates standings for a 2-0 win and marks standingsUpdated=true", async () => {
+    setupDefaultMocks();
+    const before = makeSnapshot({ ...defaultMatchData, status: "played" });
+    const after = makeSnapshot(defaultMatchData);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      { standingsUpdated: true }
+    );
+
+    // batch.set called for each standings row (2 teams)
+    expect(mockBatchSet).toHaveBeenCalledTimes(2);
+
+    // Verify teamA standings: 3 pts, wins20
+    const teamASetCall = mockBatchSet.mock.calls.find(
+      ([ref]) => ref.id === "team-a"
+    );
+    expect(teamASetCall).toBeDefined();
+    const teamAData = teamASetCall![1];
+    expect(teamAData.points).toBe(3);
+    expect(teamAData.wins20).toBe(1);
+    expect(teamAData.wins21).toBe(0);
+    expect(teamAData.losses02).toBe(0);
+    expect(teamAData.played).toBe(1);
+
+    // Verify teamB standings: 0 pts, losses02
+    const teamBSetCall = mockBatchSet.mock.calls.find(
+      ([ref]) => ref.id === "team-b"
+    );
+    expect(teamBSetCall).toBeDefined();
+    const teamBData = teamBSetCall![1];
+    expect(teamBData.points).toBe(0);
+    expect(teamBData.losses02).toBe(1);
+    expect(teamBData.wins20).toBe(0);
+    expect(teamBData.played).toBe(1);
+  });
+
+  // ── Happy path: 2-1 win ────────────────────────────────────────────────────
+
+  test("updates standings for a 2-1 win: winner gets 2 pts wins21, loser gets 1 pt losses12", async () => {
+    const match2_1 = {
+      ...defaultMatchData,
+      result: {
+        sets: [
+          { teamAPoints: 21, teamBPoints: 15 },
+          { teamAPoints: 14, teamBPoints: 21 },
+          { teamAPoints: 15, teamBPoints: 12 },
+        ],
+        winner: "teamA",
+        teamAPoints: 2,
+        teamBPoints: 1,
+      },
+    };
+
+    mockStandingsGet.mockResolvedValue({
+      docs: [standingsDoc("team-a"), standingsDoc("team-b")],
+    });
+    mockMatchesWhereGet.mockResolvedValue({ docs: [] });
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    const before = makeSnapshot({ ...match2_1, status: "played" });
+    const after = makeSnapshot(match2_1);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+
+    const teamASetCall = mockBatchSet.mock.calls.find(([ref]) => ref.id === "team-a");
+    const teamAData = teamASetCall![1];
+    expect(teamAData.points).toBe(2);
+    expect(teamAData.wins21).toBe(1);
+    expect(teamAData.wins20).toBe(0);
+
+    const teamBSetCall = mockBatchSet.mock.calls.find(([ref]) => ref.id === "team-b");
+    const teamBData = teamBSetCall![1];
+    expect(teamBData.points).toBe(1);
+    expect(teamBData.losses12).toBe(1);
+    expect(teamBData.losses02).toBe(0);
+  });
+
+  // ── admin_decided status ───────────────────────────────────────────────────
+
+  test("also processes admin_decided status", async () => {
+    setupDefaultMocks();
+    const adminDecided = { ...defaultMatchData, status: "admin_decided" };
+    const before = makeSnapshot({ ...adminDecided, status: "disputed" });
+    const after = makeSnapshot(adminDecided);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Missing standings rows ─────────────────────────────────────────────────
+
+  test("returns early without writing if standings rows are missing for a team", async () => {
+    // Only teamA standings exist, teamB is missing
+    mockStandingsGet.mockResolvedValue({ docs: [standingsDoc("team-a")] });
+    mockMatchesWhereGet.mockResolvedValue({ docs: [] });
+
+    const before = makeSnapshot({ ...defaultMatchData, status: "played" });
+    const after = makeSnapshot(defaultMatchData);
+
+    await onChampionshipMatchVerifiedHandler(before, after, defaultParams);
+
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  // ── Batch commit failure ───────────────────────────────────────────────────
+
+  test("re-throws error if batch commit fails", async () => {
+    setupDefaultMocks();
+    mockBatchCommit.mockRejectedValue(new Error("Firestore write error"));
+
+    const before = makeSnapshot({ ...defaultMatchData, status: "played" });
+    const after = makeSnapshot(defaultMatchData);
+
+    await expect(
+      onChampionshipMatchVerifiedHandler(before, after, defaultParams)
+    ).rejects.toThrow("Firestore write error");
+  });
+});

--- a/functions/test/unit/standingsCalculation.test.ts
+++ b/functions/test/unit/standingsCalculation.test.ts
@@ -1,0 +1,271 @@
+// Unit tests for pure standings calculation helpers (Story 30.8).
+import {
+  computeStandingsDeltas,
+  applyDelta,
+  recalculatePositions,
+  StandingsRow,
+  MatchResultData,
+} from "../../src/standingsCalculation";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeRow(
+  teamId: string,
+  overrides: Partial<StandingsRow> = {}
+): StandingsRow {
+  return {
+    teamId,
+    teamName: `Team ${teamId}`,
+    played: 0,
+    points: 0,
+    wins20: 0,
+    wins21: 0,
+    losses12: 0,
+    losses02: 0,
+    setsWon: 0,
+    setsLost: 0,
+    position: 0,
+    ...overrides,
+  };
+}
+
+const sets2_0: MatchResultData["result"]["sets"] = [
+  { teamAPoints: 21, teamBPoints: 15 },
+  { teamAPoints: 21, teamBPoints: 18 },
+];
+
+const sets2_1: MatchResultData["result"]["sets"] = [
+  { teamAPoints: 21, teamBPoints: 15 },
+  { teamAPoints: 18, teamBPoints: 21 },
+  { teamAPoints: 15, teamBPoints: 12 },
+];
+
+const sets0_2: MatchResultData["result"]["sets"] = [
+  { teamAPoints: 15, teamBPoints: 21 },
+  { teamAPoints: 18, teamBPoints: 21 },
+];
+
+// ============================================================================
+// computeStandingsDeltas
+// ============================================================================
+
+describe("computeStandingsDeltas", () => {
+  test("2-0 win by teamA: winner gets 3 pts, wins20; loser gets 0 pts, losses02", () => {
+    const match: MatchResultData = {
+      teamAId: "a",
+      teamBId: "b",
+      result: { sets: sets2_0, winner: "teamA", teamAPoints: 3, teamBPoints: 0 },
+    };
+
+    const { teamA, teamB } = computeStandingsDeltas(match);
+
+    expect(teamA.points).toBe(3);
+    expect(teamA.wins20).toBe(1);
+    expect(teamA.wins21).toBe(0);
+    expect(teamA.losses12).toBe(0);
+    expect(teamA.losses02).toBe(0);
+    expect(teamA.setsWon).toBe(2);
+    expect(teamA.setsLost).toBe(0);
+    expect(teamA.played).toBe(1);
+
+    expect(teamB.points).toBe(0);
+    expect(teamB.wins20).toBe(0);
+    expect(teamB.wins21).toBe(0);
+    expect(teamB.losses12).toBe(0);
+    expect(teamB.losses02).toBe(1);
+    expect(teamB.setsWon).toBe(0);
+    expect(teamB.setsLost).toBe(2);
+    expect(teamB.played).toBe(1);
+  });
+
+  test("2-1 win by teamA: winner gets 2 pts, wins21; loser gets 1 pt, losses12", () => {
+    const match: MatchResultData = {
+      teamAId: "a",
+      teamBId: "b",
+      result: { sets: sets2_1, winner: "teamA", teamAPoints: 2, teamBPoints: 1 },
+    };
+
+    const { teamA, teamB } = computeStandingsDeltas(match);
+
+    expect(teamA.points).toBe(2);
+    expect(teamA.wins20).toBe(0);
+    expect(teamA.wins21).toBe(1);
+    expect(teamA.losses12).toBe(0);
+    expect(teamA.losses02).toBe(0);
+    expect(teamA.setsWon).toBe(2);
+    expect(teamA.setsLost).toBe(1);
+
+    expect(teamB.points).toBe(1);
+    expect(teamB.wins20).toBe(0);
+    expect(teamB.wins21).toBe(0);
+    expect(teamB.losses12).toBe(1);
+    expect(teamB.losses02).toBe(0);
+    expect(teamB.setsWon).toBe(1);
+    expect(teamB.setsLost).toBe(2);
+  });
+
+  test("0-2 loss by teamA (teamB wins 2-0): teamB gets 3 pts, wins20", () => {
+    const match: MatchResultData = {
+      teamAId: "a",
+      teamBId: "b",
+      result: { sets: sets0_2, winner: "teamB", teamAPoints: 0, teamBPoints: 3 },
+    };
+
+    const { teamA, teamB } = computeStandingsDeltas(match);
+
+    expect(teamA.points).toBe(0);
+    expect(teamA.losses02).toBe(1);
+    expect(teamA.wins20).toBe(0);
+    expect(teamA.setsWon).toBe(0);
+    expect(teamA.setsLost).toBe(2);
+
+    expect(teamB.points).toBe(3);
+    expect(teamB.wins20).toBe(1);
+    expect(teamB.losses02).toBe(0);
+    expect(teamB.setsWon).toBe(2);
+    expect(teamB.setsLost).toBe(0);
+  });
+
+  test("1-2 loss by teamA (teamB wins 2-1): teamB gets 2 pts, wins21; teamA gets 1 pt, losses12", () => {
+    const sets1_2: MatchResultData["result"]["sets"] = [
+      { teamAPoints: 21, teamBPoints: 18 },
+      { teamAPoints: 14, teamBPoints: 21 },
+      { teamAPoints: 12, teamBPoints: 15 },
+    ];
+
+    const match: MatchResultData = {
+      teamAId: "a",
+      teamBId: "b",
+      result: { sets: sets1_2, winner: "teamB", teamAPoints: 1, teamBPoints: 2 },
+    };
+
+    const { teamA, teamB } = computeStandingsDeltas(match);
+
+    expect(teamA.points).toBe(1);
+    expect(teamA.losses12).toBe(1);
+    expect(teamA.wins20).toBe(0);
+    expect(teamA.wins21).toBe(0);
+    expect(teamA.losses02).toBe(0);
+
+    expect(teamB.points).toBe(2);
+    expect(teamB.wins21).toBe(1);
+    expect(teamB.wins20).toBe(0);
+    expect(teamB.losses12).toBe(0);
+    expect(teamB.losses02).toBe(0);
+  });
+});
+
+// ============================================================================
+// applyDelta
+// ============================================================================
+
+describe("applyDelta", () => {
+  test("adds delta fields to existing row values", () => {
+    const row = makeRow("a", { played: 2, points: 4, setsWon: 4, setsLost: 1, wins20: 1, wins21: 1 });
+    const delta = {
+      played: 1,
+      points: 3,
+      wins20: 1,
+      wins21: 0,
+      losses12: 0,
+      losses02: 0,
+      setsWon: 2,
+      setsLost: 0,
+    };
+
+    const updated = applyDelta(row, delta);
+
+    expect(updated.played).toBe(3);
+    expect(updated.points).toBe(7);
+    expect(updated.wins20).toBe(2);
+    expect(updated.wins21).toBe(1);
+    expect(updated.setsWon).toBe(6);
+    expect(updated.setsLost).toBe(1);
+    expect(updated.teamId).toBe("a"); // unchanged
+    expect(updated.teamName).toBe("Team a"); // unchanged
+  });
+});
+
+// ============================================================================
+// recalculatePositions
+// ============================================================================
+
+describe("recalculatePositions", () => {
+  const noHeadToHead = (_a: string, _b: string) => null;
+
+  test("sorts teams by points descending", () => {
+    const standings = [
+      makeRow("c", { points: 1 }),
+      makeRow("a", { points: 6 }),
+      makeRow("b", { points: 3 }),
+    ];
+
+    const result = recalculatePositions(standings, noHeadToHead);
+
+    expect(result[0].teamId).toBe("a");
+    expect(result[0].position).toBe(1);
+    expect(result[1].teamId).toBe("b");
+    expect(result[1].position).toBe(2);
+    expect(result[2].teamId).toBe("c");
+    expect(result[2].position).toBe(3);
+  });
+
+  test("uses head-to-head tiebreaker when points are equal", () => {
+    const standings = [
+      makeRow("a", { points: 3 }),
+      makeRow("b", { points: 3 }),
+    ];
+
+    // b beat a in their match
+    const h2h = (idA: string, idB: string): string | null => {
+      if ((idA === "a" && idB === "b") || (idA === "b" && idB === "a")) return "b";
+      return null;
+    };
+
+    const result = recalculatePositions(standings, h2h);
+
+    expect(result[0].teamId).toBe("b");
+    expect(result[0].position).toBe(1);
+    expect(result[1].teamId).toBe("a");
+    expect(result[1].position).toBe(2);
+  });
+
+  test("uses set ratio as final tiebreaker when points equal and no H2H result", () => {
+    const standings = [
+      makeRow("a", { points: 3, setsWon: 4, setsLost: 3 }), // ratio: +1
+      makeRow("b", { points: 3, setsWon: 6, setsLost: 2 }), // ratio: +4
+    ];
+
+    const result = recalculatePositions(standings, noHeadToHead);
+
+    expect(result[0].teamId).toBe("b"); // better set ratio
+    expect(result[1].teamId).toBe("a");
+  });
+
+  test("does not mutate the input array", () => {
+    const standings = [
+      makeRow("a", { points: 1 }),
+      makeRow("b", { points: 3 }),
+    ];
+    const originalFirst = standings[0].teamId;
+
+    recalculatePositions(standings, noHeadToHead);
+
+    expect(standings[0].teamId).toBe(originalFirst);
+  });
+
+  test("assigns position 1 through N for all teams", () => {
+    const standings = [
+      makeRow("a", { points: 6 }),
+      makeRow("b", { points: 3 }),
+      makeRow("c", { points: 0 }),
+    ];
+
+    const result = recalculatePositions(standings, noHeadToHead);
+
+    const positions = result.map((r) => r.position);
+    expect(positions).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Firestore trigger** `onChampionshipMatchVerified`: fires on `championships/{id}/matches/{id}` when `status` changes to `verified` or `admin_decided`
- **Idempotency**: skips processing if `standingsUpdated === true` on the match doc; sets it to `true` atomically in the final batch write
- **Pure functions** (`standingsCalculation.ts`):
  - `computeStandingsDeltas`: computes `played/points/wins20/wins21/losses12/losses02/setsWon/setsLost` increments for both teams from a match result
  - `applyDelta`: returns a new standings row with delta added (immutable)
  - `recalculatePositions`: sorts all teams by points DESC → head-to-head → set ratio DESC, assigns 1-indexed positions
- **Trigger flow**: loads all standings + all previously completed matches → applies deltas → recalculates positions for all teams → single batch write for all standings + `standingsUpdated: true`
- **Points system**: Win 2-0 → 3/0 pts | Win 2-1 → 2/1 pts

## Test plan

- [ ] Win 2-0: winner gets 3 pts + `wins20`, loser gets 0 pts + `losses02`
- [ ] Win 2-1: winner gets 2 pts + `wins21`, loser gets 1 pt + `losses12`
- [ ] Positions correctly ordered after multiple matches
- [ ] Teams tied on points: head-to-head decides position
- [ ] No head-to-head match: set ratio decides position
- [ ] Trigger fired twice does not double-count standings (idempotency guard)
- [ ] Missing standings rows → no write, error logged
- [ ] Batch commit failure → error re-thrown
- [ ] `npm test` passes (723/723)