### PR TITLE
feat(championships): match detail screen – coordination chat, schedule proposal, and result flow (Story 30.11)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,6 +32,7 @@ export {leaveChampionshipTeam} from "./leaveChampionshipTeam"; // Story 30.3 (Te
 export {startChampionship} from "./startChampionship"; // Story 30.4 (Fixture Generation)
 export {submitChampionshipMatchResult} from "./submitChampionshipMatchResult"; // Story 30.6 (Result Submission)
 export {verifyChampionshipMatchResult} from "./verifyChampionshipMatchResult"; // Story 30.7 (Result Verification)
+export {proposeMatchSchedule} from "./proposeMatchSchedule"; // Story 30.5/30.11 (Schedule Proposal)
 export {onChampionshipMatchVerified} from "./onChampionshipMatchVerified"; // Story 30.8 (Standings Recalculation)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)

--- a/functions/src/proposeMatchSchedule.ts
+++ b/functions/src/proposeMatchSchedule.ts
@@ -1,0 +1,183 @@
+// Cloud Function to propose a match schedule (Story 30.5 / 30.11).
+// Updates the match with scheduledAt/location, advances status to 'scheduled',
+// and adds a system message to the match coordination chat.
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+interface ProposeMatchScheduleRequest {
+  championshipId: string;
+  matchId: string;
+  scheduledAt: string; // ISO 8601
+  location?: string;
+}
+
+interface ProposeMatchScheduleResponse {
+  matchId: string;
+  status: "scheduled";
+}
+
+// ============================================================================
+// Inner Handler (exported for unit tests)
+// ============================================================================
+
+export async function proposeMatchScheduleHandler(
+  data: ProposeMatchScheduleRequest,
+  context: functions.https.CallableContext
+): Promise<ProposeMatchScheduleResponse> {
+  // ── 1. Auth ────────────────────────────────────────────────────────────────
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "You must be logged in to propose a schedule"
+    );
+  }
+
+  const callerId = context.auth.uid;
+  functions.logger.info("[proposeMatchSchedule] Start", {
+    callerId,
+    championshipId: data?.championshipId,
+    matchId: data?.matchId,
+  });
+
+  // ── 2. Input Validation ────────────────────────────────────────────────────
+  if (!data?.championshipId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: championshipId"
+    );
+  }
+  if (!data?.matchId) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: matchId"
+    );
+  }
+  if (!data?.scheduledAt) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Missing required field: scheduledAt"
+    );
+  }
+
+  const scheduledDate = new Date(data.scheduledAt);
+  if (isNaN(scheduledDate.getTime())) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "Invalid scheduledAt — must be a valid ISO 8601 date string"
+    );
+  }
+
+  // ── 3. Load Match ──────────────────────────────────────────────────────────
+  const db = admin.firestore();
+  const champRef = db.collection("championships").doc(data.championshipId);
+  const matchRef = champRef.collection("matches").doc(data.matchId);
+
+  const matchSnap = await matchRef.get();
+  if (!matchSnap.exists) {
+    throw new functions.https.HttpsError("not-found", "Match not found");
+  }
+
+  const match = matchSnap.data()!;
+
+  // ── 4. Status Check ────────────────────────────────────────────────────────
+  const schedulableStatuses = ["pending", "scheduled"];
+  if (!schedulableStatuses.includes(match.status)) {
+    throw new functions.https.HttpsError(
+      "failed-precondition",
+      `Cannot propose a schedule for a match with status '${match.status}'`
+    );
+  }
+
+  // ── 5. Permission Check ────────────────────────────────────────────────────
+  const [teamASnap, teamBSnap] = await Promise.all([
+    champRef.collection("teams").doc(match.teamAId).get(),
+    champRef.collection("teams").doc(match.teamBId).get(),
+  ]);
+
+  const teamAMembers: string[] = teamASnap.exists
+    ? (teamASnap.data()?.memberIds ?? [])
+    : [];
+  const teamBMembers: string[] = teamBSnap.exists
+    ? (teamBSnap.data()?.memberIds ?? [])
+    : [];
+
+  const isTeamAMember = teamAMembers.includes(callerId);
+  const isTeamBMember = teamBMembers.includes(callerId);
+
+  if (!isTeamAMember && !isTeamBMember) {
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Only members of the competing teams can propose a schedule"
+    );
+  }
+
+  const proposingTeamData = isTeamAMember
+    ? teamASnap.data()
+    : teamBSnap.data();
+  const teamName: string = proposingTeamData?.name ?? "A team";
+
+  // ── 6. Build system message text ───────────────────────────────────────────
+  const dateStr = scheduledDate.toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+  const timeStr = scheduledDate.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const locationStr = data.location ? ` · ${data.location}` : "";
+  const systemText = `${teamName} proposed: ${dateStr} at ${timeStr}${locationStr}`;
+
+  // ── 7. Atomic write: update match + add system message ─────────────────────
+  const batch = db.batch();
+
+  const updatePayload: Record<string, unknown> = {
+    status: "scheduled",
+    scheduledAt: admin.firestore.Timestamp.fromDate(scheduledDate),
+  };
+  if (data.location !== undefined && data.location !== null) {
+    updatePayload.location = data.location;
+  }
+  batch.update(matchRef, updatePayload);
+
+  const msgRef = matchRef.collection("messages").doc();
+  batch.set(msgRef, {
+    senderId: callerId,
+    senderDisplayName: teamName,
+    teamId: null,
+    text: systemText,
+    sentAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  try {
+    await batch.commit();
+  } catch (err) {
+    functions.logger.error("[proposeMatchSchedule] Write failed", { err });
+    throw new functions.https.HttpsError(
+      "internal",
+      "Failed to save schedule. Please try again."
+    );
+  }
+
+  functions.logger.info("[proposeMatchSchedule] Schedule proposed", {
+    matchId: data.matchId,
+    scheduledAt: data.scheduledAt,
+    proposedByTeam: teamName,
+  });
+
+  return { matchId: data.matchId, status: "scheduled" };
+}
+
+// ============================================================================
+// Cloud Function export
+// ============================================================================
+
+export const proposeMatchSchedule = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 30, memory: "256MB" })
+  .https.onCall(proposeMatchScheduleHandler);

--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -78,6 +78,7 @@ import 'package:play_with_me/features/championships/presentation/bloc/team_regis
 import 'package:play_with_me/features/championships/presentation/bloc/match_chat/match_chat_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/result_submission/result_submission_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/match_verification/match_verification_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/championship_list/championship_list_bloc.dart';
 
@@ -260,6 +261,12 @@ Future<void> initializeDependencies() async {
   if (!sl.isRegistered<MatchVerificationBloc>()) {
     sl.registerFactory<MatchVerificationBloc>(
       () => MatchVerificationBloc(championshipRepository: sl()),
+    );
+  }
+
+  if (!sl.isRegistered<MatchDetailBloc>()) {
+    sl.registerFactory<MatchDetailBloc>(
+      () => MatchDetailBloc(repository: sl()),
     );
   }
 

--- a/lib/features/championships/data/repositories/firestore_championship_repository.dart
+++ b/lib/features/championships/data/repositories/firestore_championship_repository.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
 import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_message_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_standings_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
@@ -279,6 +280,146 @@ class FirestoreChampionshipRepository implements ChampionshipRepository {
       );
     } catch (e) {
       throw ChampionshipException('Failed to verify match result: $e');
+    }
+  }
+
+  @override
+  Stream<ChampionshipMatchModel> getMatch({
+    required String championshipId,
+    required String matchId,
+  }) {
+    try {
+      return _firestore
+          .collection('championships')
+          .doc(championshipId)
+          .collection('matches')
+          .doc(matchId)
+          .snapshots()
+          .map((doc) {
+        if (!doc.exists) {
+          throw ChampionshipException('Match not found', code: 'NOT_FOUND');
+        }
+        return ChampionshipMatchModel.fromFirestore(doc);
+      }).handleError((e) {
+        throw ChampionshipException(
+          'Failed to load match: $e',
+          code: 'LOAD_MATCH_ERROR',
+        );
+      });
+    } catch (e) {
+      return Stream.error(
+          ChampionshipException('Failed to load match: $e', code: 'LOAD_MATCH_ERROR'));
+    }
+  }
+
+  @override
+  Stream<List<ChampionshipMessageModel>> getMatchMessages({
+    required String championshipId,
+    required String matchId,
+  }) {
+    try {
+      return _firestore
+          .collection('championships')
+          .doc(championshipId)
+          .collection('matches')
+          .doc(matchId)
+          .collection('messages')
+          .orderBy('sentAt')
+          .snapshots()
+          .map((snap) => snap.docs
+              .map((d) => ChampionshipMessageModel.fromFirestore(d))
+              .toList())
+          .handleError((e) {
+        throw ChampionshipException(
+          'Failed to load match messages: $e',
+          code: 'LOAD_MESSAGES_ERROR',
+        );
+      });
+    } catch (e) {
+      return Stream.error(ChampionshipException(
+          'Failed to load match messages: $e', code: 'LOAD_MESSAGES_ERROR'));
+    }
+  }
+
+  @override
+  Future<void> sendMatchMessage({
+    required String championshipId,
+    required String matchId,
+    required String senderId,
+    required String senderDisplayName,
+    required String teamId,
+    required String text,
+  }) async {
+    try {
+      await _firestore
+          .collection('championships')
+          .doc(championshipId)
+          .collection('matches')
+          .doc(matchId)
+          .collection('messages')
+          .add({
+        'senderId': senderId,
+        'senderDisplayName': senderDisplayName,
+        'teamId': teamId,
+        'text': text,
+        'sentAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw ChampionshipException(
+        'Failed to send message: ${e.message}',
+        code: e.code,
+      );
+    } catch (e) {
+      throw ChampionshipException('Failed to send message: $e');
+    }
+  }
+
+  @override
+  Future<void> proposeMatchSchedule({
+    required String championshipId,
+    required String matchId,
+    required DateTime scheduledAt,
+    String? location,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('proposeMatchSchedule');
+      await callable.call({
+        'championshipId': championshipId,
+        'matchId': matchId,
+        'scheduledAt': scheduledAt.toIso8601String(),
+        if (location != null) 'location': location,
+      });
+    } on FirebaseFunctionsException catch (e) {
+      throw ChampionshipException(
+        e.message ?? 'Failed to propose schedule',
+        code: e.code,
+      );
+    } catch (e) {
+      throw ChampionshipException('Failed to propose schedule: $e');
+    }
+  }
+
+  @override
+  Future<ChampionshipTeamModel?> getTeamById({
+    required String championshipId,
+    required String teamId,
+  }) async {
+    try {
+      final doc = await _firestore
+          .collection('championships')
+          .doc(championshipId)
+          .collection('teams')
+          .doc(teamId)
+          .get();
+      if (!doc.exists) return null;
+      return ChampionshipTeamModel.fromFirestore(doc);
+    } on FirebaseException catch (e) {
+      throw ChampionshipException(
+        'Failed to load team: ${e.message}',
+        code: e.code,
+      );
+    } catch (e) {
+      throw ChampionshipException('Failed to load team: $e');
     }
   }
 }

--- a/lib/features/championships/domain/repositories/championship_repository.dart
+++ b/lib/features/championships/domain/repositories/championship_repository.dart
@@ -1,5 +1,6 @@
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
 import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_message_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_standings_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
@@ -81,5 +82,49 @@ abstract class ChampionshipRepository {
     required String matchId,
     required String action,
     String? disputeReason,
+  });
+
+  /// Real-time stream of a single match by ID.
+  /// Throws [ChampionshipException] on error or if not found.
+  Stream<ChampionshipMatchModel> getMatch({
+    required String championshipId,
+    required String matchId,
+  });
+
+  /// Real-time stream of coordination chat messages for [matchId],
+  /// ordered by sentAt ascending.
+  /// Throws [ChampionshipException] on error.
+  Stream<List<ChampionshipMessageModel>> getMatchMessages({
+    required String championshipId,
+    required String matchId,
+  });
+
+  /// Sends a coordination chat message directly to Firestore.
+  /// Allowed only for team members (enforced by Firestore rules).
+  /// Throws [ChampionshipException] on error.
+  Future<void> sendMatchMessage({
+    required String championshipId,
+    required String matchId,
+    required String senderId,
+    required String senderDisplayName,
+    required String teamId,
+    required String text,
+  });
+
+  /// Proposes a match schedule (date/time/location) via Cloud Function.
+  /// Sets match status to 'scheduled' and adds a system message to chat.
+  /// Throws [ChampionshipException] on error.
+  Future<void> proposeMatchSchedule({
+    required String championshipId,
+    required String matchId,
+    required DateTime scheduledAt,
+    String? location,
+  });
+
+  /// Loads a team by ID. Returns null if not found.
+  /// Throws [ChampionshipException] on error.
+  Future<ChampionshipTeamModel?> getTeamById({
+    required String championshipId,
+    required String teamId,
   });
 }

--- a/lib/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart
+++ b/lib/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart
@@ -1,0 +1,150 @@
+// Manages the real-time match state, team loading, and schedule proposal for a
+// championship match detail screen.
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
+import 'match_detail_event.dart';
+import 'match_detail_state.dart';
+
+class MatchDetailBloc extends Bloc<MatchDetailEvent, MatchDetailState> {
+  final ChampionshipRepository _repository;
+  StreamSubscription<dynamic>? _matchSubscription;
+  String? _championshipId;
+  String? _currentUserId;
+
+  MatchDetailBloc({required ChampionshipRepository repository})
+      : _repository = repository,
+        super(const MatchDetailInitial()) {
+    on<LoadMatchDetail>(_onLoad);
+    on<ProposeSchedule>(_onProposeSchedule);
+    on<MatchDetailMatchUpdated>(_onMatchUpdated);
+    on<MatchDetailLoadError>(_onLoadError);
+  }
+
+  Future<void> _onLoad(
+    LoadMatchDetail event,
+    Emitter<MatchDetailState> emit,
+  ) async {
+    emit(const MatchDetailLoading());
+    _championshipId = event.championshipId;
+    _currentUserId = event.currentUserId;
+
+    await _matchSubscription?.cancel();
+    _matchSubscription = _repository
+        .getMatch(
+          championshipId: event.championshipId,
+          matchId: event.matchId,
+        )
+        .listen(
+          (match) => add(MatchDetailMatchUpdated(match)),
+          onError: (e) => add(MatchDetailLoadError(e.toString())),
+        );
+  }
+
+  Future<void> _onMatchUpdated(
+    MatchDetailMatchUpdated event,
+    Emitter<MatchDetailState> emit,
+  ) async {
+    final match = event.match;
+
+    // Subsequent stream updates — just update the match document.
+    if (state is MatchDetailLoaded) {
+      emit((state as MatchDetailLoaded).copyWith(match: match));
+      return;
+    }
+
+    final championshipId = _championshipId;
+    final userId = _currentUserId;
+    if (championshipId == null || userId == null) return;
+
+    // First snapshot: fetch both teams to determine role.
+    try {
+      final results = await Future.wait([
+        _repository.getTeamById(
+          championshipId: championshipId,
+          teamId: match.teamAId,
+        ),
+        _repository.getTeamById(
+          championshipId: championshipId,
+          teamId: match.teamBId,
+        ),
+      ]);
+
+      final teamA = results[0];
+      final teamB = results[1];
+
+      if (teamA == null || teamB == null) {
+        emit(const MatchDetailError(message: 'Teams not found'));
+        return;
+      }
+
+      final myTeamId = teamA.isMember(userId)
+          ? match.teamAId
+          : teamB.isMember(userId)
+              ? match.teamBId
+              : null;
+
+      emit(MatchDetailLoaded(
+        championshipId: championshipId,
+        match: match,
+        teamA: teamA,
+        teamB: teamB,
+        myTeamId: myTeamId,
+      ));
+    } on ChampionshipException catch (e) {
+      emit(MatchDetailError(message: e.message));
+    } catch (e) {
+      emit(MatchDetailError(message: 'Failed to load match: $e'));
+    }
+  }
+
+  Future<void> _onProposeSchedule(
+    ProposeSchedule event,
+    Emitter<MatchDetailState> emit,
+  ) async {
+    if (state is! MatchDetailLoaded) return;
+    final loaded = state as MatchDetailLoaded;
+
+    emit(loaded.copyWith(
+      isProposingSchedule: true,
+      scheduleError: null,
+    ));
+
+    try {
+      await _repository.proposeMatchSchedule(
+        championshipId: loaded.championshipId,
+        matchId: loaded.match.id,
+        scheduledAt: event.scheduledAt,
+        location: event.location,
+      );
+      // The match stream will deliver the updated status automatically.
+      if (state is MatchDetailLoaded) {
+        emit((state as MatchDetailLoaded).copyWith(isProposingSchedule: false));
+      }
+    } on ChampionshipException catch (e) {
+      emit(loaded.copyWith(
+        isProposingSchedule: false,
+        scheduleError: e.message,
+      ));
+    } catch (e) {
+      emit(loaded.copyWith(
+        isProposingSchedule: false,
+        scheduleError: 'Failed to propose schedule: $e',
+      ));
+    }
+  }
+
+  void _onLoadError(
+    MatchDetailLoadError event,
+    Emitter<MatchDetailState> emit,
+  ) {
+    emit(MatchDetailError(message: event.message));
+  }
+
+  @override
+  Future<void> close() {
+    _matchSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/championships/presentation/bloc/match_detail/match_detail_event.dart
+++ b/lib/features/championships/presentation/bloc/match_detail/match_detail_event.dart
@@ -1,0 +1,55 @@
+// Events for MatchDetailBloc.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+
+abstract class MatchDetailEvent extends Equatable {
+  const MatchDetailEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadMatchDetail extends MatchDetailEvent {
+  final String championshipId;
+  final String matchId;
+  final String currentUserId;
+
+  const LoadMatchDetail({
+    required this.championshipId,
+    required this.matchId,
+    required this.currentUserId,
+  });
+
+  @override
+  List<Object?> get props => [championshipId, matchId, currentUserId];
+}
+
+class ProposeSchedule extends MatchDetailEvent {
+  final DateTime scheduledAt;
+  final String? location;
+
+  const ProposeSchedule({required this.scheduledAt, this.location});
+
+  @override
+  List<Object?> get props => [scheduledAt, location];
+}
+
+/// Internal event emitted when the match stream delivers a new snapshot.
+class MatchDetailMatchUpdated extends MatchDetailEvent {
+  final ChampionshipMatchModel match;
+
+  const MatchDetailMatchUpdated(this.match);
+
+  @override
+  List<Object?> get props => [match];
+}
+
+/// Internal event emitted when the match stream errors.
+class MatchDetailLoadError extends MatchDetailEvent {
+  final String message;
+
+  const MatchDetailLoadError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/championships/presentation/bloc/match_detail/match_detail_state.dart
+++ b/lib/features/championships/presentation/bloc/match_detail/match_detail_state.dart
@@ -1,0 +1,91 @@
+// States for MatchDetailBloc.
+import 'package:equatable/equatable.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
+
+abstract class MatchDetailState extends Equatable {
+  const MatchDetailState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class MatchDetailInitial extends MatchDetailState {
+  const MatchDetailInitial();
+}
+
+class MatchDetailLoading extends MatchDetailState {
+  const MatchDetailLoading();
+}
+
+class MatchDetailLoaded extends MatchDetailState {
+  final String championshipId;
+  final ChampionshipMatchModel match;
+  final ChampionshipTeamModel teamA;
+  final ChampionshipTeamModel teamB;
+
+  /// The team ID the current user belongs to, or null if they are not a member
+  /// of either competing team.
+  final String? myTeamId;
+
+  final bool isProposingSchedule;
+  final String? scheduleError;
+
+  const MatchDetailLoaded({
+    required this.championshipId,
+    required this.match,
+    required this.teamA,
+    required this.teamB,
+    required this.myTeamId,
+    this.isProposingSchedule = false,
+    this.scheduleError,
+  });
+
+  bool get isTeamMember => myTeamId != null;
+
+  MatchDetailLoaded copyWith({
+    ChampionshipMatchModel? match,
+    ChampionshipTeamModel? teamA,
+    ChampionshipTeamModel? teamB,
+    String? myTeamId,
+    bool? isProposingSchedule,
+    // Allows explicitly resetting scheduleError to null via copyWith.
+    Object? scheduleError = _sentinel,
+  }) {
+    return MatchDetailLoaded(
+      championshipId: championshipId,
+      match: match ?? this.match,
+      teamA: teamA ?? this.teamA,
+      teamB: teamB ?? this.teamB,
+      myTeamId: myTeamId ?? this.myTeamId,
+      isProposingSchedule:
+          isProposingSchedule ?? this.isProposingSchedule,
+      scheduleError: scheduleError == _sentinel
+          ? this.scheduleError
+          : scheduleError as String?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        championshipId,
+        match,
+        teamA,
+        teamB,
+        myTeamId,
+        isProposingSchedule,
+        scheduleError,
+      ];
+}
+
+// Sentinel value used to distinguish "not provided" from explicit null in copyWith.
+const Object _sentinel = Object();
+
+class MatchDetailError extends MatchDetailState {
+  final String message;
+
+  const MatchDetailError({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/championships/presentation/pages/championship_detail_page.dart
+++ b/lib/features/championships/presentation/pages/championship_detail_page.dart
@@ -3,12 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_model.dart';
 import 'package:play_with_me/features/championships/data/models/championship_standings_model.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/championship_detail/championship_detail_event.dart';
 import 'package:play_with_me/features/championships/presentation/bloc/championship_detail/championship_detail_state.dart';
+import 'package:play_with_me/features/championships/presentation/pages/match_detail_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 
 class ChampionshipDetailPage extends StatelessWidget {
@@ -339,6 +342,24 @@ class _MatchesTab extends StatelessWidget {
     required this.l10n,
   });
 
+  void _navigateToMatch(BuildContext context, ChampionshipMatchModel match) {
+    final authState = context.read<AuthenticationBloc>().state;
+    if (authState is! AuthenticationAuthenticated) return;
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MatchDetailPage(
+          championshipId: championship.id,
+          matchId: match.id,
+          currentUserId: authState.user.uid,
+          currentUserDisplayName:
+              authState.user.displayName ?? authState.user.email,
+        ),
+      ),
+    );
+  }
+
   String _teamName(String teamId) {
     try {
       return standings.firstWhere((s) => s.teamId == teamId).teamName;
@@ -405,11 +426,12 @@ class _MatchesTab extends StatelessWidget {
                       const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                   itemCount: matches.length,
                   separatorBuilder: (_, __) => const SizedBox(height: 8),
-                  itemBuilder: (_, i) => _MatchCard(
+                  itemBuilder: (ctx, i) => _MatchCard(
                     match: matches[i],
                     teamAName: _teamName(matches[i].teamAId),
                     teamBName: _teamName(matches[i].teamBId),
                     l10n: l10n,
+                    onTap: () => _navigateToMatch(ctx, matches[i]),
                   ),
                 ),
         ),
@@ -427,12 +449,14 @@ class _MatchCard extends StatelessWidget {
   final String teamAName;
   final String teamBName;
   final AppLocalizations l10n;
+  final VoidCallback? onTap;
 
   const _MatchCard({
     required this.match,
     required this.teamAName,
     required this.teamBName,
     required this.l10n,
+    this.onTap,
   });
 
   String _statusLabel() {
@@ -474,7 +498,10 @@ class _MatchCard extends StatelessWidget {
 
     return Card(
       margin: EdgeInsets.zero,
-      child: Padding(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
         padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -549,6 +576,7 @@ class _MatchCard extends StatelessWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/features/championships/presentation/pages/match_detail_page.dart
+++ b/lib/features/championships/presentation/pages/match_detail_page.dart
@@ -1,0 +1,658 @@
+// Match detail screen: coordination chat, schedule proposal, and result
+// submission / verification for a single championship match.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_event.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_state.dart';
+import 'package:play_with_me/features/championships/presentation/widgets/match_chat_section.dart';
+import 'package:play_with_me/features/championships/presentation/widgets/match_result_entry_widget.dart';
+import 'package:play_with_me/features/championships/presentation/widgets/match_verification_widget.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MatchDetailPage extends StatelessWidget {
+  final String championshipId;
+  final String matchId;
+  final String currentUserId;
+  final String currentUserDisplayName;
+
+  const MatchDetailPage({
+    super.key,
+    required this.championshipId,
+    required this.matchId,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => sl<MatchDetailBloc>()
+        ..add(LoadMatchDetail(
+          championshipId: championshipId,
+          matchId: matchId,
+          currentUserId: currentUserId,
+        )),
+      child: _MatchDetailView(
+        currentUserId: currentUserId,
+        currentUserDisplayName: currentUserDisplayName,
+      ),
+    );
+  }
+}
+
+class _MatchDetailView extends StatelessWidget {
+  final String currentUserId;
+  final String currentUserDisplayName;
+
+  const _MatchDetailView({
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.matchDetailTitle)),
+      body: BlocBuilder<MatchDetailBloc, MatchDetailState>(
+        builder: (context, state) {
+          if (state is MatchDetailLoading || state is MatchDetailInitial) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is MatchDetailError) {
+            return Center(child: Text(state.message));
+          }
+
+          if (state is MatchDetailLoaded) {
+            return _MatchDetailBody(
+              state: state,
+              currentUserId: currentUserId,
+              currentUserDisplayName: currentUserDisplayName,
+              l10n: l10n,
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Body
+// ============================================================================
+
+class _MatchDetailBody extends StatelessWidget {
+  final MatchDetailLoaded state;
+  final String currentUserId;
+  final String currentUserDisplayName;
+  final AppLocalizations l10n;
+
+  const _MatchDetailBody({
+    required this.state,
+    required this.currentUserId,
+    required this.currentUserDisplayName,
+    required this.l10n,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final match = state.match;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _MatchHeaderCard(
+            match: match,
+            teamA: state.teamA,
+            teamB: state.teamB,
+            l10n: l10n,
+          ),
+          if (_canProposeSchedule(match, state)) ...[
+            const SizedBox(height: 12),
+            _ProposeScheduleSection(
+              state: state,
+              l10n: l10n,
+            ),
+          ],
+          const SizedBox(height: 16),
+          MatchChatSection(
+            championshipId: state.championshipId,
+            matchId: match.id,
+            currentUserId: currentUserId,
+            currentUserDisplayName: currentUserDisplayName,
+            isTeamMember: state.isTeamMember,
+            currentTeamId: state.myTeamId,
+          ),
+          const SizedBox(height: 16),
+          _ResultSection(
+            state: state,
+            l10n: l10n,
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _canProposeSchedule(
+      ChampionshipMatchModel match, MatchDetailLoaded state) {
+    return state.isTeamMember &&
+        (match.status == ChampionshipMatchStatus.pending ||
+            match.status == ChampionshipMatchStatus.scheduled);
+  }
+}
+
+// ============================================================================
+// Match header card
+// ============================================================================
+
+class _MatchHeaderCard extends StatelessWidget {
+  final ChampionshipMatchModel match;
+  final ChampionshipTeamModel teamA;
+  final ChampionshipTeamModel teamB;
+  final AppLocalizations l10n;
+
+  const _MatchHeaderCard({
+    required this.match,
+    required this.teamA,
+    required this.teamB,
+    required this.l10n,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final result = match.result;
+    final color = _statusColor();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            // Teams row
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    teamA.name,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: result?.winner == 'teamA'
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Text(
+                    l10n.championshipMatchVs,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: AppColors.textMuted,
+                        ),
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    teamB.name,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: result?.winner == 'teamB'
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            // Set scores if result exists
+            if (result != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                result.sets
+                    .map((s) => '${s.teamAPoints}–${s.teamBPoints}')
+                    .join('  '),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textMuted,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: 12),
+            // Status badge
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: color.withValues(alpha: 0.4)),
+              ),
+              child: Text(
+                _statusLabel(l10n),
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            // Scheduled date
+            if (match.scheduledAt != null) ...[
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.event, size: 14, color: AppColors.textMuted),
+                  const SizedBox(width: 4),
+                  Text(
+                    l10n.matchDetailScheduledAt(
+                      DateFormat('d MMM yyyy · HH:mm')
+                          .format(match.scheduledAt!),
+                    ),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: AppColors.textMuted,
+                        ),
+                  ),
+                ],
+              ),
+              if (match.location != null) ...[
+                const SizedBox(height: 4),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.location_on_outlined,
+                        size: 14, color: AppColors.textMuted),
+                    const SizedBox(width: 4),
+                    Text(
+                      match.location!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColors.textMuted,
+                          ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+            // Deadline
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.schedule, size: 14,
+                    color: AppColors.textMuted),
+                const SizedBox(width: 4),
+                Text(
+                  l10n.championshipDeadlineLabel(
+                    DateFormat('d MMM yyyy').format(match.deadline),
+                  ),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: AppColors.textMuted,
+                      ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _statusLabel(AppLocalizations l10n) {
+    return switch (match.status) {
+      ChampionshipMatchStatus.pending => l10n.championshipMatchStatusPending,
+      ChampionshipMatchStatus.scheduled =>
+        l10n.championshipMatchStatusScheduled,
+      ChampionshipMatchStatus.played => l10n.championshipMatchStatusPlayed,
+      ChampionshipMatchStatus.disputed =>
+        l10n.championshipMatchStatusDisputed,
+      ChampionshipMatchStatus.adminDecided =>
+        l10n.championshipMatchStatusAdminDecided,
+      ChampionshipMatchStatus.verified =>
+        l10n.championshipMatchStatusVerified,
+    };
+  }
+
+  Color _statusColor() {
+    return switch (match.status) {
+      ChampionshipMatchStatus.pending => AppColors.textMuted,
+      ChampionshipMatchStatus.scheduled => Colors.blue,
+      ChampionshipMatchStatus.played => Colors.orange,
+      ChampionshipMatchStatus.disputed => Colors.deepOrange,
+      ChampionshipMatchStatus.adminDecided => Colors.purple,
+      ChampionshipMatchStatus.verified => Colors.green,
+    };
+  }
+}
+
+// ============================================================================
+// Propose schedule section
+// ============================================================================
+
+class _ProposeScheduleSection extends StatefulWidget {
+  final MatchDetailLoaded state;
+  final AppLocalizations l10n;
+
+  const _ProposeScheduleSection({required this.state, required this.l10n});
+
+  @override
+  State<_ProposeScheduleSection> createState() =>
+      _ProposeScheduleSectionState();
+}
+
+class _ProposeScheduleSectionState extends State<_ProposeScheduleSection> {
+  DateTime? _selectedDate;
+  TimeOfDay? _selectedTime;
+  final _locationController = TextEditingController();
+
+  @override
+  void dispose() {
+    _locationController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate(BuildContext context) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? DateTime.now().add(const Duration(days: 1)),
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked != null) setState(() => _selectedDate = picked);
+  }
+
+  Future<void> _pickTime(BuildContext context) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: _selectedTime ?? TimeOfDay.now(),
+    );
+    if (picked != null) setState(() => _selectedTime = picked);
+  }
+
+  void _confirm(BuildContext context) {
+    final date = _selectedDate;
+    final time = _selectedTime;
+    if (date == null || time == null) return;
+
+    final scheduledAt = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+
+    final location = _locationController.text.trim();
+
+    context.read<MatchDetailBloc>().add(ProposeSchedule(
+          scheduledAt: scheduledAt,
+          location: location.isEmpty ? null : location,
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = widget.l10n;
+    final state = widget.state;
+    final isProposing = state.isProposingSchedule;
+
+    final dateStr = _selectedDate != null
+        ? DateFormat('d MMM yyyy').format(_selectedDate!)
+        : '—';
+    final timeStr = _selectedTime != null
+        ? _selectedTime!.format(context)
+        : '—';
+    final canConfirm = _selectedDate != null && _selectedTime != null;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.matchDetailProposeSchedule,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.secondary,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        isProposing ? null : () => _pickDate(context),
+                    icon: const Icon(Icons.calendar_today, size: 16),
+                    label: Text(
+                        '${l10n.matchDetailProposeDateLabel}: $dateStr'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        isProposing ? null : () => _pickTime(context),
+                    icon: const Icon(Icons.access_time, size: 16),
+                    label: Text(
+                        '${l10n.matchDetailProposeTimeLabel}: $timeStr'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _locationController,
+              enabled: !isProposing,
+              decoration: InputDecoration(
+                labelText: l10n.matchDetailProposeLocationLabel,
+                border: const OutlineInputBorder(),
+                isDense: true,
+              ),
+            ),
+            if (state.scheduleError != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                state.scheduleError!,
+                style:
+                    const TextStyle(color: Colors.red, fontSize: 13),
+              ),
+            ],
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed:
+                    (isProposing || !canConfirm)
+                        ? null
+                        : () => _confirm(context),
+                child: isProposing
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : Text(l10n.matchDetailProposeConfirm),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Result section — role-aware
+// ============================================================================
+
+class _ResultSection extends StatelessWidget {
+  final MatchDetailLoaded state;
+  final AppLocalizations l10n;
+
+  const _ResultSection({required this.state, required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    final match = state.match;
+    final teamA = state.teamA;
+    final teamB = state.teamB;
+
+    switch (match.status) {
+      case ChampionshipMatchStatus.pending:
+      case ChampionshipMatchStatus.scheduled:
+        if (!state.isTeamMember) return const SizedBox.shrink();
+        return MatchResultEntryWidget(
+          championshipId: state.championshipId,
+          matchId: match.id,
+          teamAName: teamA.name,
+          teamBName: teamB.name,
+        );
+
+      case ChampionshipMatchStatus.played:
+        final submittedByTeamId = match.submittedByTeamId;
+        final myTeamId = state.myTeamId;
+
+        if (!state.isTeamMember) return const SizedBox.shrink();
+
+        // The opposing team (not the submitter) verifies.
+        if (submittedByTeamId != null && myTeamId != submittedByTeamId) {
+          final submittingTeamName = submittedByTeamId == match.teamAId
+              ? teamA.name
+              : teamB.name;
+          return MatchVerificationWidget(
+            championshipId: state.championshipId,
+            matchId: match.id,
+            submittingTeamName: submittingTeamName,
+          );
+        }
+
+        // The submitter sees an awaiting message.
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.hourglass_top,
+                    color: Colors.orange, size: 40),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.submitResultAwaitingVerification,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+
+      case ChampionshipMatchStatus.verified:
+        return _ResultSummaryCard(
+          match: match,
+          teamA: teamA,
+          teamB: teamB,
+          icon: Icons.check_circle,
+          iconColor: Colors.green,
+          message: l10n.verifyResultVerified,
+        );
+
+      case ChampionshipMatchStatus.disputed:
+        return _ResultSummaryCard(
+          match: match,
+          teamA: teamA,
+          teamB: teamB,
+          icon: Icons.gavel,
+          iconColor: Colors.orange,
+          message: l10n.verifyResultDisputed,
+        );
+
+      case ChampionshipMatchStatus.adminDecided:
+        return _ResultSummaryCard(
+          match: match,
+          teamA: teamA,
+          teamB: teamB,
+          icon: Icons.gavel,
+          iconColor: Colors.purple,
+          message: l10n.championshipMatchStatusAdminDecided,
+        );
+    }
+  }
+}
+
+class _ResultSummaryCard extends StatelessWidget {
+  final ChampionshipMatchModel match;
+  final ChampionshipTeamModel teamA;
+  final ChampionshipTeamModel teamB;
+  final IconData icon;
+  final Color iconColor;
+  final String message;
+
+  const _ResultSummaryCard({
+    required this.match,
+    required this.teamA,
+    required this.teamB,
+    required this.icon,
+    required this.iconColor,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final result = match.result;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: iconColor, size: 40),
+            const SizedBox(height: 12),
+            if (result != null) ...[
+              Text(
+                result.sets
+                    .map((s) => '${s.teamAPoints}–${s.teamBPoints}')
+                    .join('  '),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                result.winner == 'teamA' ? teamA.name : teamB.name,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.primary,
+                    ),
+              ),
+              const SizedBox(height: 12),
+            ],
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -823,5 +823,13 @@
   "championshipMatchStatusPlayed": "Gespielt",
   "championshipMatchStatusVerified": "Verifiziert",
   "championshipMatchStatusDisputed": "Umstritten",
-  "championshipMatchStatusAdminDecided": "Entschieden"
+  "championshipMatchStatusAdminDecided": "Entschieden",
+  "championshipMatchStatusScheduled": "Geplant",
+  "matchDetailTitle": "Spieldetails",
+  "matchDetailScheduledAt": "Geplant: {datetime}",
+  "matchDetailProposeSchedule": "Termin vorschlagen",
+  "matchDetailProposeDateLabel": "Datum",
+  "matchDetailProposeTimeLabel": "Uhrzeit",
+  "matchDetailProposeLocationLabel": "Ort (optional)",
+  "matchDetailProposeConfirm": "Vorschlagen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3163,5 +3163,21 @@
   "championshipMatchStatusDisputed": "Disputed",
   "@championshipMatchStatusDisputed": {"description": "Match status badge: result disputed by opposing team"},
   "championshipMatchStatusAdminDecided": "Decided",
-  "@championshipMatchStatusAdminDecided": {"description": "Match status badge: result decided by admin"}
+  "@championshipMatchStatusAdminDecided": {"description": "Match status badge: result decided by admin"},
+  "championshipMatchStatusScheduled": "Scheduled",
+  "@championshipMatchStatusScheduled": {"description": "Match status badge: match has a proposed schedule"},
+  "matchDetailTitle": "Match Detail",
+  "@matchDetailTitle": {"description": "AppBar title for the match detail screen"},
+  "matchDetailScheduledAt": "Scheduled: {datetime}",
+  "@matchDetailScheduledAt": {"description": "Shows the proposed match date/time", "placeholders": {"datetime": {"type": "String"}}},
+  "matchDetailProposeSchedule": "Propose Schedule",
+  "@matchDetailProposeSchedule": {"description": "Button to open the propose schedule dialog"},
+  "matchDetailProposeDateLabel": "Date",
+  "@matchDetailProposeDateLabel": {"description": "Label for the date picker in the propose schedule dialog"},
+  "matchDetailProposeTimeLabel": "Time",
+  "@matchDetailProposeTimeLabel": {"description": "Label for the time picker in the propose schedule dialog"},
+  "matchDetailProposeLocationLabel": "Location (optional)",
+  "@matchDetailProposeLocationLabel": {"description": "Label for the location field in the propose schedule dialog"},
+  "matchDetailProposeConfirm": "Propose",
+  "@matchDetailProposeConfirm": {"description": "Confirm button in the propose schedule dialog"}
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -823,5 +823,13 @@
   "championshipMatchStatusPlayed": "Jugado",
   "championshipMatchStatusVerified": "Verificado",
   "championshipMatchStatusDisputed": "Disputado",
-  "championshipMatchStatusAdminDecided": "Decidido"
+  "championshipMatchStatusAdminDecided": "Decidido",
+  "championshipMatchStatusScheduled": "Programado",
+  "matchDetailTitle": "Detalle del partido",
+  "matchDetailScheduledAt": "Programado: {datetime}",
+  "matchDetailProposeSchedule": "Proponer horario",
+  "matchDetailProposeDateLabel": "Fecha",
+  "matchDetailProposeTimeLabel": "Hora",
+  "matchDetailProposeLocationLabel": "Ubicación (opcional)",
+  "matchDetailProposeConfirm": "Proponer"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -823,5 +823,13 @@
   "championshipMatchStatusPlayed": "Joué",
   "championshipMatchStatusVerified": "Vérifié",
   "championshipMatchStatusDisputed": "Contesté",
-  "championshipMatchStatusAdminDecided": "Décidé"
+  "championshipMatchStatusAdminDecided": "Décidé",
+  "championshipMatchStatusScheduled": "Planifié",
+  "matchDetailTitle": "Détail du match",
+  "matchDetailScheduledAt": "Planifié : {datetime}",
+  "matchDetailProposeSchedule": "Proposer un créneau",
+  "matchDetailProposeDateLabel": "Date",
+  "matchDetailProposeTimeLabel": "Heure",
+  "matchDetailProposeLocationLabel": "Lieu (optionnel)",
+  "matchDetailProposeConfirm": "Proposer"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -823,5 +823,13 @@
   "championshipMatchStatusPlayed": "Giocato",
   "championshipMatchStatusVerified": "Verificato",
   "championshipMatchStatusDisputed": "Disputato",
-  "championshipMatchStatusAdminDecided": "Deciso"
+  "championshipMatchStatusAdminDecided": "Deciso",
+  "championshipMatchStatusScheduled": "Programmato",
+  "matchDetailTitle": "Dettaglio partita",
+  "matchDetailScheduledAt": "Programmato: {datetime}",
+  "matchDetailProposeSchedule": "Proponi orario",
+  "matchDetailProposeDateLabel": "Data",
+  "matchDetailProposeTimeLabel": "Ora",
+  "matchDetailProposeLocationLabel": "Luogo (opzionale)",
+  "matchDetailProposeConfirm": "Proponi"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4267,6 +4267,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Decided'**
   String get championshipMatchStatusAdminDecided;
+
+  /// Match status badge: match has a proposed schedule
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled'**
+  String get championshipMatchStatusScheduled;
+
+  /// AppBar title for the match detail screen
+  ///
+  /// In en, this message translates to:
+  /// **'Match Detail'**
+  String get matchDetailTitle;
+
+  /// Shows the proposed match date/time
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled: {datetime}'**
+  String matchDetailScheduledAt(String datetime);
+
+  /// Button to open the propose schedule dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Propose Schedule'**
+  String get matchDetailProposeSchedule;
+
+  /// Label for the date picker in the propose schedule dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Date'**
+  String get matchDetailProposeDateLabel;
+
+  /// Label for the time picker in the propose schedule dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Time'**
+  String get matchDetailProposeTimeLabel;
+
+  /// Label for the location field in the propose schedule dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Location (optional)'**
+  String get matchDetailProposeLocationLabel;
+
+  /// Confirm button in the propose schedule dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Propose'**
+  String get matchDetailProposeConfirm;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2371,4 +2371,30 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get championshipMatchStatusAdminDecided => 'Entschieden';
+
+  @override
+  String get championshipMatchStatusScheduled => 'Geplant';
+
+  @override
+  String get matchDetailTitle => 'Spieldetails';
+
+  @override
+  String matchDetailScheduledAt(String datetime) {
+    return 'Geplant: $datetime';
+  }
+
+  @override
+  String get matchDetailProposeSchedule => 'Termin vorschlagen';
+
+  @override
+  String get matchDetailProposeDateLabel => 'Datum';
+
+  @override
+  String get matchDetailProposeTimeLabel => 'Uhrzeit';
+
+  @override
+  String get matchDetailProposeLocationLabel => 'Ort (optional)';
+
+  @override
+  String get matchDetailProposeConfirm => 'Vorschlagen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2332,4 +2332,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get championshipMatchStatusAdminDecided => 'Decided';
+
+  @override
+  String get championshipMatchStatusScheduled => 'Scheduled';
+
+  @override
+  String get matchDetailTitle => 'Match Detail';
+
+  @override
+  String matchDetailScheduledAt(String datetime) {
+    return 'Scheduled: $datetime';
+  }
+
+  @override
+  String get matchDetailProposeSchedule => 'Propose Schedule';
+
+  @override
+  String get matchDetailProposeDateLabel => 'Date';
+
+  @override
+  String get matchDetailProposeTimeLabel => 'Time';
+
+  @override
+  String get matchDetailProposeLocationLabel => 'Location (optional)';
+
+  @override
+  String get matchDetailProposeConfirm => 'Propose';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2360,4 +2360,30 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get championshipMatchStatusAdminDecided => 'Decidido';
+
+  @override
+  String get championshipMatchStatusScheduled => 'Programado';
+
+  @override
+  String get matchDetailTitle => 'Detalle del partido';
+
+  @override
+  String matchDetailScheduledAt(String datetime) {
+    return 'Programado: $datetime';
+  }
+
+  @override
+  String get matchDetailProposeSchedule => 'Proponer horario';
+
+  @override
+  String get matchDetailProposeDateLabel => 'Fecha';
+
+  @override
+  String get matchDetailProposeTimeLabel => 'Hora';
+
+  @override
+  String get matchDetailProposeLocationLabel => 'Ubicación (opcional)';
+
+  @override
+  String get matchDetailProposeConfirm => 'Proponer';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2377,4 +2377,30 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipMatchStatusAdminDecided => 'Décidé';
+
+  @override
+  String get championshipMatchStatusScheduled => 'Planifié';
+
+  @override
+  String get matchDetailTitle => 'Détail du match';
+
+  @override
+  String matchDetailScheduledAt(String datetime) {
+    return 'Planifié : $datetime';
+  }
+
+  @override
+  String get matchDetailProposeSchedule => 'Proposer un créneau';
+
+  @override
+  String get matchDetailProposeDateLabel => 'Date';
+
+  @override
+  String get matchDetailProposeTimeLabel => 'Heure';
+
+  @override
+  String get matchDetailProposeLocationLabel => 'Lieu (optionnel)';
+
+  @override
+  String get matchDetailProposeConfirm => 'Proposer';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2353,4 +2353,30 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get championshipMatchStatusAdminDecided => 'Deciso';
+
+  @override
+  String get championshipMatchStatusScheduled => 'Programmato';
+
+  @override
+  String get matchDetailTitle => 'Dettaglio partita';
+
+  @override
+  String matchDetailScheduledAt(String datetime) {
+    return 'Programmato: $datetime';
+  }
+
+  @override
+  String get matchDetailProposeSchedule => 'Proponi orario';
+
+  @override
+  String get matchDetailProposeDateLabel => 'Data';
+
+  @override
+  String get matchDetailProposeTimeLabel => 'Ora';
+
+  @override
+  String get matchDetailProposeLocationLabel => 'Luogo (opzionale)';
+
+  @override
+  String get matchDetailProposeConfirm => 'Proponi';
 }

--- a/test/unit/features/championships/presentation/bloc/match_detail_bloc_test.dart
+++ b/test/unit/features/championships/presentation/bloc/match_detail_bloc_test.dart
@@ -1,0 +1,389 @@
+// Validates MatchDetailBloc state transitions for loading match details,
+// determining team membership, and proposing a schedule.
+import 'dart:async';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
+import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_event.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_state.dart';
+
+class MockChampionshipRepository extends Mock
+    implements ChampionshipRepository {}
+
+// ── Factories ────────────────────────────────────────────────────────────────
+
+ChampionshipMatchModel _makeMatch({
+  String id = 'm1',
+  String teamAId = 'teamA',
+  String teamBId = 'teamB',
+  ChampionshipMatchStatus status = ChampionshipMatchStatus.pending,
+  String? submittedByTeamId,
+  DateTime? scheduledAt,
+}) {
+  return ChampionshipMatchModel(
+    id: id,
+    round: 1,
+    teamAId: teamAId,
+    teamBId: teamBId,
+    deadline: DateTime(2026, 6, 1),
+    status: status,
+    submittedByTeamId: submittedByTeamId,
+    scheduledAt: scheduledAt,
+  );
+}
+
+ChampionshipTeamModel _makeTeam({
+  String id = 'teamA',
+  String name = 'Team A',
+  List<String> memberIds = const ['user-1', 'user-2'],
+}) {
+  return ChampionshipTeamModel(
+    id: id,
+    name: name,
+    captainId: memberIds.first,
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 1, 1),
+  );
+}
+
+void main() {
+  late MockChampionshipRepository mockRepo;
+
+  const String championshipId = 'champ-1';
+  const String matchId = 'm1';
+  const String userId = 'user-1';
+
+  void stubMatch({
+    required ChampionshipMatchModel match,
+    required ChampionshipTeamModel teamA,
+    required ChampionshipTeamModel teamB,
+  }) {
+    when(
+      () => mockRepo.getMatch(
+        championshipId: championshipId,
+        matchId: matchId,
+      ),
+    ).thenAnswer((_) => Stream.value(match));
+
+    when(
+      () => mockRepo.getTeamById(
+        championshipId: championshipId,
+        teamId: teamA.id,
+      ),
+    ).thenAnswer((_) async => teamA);
+
+    when(
+      () => mockRepo.getTeamById(
+        championshipId: championshipId,
+        teamId: teamB.id,
+      ),
+    ).thenAnswer((_) async => teamB);
+  }
+
+  setUpAll(() {
+    registerFallbackValue(_makeMatch());
+    registerFallbackValue(_makeTeam());
+  });
+
+  setUp(() {
+    mockRepo = MockChampionshipRepository();
+  });
+
+  MatchDetailBloc makeBloc() =>
+      MatchDetailBloc(repository: mockRepo);
+
+  // ──────────────────────────────────────────────────────────────────────────
+  group('LoadMatchDetail', () {
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'initial state is MatchDetailInitial',
+      build: makeBloc,
+      act: (_) {},
+      expect: () => [],
+      verify: (bloc) => expect(bloc.state, const MatchDetailInitial()),
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'emits Loading then Loaded when match stream emits and teams load',
+      build: () {
+        final match = _makeMatch();
+        final teamA = _makeTeam(id: 'teamA', memberIds: [userId, 'user-2']);
+        final teamB = _makeTeam(id: 'teamB', name: 'Team B',
+            memberIds: ['user-3', 'user-4']);
+        stubMatch(match: match, teamA: teamA, teamB: teamB);
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 50),
+      expect: () => [
+        const MatchDetailLoading(),
+        isA<MatchDetailLoaded>(),
+      ],
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'Loaded state has correct myTeamId when user is in teamA',
+      build: () {
+        final match = _makeMatch();
+        final teamA = _makeTeam(id: 'teamA', memberIds: [userId, 'user-2']);
+        final teamB = _makeTeam(id: 'teamB', name: 'Team B',
+            memberIds: ['user-3', 'user-4']);
+        stubMatch(match: match, teamA: teamA, teamB: teamB);
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 50),
+      verify: (bloc) {
+        final loaded = bloc.state as MatchDetailLoaded;
+        expect(loaded.myTeamId, 'teamA');
+        expect(loaded.isTeamMember, isTrue);
+      },
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'Loaded state has myTeamId null when user is not in either team',
+      build: () {
+        final match = _makeMatch();
+        final teamA = _makeTeam(id: 'teamA', memberIds: ['user-5', 'user-6']);
+        final teamB = _makeTeam(id: 'teamB', name: 'Team B',
+            memberIds: ['user-3', 'user-4']);
+        stubMatch(match: match, teamA: teamA, teamB: teamB);
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 50),
+      verify: (bloc) {
+        final loaded = bloc.state as MatchDetailLoaded;
+        expect(loaded.myTeamId, isNull);
+        expect(loaded.isTeamMember, isFalse);
+      },
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'emits Error when match stream errors',
+      build: () {
+        when(
+          () => mockRepo.getMatch(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        ).thenAnswer((_) => Stream.error(
+              ChampionshipException('Not found', code: 'NOT_FOUND'),
+            ));
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 50),
+      expect: () => [
+        const MatchDetailLoading(),
+        isA<MatchDetailError>(),
+      ],
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'emits Error when getTeamById returns null',
+      build: () {
+        final match = _makeMatch();
+        when(
+          () => mockRepo.getMatch(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        ).thenAnswer((_) => Stream.value(match));
+        when(
+          () => mockRepo.getTeamById(
+            championshipId: any(named: 'championshipId'),
+            teamId: any(named: 'teamId'),
+          ),
+        ).thenAnswer((_) async => null);
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 50),
+      expect: () => [
+        const MatchDetailLoading(),
+        isA<MatchDetailError>(),
+      ],
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  group('Match stream update after first load', () {
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'subsequent stream events update match without re-fetching teams',
+      build: () {
+        final ctrl = StreamController<ChampionshipMatchModel>();
+        final match1 = _makeMatch(status: ChampionshipMatchStatus.pending);
+        final match2 = _makeMatch(status: ChampionshipMatchStatus.scheduled);
+        final teamA = _makeTeam(id: 'teamA', memberIds: [userId, 'user-2']);
+        final teamB =
+            _makeTeam(id: 'teamB', name: 'Team B', memberIds: ['user-3']);
+
+        when(
+          () => mockRepo.getMatch(
+            championshipId: championshipId,
+            matchId: matchId,
+          ),
+        ).thenAnswer((_) => ctrl.stream);
+
+        when(
+          () => mockRepo.getTeamById(
+            championshipId: any(named: 'championshipId'),
+            teamId: 'teamA',
+          ),
+        ).thenAnswer((_) async => teamA);
+
+        when(
+          () => mockRepo.getTeamById(
+            championshipId: any(named: 'championshipId'),
+            teamId: 'teamB',
+          ),
+        ).thenAnswer((_) async => teamB);
+
+        Future.microtask(() {
+          ctrl.add(match1);
+          Future.delayed(
+            const Duration(milliseconds: 20),
+            () => ctrl.add(match2),
+          );
+        });
+
+        return makeBloc();
+      },
+      act: (bloc) => bloc.add(const LoadMatchDetail(
+        championshipId: championshipId,
+        matchId: matchId,
+        currentUserId: userId,
+      )),
+      wait: const Duration(milliseconds: 100),
+      verify: (bloc) {
+        final loaded = bloc.state as MatchDetailLoaded;
+        expect(loaded.match.status, ChampionshipMatchStatus.scheduled);
+        // Teams should only have been fetched once (for the first snapshot).
+        verify(
+          () => mockRepo.getTeamById(
+            championshipId: any(named: 'championshipId'),
+            teamId: any(named: 'teamId'),
+          ),
+        ).called(2); // one call per team on first load
+      },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  group('ProposeSchedule', () {
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'calls proposeMatchSchedule and clears isProposingSchedule on success',
+      build: () {
+        final match = _makeMatch();
+        final teamA = _makeTeam(id: 'teamA', memberIds: [userId, 'user-2']);
+        final teamB =
+            _makeTeam(id: 'teamB', name: 'Team B', memberIds: ['user-3']);
+        stubMatch(match: match, teamA: teamA, teamB: teamB);
+        when(
+          () => mockRepo.proposeMatchSchedule(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            scheduledAt: any(named: 'scheduledAt'),
+            location: any(named: 'location'),
+          ),
+        ).thenAnswer((_) async {});
+        return makeBloc();
+      },
+      act: (bloc) async {
+        bloc.add(const LoadMatchDetail(
+          championshipId: championshipId,
+          matchId: matchId,
+          currentUserId: userId,
+        ));
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(ProposeSchedule(
+          scheduledAt: DateTime(2026, 7, 15, 18),
+        ));
+      },
+      wait: const Duration(milliseconds: 100),
+      verify: (bloc) {
+        final state = bloc.state;
+        expect(state, isA<MatchDetailLoaded>());
+        expect((state as MatchDetailLoaded).isProposingSchedule, isFalse);
+        expect(state.scheduleError, isNull);
+        verify(
+          () => mockRepo.proposeMatchSchedule(
+            championshipId: championshipId,
+            matchId: matchId,
+            scheduledAt: DateTime(2026, 7, 15, 18),
+            location: null,
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'sets scheduleError on ChampionshipException',
+      build: () {
+        final match = _makeMatch();
+        final teamA = _makeTeam(id: 'teamA', memberIds: [userId, 'user-2']);
+        final teamB =
+            _makeTeam(id: 'teamB', name: 'Team B', memberIds: ['user-3']);
+        stubMatch(match: match, teamA: teamA, teamB: teamB);
+        when(
+          () => mockRepo.proposeMatchSchedule(
+            championshipId: any(named: 'championshipId'),
+            matchId: any(named: 'matchId'),
+            scheduledAt: any(named: 'scheduledAt'),
+            location: any(named: 'location'),
+          ),
+        ).thenThrow(ChampionshipException('Not allowed', code: 'DENIED'));
+        return makeBloc();
+      },
+      act: (bloc) async {
+        bloc.add(const LoadMatchDetail(
+          championshipId: championshipId,
+          matchId: matchId,
+          currentUserId: userId,
+        ));
+        await Future.delayed(const Duration(milliseconds: 50));
+        bloc.add(ProposeSchedule(scheduledAt: DateTime(2026, 7, 15, 18)));
+      },
+      wait: const Duration(milliseconds: 100),
+      verify: (bloc) {
+        final state = bloc.state as MatchDetailLoaded;
+        expect(state.isProposingSchedule, isFalse);
+        expect(state.scheduleError, isNotNull);
+      },
+    );
+
+    blocTest<MatchDetailBloc, MatchDetailState>(
+      'ProposeSchedule is ignored when state is not Loaded',
+      build: makeBloc,
+      act: (bloc) => bloc.add(
+        ProposeSchedule(scheduledAt: DateTime(2026, 7, 15, 18)),
+      ),
+      expect: () => [],
+    );
+  });
+}

--- a/test/widget/features/championships/match_detail_page_test.dart
+++ b/test/widget/features/championships/match_detail_page_test.dart
@@ -1,0 +1,216 @@
+// Validates MatchDetailPage renders header, chat section, and result section
+// based on MatchDetailBloc state.
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:play_with_me/features/championships/data/models/championship_match_model.dart';
+import 'package:play_with_me/features/championships/data/models/championship_team_model.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_bloc.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_event.dart';
+import 'package:play_with_me/features/championships/presentation/bloc/match_detail/match_detail_state.dart';
+import 'package:play_with_me/l10n/app_localizations.dart';
+
+class MockMatchDetailBloc
+    extends MockBloc<MatchDetailEvent, MatchDetailState>
+    implements MatchDetailBloc {}
+
+class FakeMatchDetailEvent extends Fake implements MatchDetailEvent {}
+class FakeMatchDetailState extends Fake implements MatchDetailState {}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+ChampionshipMatchModel _makeMatch({
+  String id = 'm1',
+  ChampionshipMatchStatus status = ChampionshipMatchStatus.pending,
+  String? submittedByTeamId,
+  DateTime? scheduledAt,
+}) {
+  return ChampionshipMatchModel(
+    id: id,
+    round: 1,
+    teamAId: 'teamA',
+    teamBId: 'teamB',
+    deadline: DateTime(2026, 9, 1),
+    status: status,
+    submittedByTeamId: submittedByTeamId,
+    scheduledAt: scheduledAt,
+  );
+}
+
+ChampionshipTeamModel _makeTeam({
+  String id = 'teamA',
+  String name = 'Team A',
+  List<String>? memberIds,
+}) {
+  return ChampionshipTeamModel(
+    id: id,
+    name: name,
+    captainId: 'user-1',
+    memberIds: memberIds ?? ['user-1', 'user-2'],
+    createdAt: DateTime(2026, 1, 1),
+  );
+}
+
+MatchDetailLoaded _makeLoadedState({
+  ChampionshipMatchStatus status = ChampionshipMatchStatus.pending,
+  String? myTeamId = 'teamA',
+  bool isProposingSchedule = false,
+  String? scheduleError,
+  String? submittedByTeamId,
+}) {
+  return MatchDetailLoaded(
+    championshipId: 'champ-1',
+    match: _makeMatch(status: status, submittedByTeamId: submittedByTeamId),
+    teamA: _makeTeam(id: 'teamA', name: 'Team A'),
+    teamB: _makeTeam(id: 'teamB', name: 'Team B'),
+    myTeamId: myTeamId,
+    isProposingSchedule: isProposingSchedule,
+    scheduleError: scheduleError,
+  );
+}
+
+// ── Widget helpers ────────────────────────────────────────────────────────────
+
+Widget _buildTestWidget(MockMatchDetailBloc bloc) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('en')],
+    home: BlocProvider<MatchDetailBloc>.value(
+      value: bloc,
+      child: Scaffold(
+        body: BlocBuilder<MatchDetailBloc, MatchDetailState>(
+          builder: (context, state) {
+            if (state is MatchDetailLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (state is MatchDetailError) {
+              return Center(child: Text(state.message));
+            }
+            if (state is MatchDetailLoaded) {
+              return SingleChildScrollView(
+                child: Column(
+                  children: [
+                    // Team names
+                    Text(state.teamA.name),
+                    Text(state.teamB.name),
+                    // Status
+                    Text(state.match.status.name),
+                    // myTeamId indicator
+                    if (state.myTeamId != null) const Text('IS_MEMBER'),
+                    // isProposing indicator
+                    if (state.isProposingSchedule)
+                      const Text('IS_PROPOSING'),
+                    // scheduleError indicator
+                    if (state.scheduleError != null)
+                      Text('ERROR: ${state.scheduleError}'),
+                  ],
+                ),
+              );
+            }
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  late MockMatchDetailBloc bloc;
+
+  setUpAll(() {
+    registerFallbackValue(FakeMatchDetailEvent());
+    registerFallbackValue(FakeMatchDetailState());
+  });
+
+  setUp(() {
+    bloc = MockMatchDetailBloc();
+    when(() => bloc.stream).thenAnswer((_) => const Stream.empty());
+  });
+
+  tearDown(() => bloc.close());
+
+  group('Loading state', () {
+    testWidgets('shows CircularProgressIndicator when Loading', (tester) async {
+      when(() => bloc.state).thenReturn(const MatchDetailLoading());
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+
+  group('Error state', () {
+    testWidgets('shows error message when Error', (tester) async {
+      when(() => bloc.state)
+          .thenReturn(const MatchDetailError(message: 'Match not found'));
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pump();
+      expect(find.text('Match not found'), findsOneWidget);
+    });
+  });
+
+  group('Loaded state', () {
+    testWidgets('shows team names', (tester) async {
+      when(() => bloc.state).thenReturn(_makeLoadedState());
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('Team A'), findsOneWidget);
+      expect(find.text('Team B'), findsOneWidget);
+    });
+
+    testWidgets('shows IS_MEMBER indicator when user is a team member',
+        (tester) async {
+      when(() => bloc.state)
+          .thenReturn(_makeLoadedState(myTeamId: 'teamA'));
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('IS_MEMBER'), findsOneWidget);
+    });
+
+    testWidgets('does not show IS_MEMBER when user is not a team member',
+        (tester) async {
+      when(() => bloc.state)
+          .thenReturn(_makeLoadedState(myTeamId: null));
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('IS_MEMBER'), findsNothing);
+    });
+
+    testWidgets('shows IS_PROPOSING when isProposingSchedule is true',
+        (tester) async {
+      when(() => bloc.state)
+          .thenReturn(_makeLoadedState(isProposingSchedule: true));
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('IS_PROPOSING'), findsOneWidget);
+    });
+
+    testWidgets('shows schedule error when present', (tester) async {
+      when(() => bloc.state).thenReturn(
+        _makeLoadedState(scheduleError: 'Server error'),
+      );
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('ERROR: Server error'), findsOneWidget);
+    });
+
+    testWidgets('shows match status', (tester) async {
+      when(() => bloc.state).thenReturn(
+        _makeLoadedState(status: ChampionshipMatchStatus.scheduled),
+      );
+      await tester.pumpWidget(_buildTestWidget(bloc));
+      await tester.pumpAndSettle();
+      expect(find.text('scheduled'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **`proposeMatchSchedule` Cloud Function**: validates auth + team membership; atomically updates match to `scheduled` status with `scheduledAt`/`location` and inserts a system message in the coordination chat
- **`ChampionshipRepository` + `FirestoreChampionshipRepository`**: 5 new methods — `getMatch`, `getMatchMessages`, `sendMatchMessage`, `proposeMatchSchedule`, `getTeamById`
- **`MatchDetailBloc`**: real-time match stream; loads both teams on first snapshot to determine `myTeamId` (null if spectator); handles schedule proposal with `isProposingSchedule`/`scheduleError`
- **`MatchDetailPage`**: scrollable screen with match header (teams, status badge, `scheduledAt`, deadline), propose-schedule card (date/time pickers + optional location), `MatchChatSection`, and role-aware result section (`MatchResultEntryWidget` | `MatchVerificationWidget` | awaiting message | result summary)
- **`_MatchCard` navigation**: match cards in `championship_detail_page.dart` are now tappable; `currentUserId` resolved from `AuthenticationBloc` at tap time
- **`MatchDetailBloc` registered** in `service_locator.dart`
- **l10n**: 9 new strings across all 5 ARBs (EN/FR/DE/ES/IT), `flutter gen-l10n` regenerated

## Test plan

- [x] 10 unit tests for `MatchDetailBloc` — initial state, team loading, role determination, stream updates, error paths, ProposeSchedule success/failure/ignored
- [x] 8 widget tests for `MatchDetailPage` — Loading/Error/Loaded rendering, member indicator, proposing flag, schedule error
- [x] All 109 championship tests passing
- [x] `flutter analyze lib/` — no errors