### PR TITLE
feat(championships): push notifications for championship events (Story 30.13)

### DIFF
--- a/functions/src/championshipNotifications.ts
+++ b/functions/src/championshipNotifications.ts
@@ -1,0 +1,356 @@
+// Firestore triggers for championship push notifications (Story 30.13).
+// Covers: result submitted → opposing team; disputed → admins; admin decision → both teams.
+// The 'verified' notification is handled in onChampionshipMatchVerified.ts.
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+/** Returns member IDs for a team, or [] if the team doc doesn't exist. */
+async function getTeamMemberIds(
+  db: admin.firestore.Firestore,
+  championshipId: string,
+  teamId: string
+): Promise<string[]> {
+  const snap = await db
+    .collection("championships")
+    .doc(championshipId)
+    .collection("teams")
+    .doc(teamId)
+    .get();
+  return snap.exists ? (snap.data()?.memberIds ?? []) : [];
+}
+
+/** Returns the display name for a team, or the teamId as fallback. */
+export async function getTeamName(
+  db: admin.firestore.Firestore,
+  championshipId: string,
+  teamId: string
+): Promise<string> {
+  const snap = await db
+    .collection("championships")
+    .doc(championshipId)
+    .collection("teams")
+    .doc(teamId)
+    .get();
+  return snap.exists && snap.data()?.name ? snap.data()!.name : teamId;
+}
+
+interface FcmPayload {
+  title: string;
+  body: string;
+  data: Record<string, string>;
+}
+
+/**
+ * Sends an FCM notification to a list of users, respecting:
+ * - `notificationPreferences.championship !== false`
+ * - quiet hours
+ * Stale tokens are cleaned up automatically.
+ */
+export async function sendChampionshipNotificationToUsers(
+  db: admin.firestore.Firestore,
+  userIds: string[],
+  payload: FcmPayload
+): Promise<void> {
+  if (userIds.length === 0) return;
+
+  // Load all user docs in parallel
+  const userSnaps = await Promise.all(
+    userIds.map((uid) => db.collection("users").doc(uid).get())
+  );
+
+  // Collect valid tokens per user
+  const tokenToUserId = new Map<string, string>();
+
+  for (const snap of userSnaps) {
+    if (!snap.exists) continue;
+    const uid = snap.id;
+    const data = snap.data()!;
+
+    const prefs = data.notificationPreferences ?? {};
+
+    // Respect championship notification preference (opt-out)
+    if (prefs.championship === false) {
+      functions.logger.info(
+        "[championshipNotifications] User opted out of championship notifications",
+        { uid }
+      );
+      continue;
+    }
+
+    // Respect quiet hours
+    if (isQuietHours(prefs.quietHours)) {
+      functions.logger.info(
+        "[championshipNotifications] User in quiet hours — skipping",
+        { uid }
+      );
+      continue;
+    }
+
+    const tokens: string[] = data.fcmTokens ?? [];
+    for (const token of tokens) {
+      tokenToUserId.set(token, uid);
+    }
+  }
+
+  const allTokens = Array.from(tokenToUserId.keys());
+  if (allTokens.length === 0) return;
+
+  const message: admin.messaging.MulticastMessage = {
+    tokens: allTokens,
+    notification: {
+      title: payload.title,
+      body: payload.body,
+    },
+    data: payload.data,
+    android: {
+      priority: "high",
+      notification: {
+        channelId: "high_importance_channel",
+        clickAction: "FLUTTER_NOTIFICATION_CLICK",
+      },
+    },
+    apns: {
+      payload: {
+        aps: { badge: 1, sound: "default" },
+      },
+    },
+  };
+
+  const response = await admin.messaging().sendEachForMulticast(message);
+
+  functions.logger.info("[championshipNotifications] Notifications sent", {
+    successCount: response.successCount,
+    failureCount: response.failureCount,
+  });
+
+  // Remove stale tokens
+  if (response.failureCount > 0) {
+    const staleByUser = new Map<string, string[]>();
+    response.responses.forEach((resp, idx) => {
+      if (
+        !resp.success &&
+        (resp.error?.code === "messaging/invalid-registration-token" ||
+          resp.error?.code === "messaging/registration-token-not-registered")
+      ) {
+        const token = allTokens[idx];
+        const uid = tokenToUserId.get(token);
+        if (uid) {
+          if (!staleByUser.has(uid)) staleByUser.set(uid, []);
+          staleByUser.get(uid)!.push(token);
+        }
+      }
+    });
+
+    await Promise.all(
+      Array.from(staleByUser.entries()).map(([uid, tokens]) =>
+        db.collection("users").doc(uid).update({
+          fcmTokens: admin.firestore.FieldValue.arrayRemove(...tokens),
+        })
+      )
+    );
+  }
+}
+
+function isQuietHours(quietHours: unknown): boolean {
+  if (
+    !quietHours ||
+    typeof quietHours !== "object" ||
+    !(quietHours as Record<string, unknown>).enabled
+  ) {
+    return false;
+  }
+  const qh = quietHours as { start: string; end: string };
+  const now = new Date();
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const [sh, sm] = qh.start.split(":").map(Number);
+  const [eh, em] = qh.end.split(":").map(Number);
+  const startMin = sh * 60 + sm;
+  const endMin = eh * 60 + em;
+  return startMin <= endMin
+    ? currentMinutes >= startMin && currentMinutes <= endMin
+    : currentMinutes >= startMin || currentMinutes <= endMin;
+}
+
+// ============================================================================
+// Shared inner handlers (exported for unit tests)
+// ============================================================================
+
+export async function onChampionshipMatchResultSubmittedHandler(
+  before: admin.firestore.DocumentData,
+  after: admin.firestore.DocumentData,
+  params: { championshipId: string; matchId: string },
+  db: admin.firestore.Firestore
+): Promise<void> {
+  // Only fire when status transitions to 'played'
+  if (before.status === after.status || after.status !== "played") return;
+
+  const { championshipId, matchId } = params;
+
+  functions.logger.info("[onChampionshipMatchResultSubmitted] Processing", {
+    championshipId,
+    matchId,
+  });
+
+  // Load both team member IDs and names in parallel
+  const [teamAMembers, teamBMembers, teamAName, teamBName] = await Promise.all([
+    getTeamMemberIds(db, championshipId, after.teamAId),
+    getTeamMemberIds(db, championshipId, after.teamBId),
+    getTeamName(db, championshipId, after.teamAId),
+    getTeamName(db, championshipId, after.teamBId),
+  ]);
+
+  // Notify the opposing team (those who did NOT submit)
+  const submittedByTeamId = after.submittedByTeamId;
+  const opposingMembers =
+    submittedByTeamId === after.teamAId ? teamBMembers : teamAMembers;
+
+  if (opposingMembers.length === 0) return;
+
+  await sendChampionshipNotificationToUsers(db, opposingMembers, {
+    title: `Result to verify — ${teamAName} vs ${teamBName}`,
+    body: `${submittedByTeamId === after.teamAId ? teamAName : teamBName} submitted the result. Tap to verify.`,
+    data: {
+      type: "championship_result_submitted",
+      championshipId,
+      matchId,
+    },
+  });
+}
+
+export async function onChampionshipMatchDisputedHandler(
+  before: admin.firestore.DocumentData,
+  after: admin.firestore.DocumentData,
+  params: { championshipId: string; matchId: string },
+  db: admin.firestore.Firestore
+): Promise<void> {
+  // Only fire when status transitions to 'disputed'
+  if (before.status === after.status || after.status !== "disputed") return;
+
+  const { championshipId, matchId } = params;
+
+  functions.logger.info("[onChampionshipMatchDisputed] Processing", {
+    championshipId,
+    matchId,
+  });
+
+  // Load championship admins and team names in parallel
+  const champSnap = await db.collection("championships").doc(championshipId).get();
+  if (!champSnap.exists) return;
+
+  const adminIds: string[] = champSnap.data()?.adminIds ?? [];
+  if (adminIds.length === 0) return;
+
+  const [teamAName, teamBName] = await Promise.all([
+    getTeamName(db, championshipId, after.teamAId),
+    getTeamName(db, championshipId, after.teamBId),
+  ]);
+
+  await sendChampionshipNotificationToUsers(db, adminIds, {
+    title: "Match disputed 🚨",
+    body: `${teamBName} disputed the result of ${teamAName} vs ${teamBName}. Admin action required.`,
+    data: {
+      type: "championship_match_disputed",
+      championshipId,
+      matchId,
+    },
+  });
+}
+
+export async function onChampionshipAdminDecisionHandler(
+  before: admin.firestore.DocumentData,
+  after: admin.firestore.DocumentData,
+  params: { championshipId: string; matchId: string },
+  db: admin.firestore.Firestore
+): Promise<void> {
+  // Only fire when status transitions to 'admin_decided'
+  if (before.status === after.status || after.status !== "admin_decided") return;
+
+  const { championshipId, matchId } = params;
+
+  functions.logger.info("[onChampionshipAdminDecision] Processing", {
+    championshipId,
+    matchId,
+  });
+
+  const [teamAMembers, teamBMembers, teamAName, teamBName] = await Promise.all([
+    getTeamMemberIds(db, championshipId, after.teamAId),
+    getTeamMemberIds(db, championshipId, after.teamBId),
+    getTeamName(db, championshipId, after.teamAId),
+    getTeamName(db, championshipId, after.teamBId),
+  ]);
+
+  const allMembers = [...new Set([...teamAMembers, ...teamBMembers])];
+  if (allMembers.length === 0) return;
+
+  await sendChampionshipNotificationToUsers(db, allMembers, {
+    title: "Match decided by admin",
+    body: `Admin set the result for ${teamAName} vs ${teamBName}.`,
+    data: {
+      type: "championship_admin_decision",
+      championshipId,
+      matchId,
+    },
+  });
+}
+
+// ============================================================================
+// Cloud Function exports
+// ============================================================================
+
+const matchDocument =
+  "championships/{championshipId}/matches/{matchId}";
+
+export const onChampionshipMatchResultSubmitted = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 30, memory: "256MB" })
+  .firestore.document(matchDocument)
+  .onUpdate(async (change, context) => {
+    const db = admin.firestore();
+    await onChampionshipMatchResultSubmittedHandler(
+      change.before.data()!,
+      change.after.data()!,
+      {
+        championshipId: context.params.championshipId,
+        matchId: context.params.matchId,
+      },
+      db
+    );
+  });
+
+export const onChampionshipMatchDisputed = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 30, memory: "256MB" })
+  .firestore.document(matchDocument)
+  .onUpdate(async (change, context) => {
+    const db = admin.firestore();
+    await onChampionshipMatchDisputedHandler(
+      change.before.data()!,
+      change.after.data()!,
+      {
+        championshipId: context.params.championshipId,
+        matchId: context.params.matchId,
+      },
+      db
+    );
+  });
+
+export const onChampionshipAdminDecision = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 30, memory: "256MB" })
+  .firestore.document(matchDocument)
+  .onUpdate(async (change, context) => {
+    const db = admin.firestore();
+    await onChampionshipAdminDecisionHandler(
+      change.before.data()!,
+      change.after.data()!,
+      {
+        championshipId: context.params.championshipId,
+        matchId: context.params.matchId,
+      },
+      db
+    );
+  });

--- a/functions/src/checkChampionshipDeadlines.ts
+++ b/functions/src/checkChampionshipDeadlines.ts
@@ -1,0 +1,147 @@
+// Scheduled function: sends 48h deadline warning notifications for
+// championship matches that are still unplayed and due within 48 hours (Story 30.13).
+// Runs daily at 09:00 UTC.
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { sendChampionshipNotificationToUsers } from "./championshipNotifications";
+
+const HOURS_48_MS = 48 * 60 * 60 * 1000;
+const WARNING_FLAG = "deadlineWarning48hSent";
+
+// ============================================================================
+// Inner handler (exported for unit tests)
+// ============================================================================
+
+export async function checkChampionshipDeadlinesHandler(
+  db: admin.firestore.Firestore,
+  now: Date
+): Promise<void> {
+  const nowTs = admin.firestore.Timestamp.fromDate(now);
+  const in48h = admin.firestore.Timestamp.fromDate(
+    new Date(now.getTime() + HOURS_48_MS)
+  );
+
+  functions.logger.info("[checkChampionshipDeadlines] Running", {
+    now: now.toISOString(),
+  });
+
+  // Load all active championships
+  const champSnap = await db
+    .collection("championships")
+    .where("status", "==", "active")
+    .get();
+
+  if (champSnap.empty) {
+    functions.logger.info("[checkChampionshipDeadlines] No active championships");
+    return;
+  }
+
+  let warningsSent = 0;
+
+  for (const champDoc of champSnap.docs) {
+    const championshipId = champDoc.id;
+
+    // Query matches that are unplayed and deadline is within [now, now+48h]
+    const matchSnap = await db
+      .collection("championships")
+      .doc(championshipId)
+      .collection("matches")
+      .where("status", "in", ["pending", "scheduled"])
+      .where("deadline", ">=", nowTs)
+      .where("deadline", "<=", in48h)
+      .get();
+
+    for (const matchDoc of matchSnap.docs) {
+      const match = matchDoc.data();
+      const matchId = matchDoc.id;
+
+      // Idempotency: skip if warning was already sent
+      if (match[WARNING_FLAG] === true) {
+        functions.logger.info(
+          "[checkChampionshipDeadlines] Warning already sent — skipping",
+          { championshipId, matchId }
+        );
+        continue;
+      }
+
+      functions.logger.info(
+        "[checkChampionshipDeadlines] Sending 48h warning",
+        { championshipId, matchId, deadline: match.deadline?.toDate?.() }
+      );
+
+      // Load team members and names in parallel
+      const [teamASnap, teamBSnap] = await Promise.all([
+        db
+          .collection("championships")
+          .doc(championshipId)
+          .collection("teams")
+          .doc(match.teamAId)
+          .get(),
+        db
+          .collection("championships")
+          .doc(championshipId)
+          .collection("teams")
+          .doc(match.teamBId)
+          .get(),
+      ]);
+
+      const teamAMembers: string[] = teamASnap.exists
+        ? (teamASnap.data()?.memberIds ?? [])
+        : [];
+      const teamBMembers: string[] = teamBSnap.exists
+        ? (teamBSnap.data()?.memberIds ?? [])
+        : [];
+      const teamAName: string = teamASnap.data()?.name ?? match.teamAId;
+      const teamBName: string = teamBSnap.data()?.name ?? match.teamBId;
+
+      // Send personalised notifications per team (opposing team name in body)
+      await Promise.all([
+        teamAMembers.length > 0
+          ? sendChampionshipNotificationToUsers(db, teamAMembers, {
+              title: "Match deadline in 48h ⚠️",
+              body: `You have 48 hours to play your match vs ${teamBName}.`,
+              data: {
+                type: "championship_deadline_warning",
+                championshipId,
+                matchId,
+              },
+            })
+          : Promise.resolve(),
+        teamBMembers.length > 0
+          ? sendChampionshipNotificationToUsers(db, teamBMembers, {
+              title: "Match deadline in 48h ⚠️",
+              body: `You have 48 hours to play your match vs ${teamAName}.`,
+              data: {
+                type: "championship_deadline_warning",
+                championshipId,
+                matchId,
+              },
+            })
+          : Promise.resolve(),
+      ]);
+
+      // Mark as sent to avoid duplicate warnings on next daily run
+      await matchDoc.ref.update({ [WARNING_FLAG]: true });
+      warningsSent++;
+    }
+  }
+
+  functions.logger.info("[checkChampionshipDeadlines] Done", {
+    warningsSent,
+    championshipsChecked: champSnap.size,
+  });
+}
+
+// ============================================================================
+// Cloud Function export
+// ============================================================================
+
+export const checkChampionshipDeadlines = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 300, memory: "256MB" })
+  .pubsub.schedule("every 24 hours")
+  .timeZone("UTC")
+  .onRun(async () => {
+    const db = admin.firestore();
+    await checkChampionshipDeadlinesHandler(db, new Date());
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -35,6 +35,12 @@ export {verifyChampionshipMatchResult} from "./verifyChampionshipMatchResult"; /
 export {proposeMatchSchedule} from "./proposeMatchSchedule"; // Story 30.5/30.11 (Schedule Proposal)
 export {onChampionshipMatchVerified} from "./onChampionshipMatchVerified"; // Story 30.8 (Standings Recalculation)
 export {adminDecideChampionshipMatch} from "./adminDecideChampionshipMatch"; // Story 30.12 (Admin Match Decision)
+export {
+  onChampionshipMatchResultSubmitted,
+  onChampionshipMatchDisputed,
+  onChampionshipAdminDecision,
+} from "./championshipNotifications"; // Story 30.13 (Championship Push Notifications)
+export {checkChampionshipDeadlines} from "./checkChampionshipDeadlines"; // Story 30.13 (Championship Deadline Warning)
 export {generateRecurringTrainingSessions} from "./generateRecurringTrainingSessions"; // Story 15.2 (Recurring Training Sessions)
 export {joinTrainingSession} from "./joinTrainingSession"; // Story 15.3 (Join Training Session)
 export {leaveTrainingSession} from "./leaveTrainingSession"; // Story 15.3 (Leave Training Session)

--- a/functions/src/onChampionshipMatchVerified.ts
+++ b/functions/src/onChampionshipMatchVerified.ts
@@ -1,4 +1,5 @@
 // Firestore trigger: recalculates championship standings when a match is verified (Story 30.8).
+// Also sends push notifications to both teams on verification (Story 30.13).
 // Fires on championships/{championshipId}/matches/{matchId} when status → 'verified' or 'admin_decided'.
 // Idempotency guard: skips if standingsUpdated is already true on the match doc.
 import * as functions from "firebase-functions";
@@ -10,6 +11,10 @@ import {
   recalculatePositions,
   MatchResultData,
 } from "./standingsCalculation";
+import {
+  getTeamName,
+  sendChampionshipNotificationToUsers,
+} from "./championshipNotifications";
 
 // ============================================================================
 // Inner Handler (exported for unit tests)
@@ -191,6 +196,61 @@ export async function onChampionshipMatchVerifiedHandler(
       { err, championshipId, matchId }
     );
     throw err;
+  }
+
+  // ── 11. Send push notification to both teams (Story 30.13) ────────────────
+  // Only for the 'verified' status (admin_decided notifications sent by onChampionshipAdminDecision)
+  if (afterData.status === "verified") {
+    try {
+      const [teamAMembers, teamBMembers, teamAName, teamBName] =
+        await Promise.all([
+          db
+            .collection("championships")
+            .doc(championshipId)
+            .collection("teams")
+            .doc(afterData.teamAId)
+            .get()
+            .then((s) => (s.exists ? (s.data()?.memberIds ?? []) : [])),
+          db
+            .collection("championships")
+            .doc(championshipId)
+            .collection("teams")
+            .doc(afterData.teamBId)
+            .get()
+            .then((s) => (s.exists ? (s.data()?.memberIds ?? []) : [])),
+          getTeamName(db, championshipId, afterData.teamAId),
+          getTeamName(db, championshipId, afterData.teamBId),
+        ]);
+
+      const winner =
+        result.winner === "teamA" ? teamAName : teamBName;
+      const loser =
+        result.winner === "teamA" ? teamBName : teamAName;
+      const scoreText = result.sets
+        .map((s: { teamAPoints: number; teamBPoints: number }) =>
+          `${s.teamAPoints}-${s.teamBPoints}`
+        )
+        .join(", ");
+
+      const allMembers = [
+        ...new Set([...teamAMembers, ...teamBMembers]),
+      ];
+      await sendChampionshipNotificationToUsers(db, allMembers, {
+        title: "Result confirmed ✓",
+        body: `${winner} defeated ${loser} (${scoreText}) — standings updated.`,
+        data: {
+          type: "championship_result_verified",
+          championshipId,
+          matchId,
+        },
+      });
+    } catch (notifErr) {
+      // Notification failure must not fail the standings update
+      functions.logger.error(
+        "[onChampionshipMatchVerified] Notification failed (non-fatal)",
+        { notifErr, matchId }
+      );
+    }
   }
 }
 

--- a/functions/test/unit/championshipNotifications.test.ts
+++ b/functions/test/unit/championshipNotifications.test.ts
@@ -1,0 +1,342 @@
+// Unit tests for championship push notification handlers (Story 30.13).
+// Validates: result submitted → opposing team, disputed → admins,
+// admin decision → both teams. All FCM sends and stale-token cleanup verified.
+
+import {
+  onChampionshipMatchResultSubmittedHandler,
+  onChampionshipMatchDisputedHandler,
+  onChampionshipAdminDecisionHandler,
+  sendChampionshipNotificationToUsers,
+} from "../../src/championshipNotifications";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => {
+  const fn: any = {
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  };
+  fn.region = jest.fn(() => fn);
+  fn.runWith = jest.fn(() => fn);
+  fn.firestore = { document: jest.fn(() => ({ onUpdate: jest.fn() })) };
+  return fn;
+});
+
+// Use var so these are hoisted (not in TDZ) when jest.mock factory runs.
+// eslint-disable-next-line no-var
+var mockSendEachForMulticast = jest.fn();
+// eslint-disable-next-line no-var
+var mockUpdate = jest.fn();
+// eslint-disable-next-line no-var
+var mockCollection = jest.fn();
+// eslint-disable-next-line no-var
+var mockArrayRemove = jest.fn((...args: string[]) => ({ type: "arrayRemove", args }));
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(
+      // Lazy wrappers so the var references are resolved at call-time, not factory-time.
+      jest.fn(() => ({
+        collection: (...a: unknown[]) => mockCollection(...a),
+      })),
+      {
+        FieldValue: { arrayRemove: (...a: string[]) => mockArrayRemove(...a) },
+      }
+    ),
+    messaging: jest.fn(() => ({
+      sendEachForMulticast: (...a: unknown[]) => mockSendEachForMulticast(...a),
+    })),
+  };
+});
+
+// ── Firestore mock builder ───────────────────────────────────────────────────
+
+/** Build a chain: db.collection(c).doc(d).collection(c2).doc(d2).get() */
+function buildDb(docs: Record<string, Record<string, unknown>>) {
+  const getDoc = (path: string) => {
+    const data = docs[path];
+    return Promise.resolve({
+      exists: !!data,
+      id: path.split("/").pop() ?? path,
+      data: () => data ?? null,
+    });
+  };
+
+  const docFn = (path: string) => ({
+    get: () => getDoc(path),
+    update: mockUpdate,
+    collection: (col: string) => ({
+      doc: (id: string) => docFn(`${path}/${col}/${id}`),
+    }),
+  });
+
+  const db: any = {
+    collection: (col: string) => ({
+      doc: (id: string) => docFn(`${col}/${id}`),
+    }),
+  };
+  return db;
+}
+
+const CHAMPIONSHIP_ID = "champ-1";
+const MATCH_ID = "match-1";
+const PARAMS = { championshipId: CHAMPIONSHIP_ID, matchId: MATCH_ID };
+
+// ── sendChampionshipNotificationToUsers tests ─────────────────────────────────
+
+describe("sendChampionshipNotificationToUsers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("sends to users with championship pref not set (default allowed)", async () => {
+    mockSendEachForMulticast.mockResolvedValue({
+      successCount: 1,
+      failureCount: 0,
+      responses: [{ success: true }],
+    });
+
+    const db = buildDb({
+      "users/user-1": { fcmTokens: ["tok1"], notificationPreferences: {} },
+    });
+
+    await sendChampionshipNotificationToUsers(db, ["user-1"], {
+      title: "Test",
+      body: "Body",
+      data: { type: "test" },
+    });
+
+    expect(mockSendEachForMulticast).toHaveBeenCalledTimes(1);
+    const msg = mockSendEachForMulticast.mock.calls[0][0];
+    expect(msg.tokens).toContain("tok1");
+    expect(msg.notification.title).toBe("Test");
+  });
+
+  test("skips users with championship pref = false", async () => {
+    const db = buildDb({
+      "users/user-1": {
+        fcmTokens: ["tok1"],
+        notificationPreferences: { championship: false },
+      },
+    });
+
+    await sendChampionshipNotificationToUsers(db, ["user-1"], {
+      title: "Test",
+      body: "Body",
+      data: { type: "test" },
+    });
+
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+
+  test("removes stale tokens on failure", async () => {
+    mockSendEachForMulticast.mockResolvedValue({
+      successCount: 0,
+      failureCount: 1,
+      responses: [
+        {
+          success: false,
+          error: { code: "messaging/registration-token-not-registered" },
+        },
+      ],
+    });
+
+    const db = buildDb({
+      "users/user-1": { fcmTokens: ["stale-tok"], notificationPreferences: {} },
+    });
+
+    await sendChampionshipNotificationToUsers(db, ["user-1"], {
+      title: "Test",
+      body: "Body",
+      data: { type: "test" },
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fcmTokens: expect.objectContaining({ type: "arrayRemove", args: ["stale-tok"] }),
+      })
+    );
+  });
+
+  test("does nothing when userIds is empty", async () => {
+    const db = buildDb({});
+    await sendChampionshipNotificationToUsers(db, [], {
+      title: "T",
+      body: "B",
+      data: { type: "t" },
+    });
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+});
+
+// ── onChampionshipMatchResultSubmitted tests ──────────────────────────────────
+
+describe("onChampionshipMatchResultSubmittedHandler", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("does nothing when status does not change to played", async () => {
+    const db = buildDb({});
+    await onChampionshipMatchResultSubmittedHandler(
+      { status: "pending", teamAId: "tA", teamBId: "tB", submittedByTeamId: "tA" },
+      { status: "pending", teamAId: "tA", teamBId: "tB", submittedByTeamId: "tA" },
+      PARAMS,
+      db
+    );
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+
+  test("sends to opposing team when result submitted", async () => {
+    mockSendEachForMulticast.mockResolvedValue({
+      successCount: 1,
+      failureCount: 0,
+      responses: [{ success: true }],
+    });
+
+    const db = buildDb({
+      [`championships/${CHAMPIONSHIP_ID}/teams/tA`]: {
+        name: "Team Alpha",
+        memberIds: ["user-a1"],
+      },
+      [`championships/${CHAMPIONSHIP_ID}/teams/tB`]: {
+        name: "Team Beta",
+        memberIds: ["user-b1"],
+      },
+      "users/user-b1": { fcmTokens: ["tok-b1"], notificationPreferences: {} },
+    });
+
+    await onChampionshipMatchResultSubmittedHandler(
+      { status: "pending" },
+      { status: "played", teamAId: "tA", teamBId: "tB", submittedByTeamId: "tA" },
+      PARAMS,
+      db
+    );
+
+    expect(mockSendEachForMulticast).toHaveBeenCalledTimes(1);
+    const msg = mockSendEachForMulticast.mock.calls[0][0];
+    expect(msg.tokens).toContain("tok-b1");
+    expect(msg.notification.title).toContain("Team Alpha");
+    expect(msg.notification.title).toContain("Team Beta");
+  });
+});
+
+// ── onChampionshipMatchDisputed tests ─────────────────────────────────────────
+
+describe("onChampionshipMatchDisputedHandler", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("does nothing when status does not change to disputed", async () => {
+    const db = buildDb({});
+    await onChampionshipMatchDisputedHandler(
+      { status: "played" },
+      { status: "played", teamAId: "tA", teamBId: "tB" },
+      PARAMS,
+      db
+    );
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+
+  test("sends to admins when match is disputed", async () => {
+    mockSendEachForMulticast.mockResolvedValue({
+      successCount: 1,
+      failureCount: 0,
+      responses: [{ success: true }],
+    });
+
+    const db = buildDb({
+      [`championships/${CHAMPIONSHIP_ID}`]: {
+        adminIds: ["admin-1"],
+      },
+      [`championships/${CHAMPIONSHIP_ID}/teams/tA`]: {
+        name: "Team Alpha",
+        memberIds: ["user-a1"],
+      },
+      [`championships/${CHAMPIONSHIP_ID}/teams/tB`]: {
+        name: "Team Beta",
+        memberIds: ["user-b1"],
+      },
+      "users/admin-1": {
+        fcmTokens: ["tok-admin"],
+        notificationPreferences: {},
+      },
+    });
+
+    await onChampionshipMatchDisputedHandler(
+      { status: "played" },
+      { status: "disputed", teamAId: "tA", teamBId: "tB" },
+      PARAMS,
+      db
+    );
+
+    expect(mockSendEachForMulticast).toHaveBeenCalledTimes(1);
+    const msg = mockSendEachForMulticast.mock.calls[0][0];
+    expect(msg.tokens).toContain("tok-admin");
+    expect(msg.notification.title).toBe("Match disputed 🚨");
+  });
+
+  test("does nothing when championship has no admins", async () => {
+    const db = buildDb({
+      [`championships/${CHAMPIONSHIP_ID}`]: { adminIds: [] },
+    });
+
+    await onChampionshipMatchDisputedHandler(
+      { status: "played" },
+      { status: "disputed", teamAId: "tA", teamBId: "tB" },
+      PARAMS,
+      db
+    );
+
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+});
+
+// ── onChampionshipAdminDecision tests ─────────────────────────────────────────
+
+describe("onChampionshipAdminDecisionHandler", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("does nothing when status does not change to admin_decided", async () => {
+    const db = buildDb({});
+    await onChampionshipAdminDecisionHandler(
+      { status: "disputed" },
+      { status: "disputed", teamAId: "tA", teamBId: "tB" },
+      PARAMS,
+      db
+    );
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+  });
+
+  test("sends to both teams when admin decides", async () => {
+    mockSendEachForMulticast.mockResolvedValue({
+      successCount: 2,
+      failureCount: 0,
+      responses: [{ success: true }, { success: true }],
+    });
+
+    const db = buildDb({
+      [`championships/${CHAMPIONSHIP_ID}/teams/tA`]: {
+        name: "Team Alpha",
+        memberIds: ["user-a1"],
+      },
+      [`championships/${CHAMPIONSHIP_ID}/teams/tB`]: {
+        name: "Team Beta",
+        memberIds: ["user-b1"],
+      },
+      "users/user-a1": { fcmTokens: ["tok-a1"], notificationPreferences: {} },
+      "users/user-b1": { fcmTokens: ["tok-b1"], notificationPreferences: {} },
+    });
+
+    await onChampionshipAdminDecisionHandler(
+      { status: "disputed" },
+      { status: "admin_decided", teamAId: "tA", teamBId: "tB" },
+      PARAMS,
+      db
+    );
+
+    expect(mockSendEachForMulticast).toHaveBeenCalledTimes(1);
+    const msg = mockSendEachForMulticast.mock.calls[0][0];
+    expect(msg.tokens).toContain("tok-a1");
+    expect(msg.tokens).toContain("tok-b1");
+    expect(msg.notification.title).toBe("Match decided by admin");
+  });
+});

--- a/functions/test/unit/checkChampionshipDeadlines.test.ts
+++ b/functions/test/unit/checkChampionshipDeadlines.test.ts
@@ -1,0 +1,282 @@
+// Unit tests for the 48h championship deadline warning scheduled function (Story 30.13).
+// Validates: warnings sent to both teams, idempotency flag prevents re-send,
+// no active championships → early exit, empty team skipped.
+
+import { checkChampionshipDeadlinesHandler } from "../../src/checkChampionshipDeadlines";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock("firebase-functions", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  region: jest.fn(() => ({
+    runWith: jest.fn(() => ({
+      pubsub: {
+        schedule: jest.fn(() => ({
+          timeZone: jest.fn(() => ({ onRun: jest.fn() })),
+        })),
+      },
+    })),
+  })),
+}));
+
+// Mock the notification helper so no real FCM calls are made.
+jest.mock("../../src/championshipNotifications", () => ({
+  sendChampionshipNotificationToUsers: jest.fn().mockResolvedValue(undefined),
+}));
+
+// eslint-disable-next-line no-var
+var mockTimestampFromDate = jest.fn((d: Date) => ({
+  toDate: () => d,
+  seconds: Math.floor(d.getTime() / 1000),
+}));
+
+jest.mock("firebase-admin", () => {
+  const actual = jest.requireActual("firebase-admin");
+  return {
+    ...actual,
+    firestore: Object.assign(jest.fn(), {
+      Timestamp: { fromDate: (d: Date) => mockTimestampFromDate(d) },
+    }),
+  };
+});
+
+// Import after mocks are registered.
+import { sendChampionshipNotificationToUsers } from "../../src/championshipNotifications";
+
+const mockSend = sendChampionshipNotificationToUsers as jest.Mock;
+
+// ── Firestore mock builder ────────────────────────────────────────────────────
+
+const mockRefUpdate = jest.fn();
+
+type DocSpec = { id: string; data: Record<string, unknown> };
+
+/**
+ * Builds a minimal db mock covering the access patterns used by
+ * checkChampionshipDeadlinesHandler:
+ *  - collection("championships").where(...).get()         → active championships
+ *  - .doc(champId).collection("matches").where(…).get()  → pending matches
+ *  - .doc(champId).collection("teams").doc(teamId).get() → team doc
+ *  - matchDoc.ref.update(flag)
+ */
+function buildDb(opts: {
+  championships?: DocSpec[];
+  matchesByChampId?: Record<string, DocSpec[]>;
+  teamDocs?: Record<string, Record<string, unknown>>; // key: "<champId>/teams/<teamId>"
+}) {
+  const {
+    championships = [],
+    matchesByChampId = {},
+    teamDocs = {},
+  } = opts;
+
+  // A chainable where() stub that always returns this same object, ending in .get().
+  const queryStub = (result: () => Promise<unknown>) => {
+    const q: Record<string, unknown> = {};
+    q["where"] = () => q;
+    q["get"] = result;
+    return q as { where: () => typeof q; get: () => Promise<unknown> };
+  };
+
+  const makeQuerySnap = (docs: DocSpec[], champId?: string) => ({
+    empty: docs.length === 0,
+    size: docs.length,
+    docs: docs.map((d) => ({
+      id: d.id,
+      exists: true,
+      data: () => d.data,
+      ref: { update: mockRefUpdate },
+      // expose champId for the handler to build sub-paths
+    })),
+  });
+
+  return {
+    collection: (col: string) => {
+      if (col !== "championships") return {};
+      return {
+        // championship-level query (active championships)
+        where: () =>
+          queryStub(() =>
+            Promise.resolve(makeQuerySnap(championships))
+          ),
+        doc: (champId: string) => ({
+          collection: (subCol: string) => {
+            if (subCol === "matches") {
+              const matches = matchesByChampId[champId] ?? [];
+              return queryStub(() =>
+                Promise.resolve(makeQuerySnap(matches, champId))
+              );
+            }
+            if (subCol === "teams") {
+              return {
+                doc: (teamId: string) => ({
+                  get: () => {
+                    const key = `${champId}/teams/${teamId}`;
+                    const data = teamDocs[key] ?? null;
+                    return Promise.resolve({
+                      exists: !!data,
+                      id: teamId,
+                      data: () => data,
+                    });
+                  },
+                }),
+              };
+            }
+            return {};
+          },
+        }),
+      };
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+const NOW = new Date("2025-06-01T09:00:00Z");
+const CHAMP_ID = "champ-1";
+const MATCH_ID = "match-1";
+
+describe("checkChampionshipDeadlinesHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("does nothing when there are no active championships", async () => {
+    const db = buildDb({ championships: [] });
+    await checkChampionshipDeadlinesHandler(db as never, NOW);
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockRefUpdate).not.toHaveBeenCalled();
+  });
+
+  test("sends 48h warning to both teams and marks flag", async () => {
+    const db = buildDb({
+      championships: [{ id: CHAMP_ID, data: { status: "active" } }],
+      matchesByChampId: {
+        [CHAMP_ID]: [
+          {
+            id: MATCH_ID,
+            data: {
+              status: "pending",
+              teamAId: "tA",
+              teamBId: "tB",
+              deadline: { toDate: () => new Date("2025-06-02T10:00:00Z") },
+              deadlineWarning48hSent: false,
+            },
+          },
+        ],
+      },
+      teamDocs: {
+        [`${CHAMP_ID}/teams/tA`]: { name: "Team Alpha", memberIds: ["user-a1"] },
+        [`${CHAMP_ID}/teams/tB`]: { name: "Team Beta", memberIds: ["user-b1"] },
+      },
+    });
+
+    await checkChampionshipDeadlinesHandler(db as never, NOW);
+
+    // Two sendChampionshipNotificationToUsers calls — one per team
+    expect(mockSend).toHaveBeenCalledTimes(2);
+
+    const calls = mockSend.mock.calls;
+    const teamACall = calls.find((c: unknown[]) =>
+      (c[1] as string[]).includes("user-a1")
+    );
+    const teamBCall = calls.find((c: unknown[]) =>
+      (c[1] as string[]).includes("user-b1")
+    );
+
+    expect(teamACall).toBeDefined();
+    expect(teamACall![2].body).toContain("Team Beta");
+    expect(teamBCall).toBeDefined();
+    expect(teamBCall![2].body).toContain("Team Alpha");
+
+    // Idempotency flag written
+    expect(mockRefUpdate).toHaveBeenCalledWith({ deadlineWarning48hSent: true });
+  });
+
+  test("skips match where deadlineWarning48hSent is already true", async () => {
+    const db = buildDb({
+      championships: [{ id: CHAMP_ID, data: { status: "active" } }],
+      matchesByChampId: {
+        [CHAMP_ID]: [
+          {
+            id: MATCH_ID,
+            data: {
+              status: "pending",
+              teamAId: "tA",
+              teamBId: "tB",
+              deadlineWarning48hSent: true,
+            },
+          },
+        ],
+      },
+    });
+
+    await checkChampionshipDeadlinesHandler(db as never, NOW);
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockRefUpdate).not.toHaveBeenCalled();
+  });
+
+  test("sends only to team B when team A has no members", async () => {
+    const db = buildDb({
+      championships: [{ id: CHAMP_ID, data: { status: "active" } }],
+      matchesByChampId: {
+        [CHAMP_ID]: [
+          {
+            id: MATCH_ID,
+            data: {
+              status: "pending",
+              teamAId: "tA",
+              teamBId: "tB",
+              deadlineWarning48hSent: false,
+            },
+          },
+        ],
+      },
+      teamDocs: {
+        [`${CHAMP_ID}/teams/tA`]: { name: "Team Alpha", memberIds: [] },
+        [`${CHAMP_ID}/teams/tB`]: { name: "Team Beta", memberIds: ["user-b1"] },
+      },
+    });
+
+    await checkChampionshipDeadlinesHandler(db as never, NOW);
+
+    // Only team B notified (team A memberIds is empty)
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const [, userIds] = mockSend.mock.calls[0] as [unknown, string[], unknown];
+    expect(userIds).toContain("user-b1");
+    expect(mockRefUpdate).toHaveBeenCalledWith({ deadlineWarning48hSent: true });
+  });
+
+  test("processes multiple championships independently", async () => {
+    const db = buildDb({
+      championships: [
+        { id: "champ-A", data: { status: "active" } },
+        { id: "champ-B", data: { status: "active" } },
+      ],
+      matchesByChampId: {
+        "champ-A": [
+          {
+            id: "match-A1",
+            data: {
+              status: "pending",
+              teamAId: "tA",
+              teamBId: "tB",
+              deadlineWarning48hSent: false,
+            },
+          },
+        ],
+        "champ-B": [], // no pending matches
+      },
+      teamDocs: {
+        "champ-A/teams/tA": { name: "Alpha", memberIds: ["u1"] },
+        "champ-A/teams/tB": { name: "Beta", memberIds: ["u2"] },
+      },
+    });
+
+    await checkChampionshipDeadlinesHandler(db as never, NOW);
+
+    // Only champ-A has a match → 2 send calls
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/features/notifications/domain/entities/notification_preferences_entity.dart
+++ b/lib/features/notifications/domain/entities/notification_preferences_entity.dart
@@ -24,6 +24,8 @@ abstract class NotificationPreferencesEntity with _$NotificationPreferencesEntit
     @Default(true) bool trainingMinParticipantsReached,
     @Default(true) bool trainingFeedbackReceived,
     @Default(true) bool trainingSessionCancelled,
+    // Championship notification preferences (Story 30.13)
+    @Default(true) bool championship,
   }) = _NotificationPreferencesEntity;
 
   const NotificationPreferencesEntity._();

--- a/lib/features/notifications/domain/entities/notification_preferences_entity.freezed.dart
+++ b/lib/features/notifications/domain/entities/notification_preferences_entity.freezed.dart
@@ -16,7 +16,8 @@ T _$identity<T>(T value) => value;
 mixin _$NotificationPreferencesEntity {
 
  bool get groupInvitations; bool get invitationAccepted; bool get gameCreated; bool get memberJoined; bool get memberLeft; bool get roleChanged; bool get friendRequestReceived; bool get friendRequestAccepted; bool get friendRemoved; bool get quietHoursEnabled; String? get quietHoursStart; String? get quietHoursEnd; Map<String, bool> get groupSpecific;// Training session notification preferences (Story 15.13)
- bool get trainingSessionCreated; bool get trainingMinParticipantsReached; bool get trainingFeedbackReceived; bool get trainingSessionCancelled;
+ bool get trainingSessionCreated; bool get trainingMinParticipantsReached; bool get trainingFeedbackReceived; bool get trainingSessionCancelled;// Championship notification preferences (Story 30.13)
+ bool get championship;
 /// Create a copy of NotificationPreferencesEntity
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +30,16 @@ $NotificationPreferencesEntityCopyWith<NotificationPreferencesEntity> get copyWi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationPreferencesEntity&&(identical(other.groupInvitations, groupInvitations) || other.groupInvitations == groupInvitations)&&(identical(other.invitationAccepted, invitationAccepted) || other.invitationAccepted == invitationAccepted)&&(identical(other.gameCreated, gameCreated) || other.gameCreated == gameCreated)&&(identical(other.memberJoined, memberJoined) || other.memberJoined == memberJoined)&&(identical(other.memberLeft, memberLeft) || other.memberLeft == memberLeft)&&(identical(other.roleChanged, roleChanged) || other.roleChanged == roleChanged)&&(identical(other.friendRequestReceived, friendRequestReceived) || other.friendRequestReceived == friendRequestReceived)&&(identical(other.friendRequestAccepted, friendRequestAccepted) || other.friendRequestAccepted == friendRequestAccepted)&&(identical(other.friendRemoved, friendRemoved) || other.friendRemoved == friendRemoved)&&(identical(other.quietHoursEnabled, quietHoursEnabled) || other.quietHoursEnabled == quietHoursEnabled)&&(identical(other.quietHoursStart, quietHoursStart) || other.quietHoursStart == quietHoursStart)&&(identical(other.quietHoursEnd, quietHoursEnd) || other.quietHoursEnd == quietHoursEnd)&&const DeepCollectionEquality().equals(other.groupSpecific, groupSpecific)&&(identical(other.trainingSessionCreated, trainingSessionCreated) || other.trainingSessionCreated == trainingSessionCreated)&&(identical(other.trainingMinParticipantsReached, trainingMinParticipantsReached) || other.trainingMinParticipantsReached == trainingMinParticipantsReached)&&(identical(other.trainingFeedbackReceived, trainingFeedbackReceived) || other.trainingFeedbackReceived == trainingFeedbackReceived)&&(identical(other.trainingSessionCancelled, trainingSessionCancelled) || other.trainingSessionCancelled == trainingSessionCancelled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationPreferencesEntity&&(identical(other.groupInvitations, groupInvitations) || other.groupInvitations == groupInvitations)&&(identical(other.invitationAccepted, invitationAccepted) || other.invitationAccepted == invitationAccepted)&&(identical(other.gameCreated, gameCreated) || other.gameCreated == gameCreated)&&(identical(other.memberJoined, memberJoined) || other.memberJoined == memberJoined)&&(identical(other.memberLeft, memberLeft) || other.memberLeft == memberLeft)&&(identical(other.roleChanged, roleChanged) || other.roleChanged == roleChanged)&&(identical(other.friendRequestReceived, friendRequestReceived) || other.friendRequestReceived == friendRequestReceived)&&(identical(other.friendRequestAccepted, friendRequestAccepted) || other.friendRequestAccepted == friendRequestAccepted)&&(identical(other.friendRemoved, friendRemoved) || other.friendRemoved == friendRemoved)&&(identical(other.quietHoursEnabled, quietHoursEnabled) || other.quietHoursEnabled == quietHoursEnabled)&&(identical(other.quietHoursStart, quietHoursStart) || other.quietHoursStart == quietHoursStart)&&(identical(other.quietHoursEnd, quietHoursEnd) || other.quietHoursEnd == quietHoursEnd)&&const DeepCollectionEquality().equals(other.groupSpecific, groupSpecific)&&(identical(other.trainingSessionCreated, trainingSessionCreated) || other.trainingSessionCreated == trainingSessionCreated)&&(identical(other.trainingMinParticipantsReached, trainingMinParticipantsReached) || other.trainingMinParticipantsReached == trainingMinParticipantsReached)&&(identical(other.trainingFeedbackReceived, trainingFeedbackReceived) || other.trainingFeedbackReceived == trainingFeedbackReceived)&&(identical(other.trainingSessionCancelled, trainingSessionCancelled) || other.trainingSessionCancelled == trainingSessionCancelled)&&(identical(other.championship, championship) || other.championship == championship));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,groupInvitations,invitationAccepted,gameCreated,memberJoined,memberLeft,roleChanged,friendRequestReceived,friendRequestAccepted,friendRemoved,quietHoursEnabled,quietHoursStart,quietHoursEnd,const DeepCollectionEquality().hash(groupSpecific),trainingSessionCreated,trainingMinParticipantsReached,trainingFeedbackReceived,trainingSessionCancelled);
+int get hashCode => Object.hash(runtimeType,groupInvitations,invitationAccepted,gameCreated,memberJoined,memberLeft,roleChanged,friendRequestReceived,friendRequestAccepted,friendRemoved,quietHoursEnabled,quietHoursStart,quietHoursEnd,const DeepCollectionEquality().hash(groupSpecific),trainingSessionCreated,trainingMinParticipantsReached,trainingFeedbackReceived,trainingSessionCancelled,championship);
 
 @override
 String toString() {
-  return 'NotificationPreferencesEntity(groupInvitations: $groupInvitations, invitationAccepted: $invitationAccepted, gameCreated: $gameCreated, memberJoined: $memberJoined, memberLeft: $memberLeft, roleChanged: $roleChanged, friendRequestReceived: $friendRequestReceived, friendRequestAccepted: $friendRequestAccepted, friendRemoved: $friendRemoved, quietHoursEnabled: $quietHoursEnabled, quietHoursStart: $quietHoursStart, quietHoursEnd: $quietHoursEnd, groupSpecific: $groupSpecific, trainingSessionCreated: $trainingSessionCreated, trainingMinParticipantsReached: $trainingMinParticipantsReached, trainingFeedbackReceived: $trainingFeedbackReceived, trainingSessionCancelled: $trainingSessionCancelled)';
+  return 'NotificationPreferencesEntity(groupInvitations: $groupInvitations, invitationAccepted: $invitationAccepted, gameCreated: $gameCreated, memberJoined: $memberJoined, memberLeft: $memberLeft, roleChanged: $roleChanged, friendRequestReceived: $friendRequestReceived, friendRequestAccepted: $friendRequestAccepted, friendRemoved: $friendRemoved, quietHoursEnabled: $quietHoursEnabled, quietHoursStart: $quietHoursStart, quietHoursEnd: $quietHoursEnd, groupSpecific: $groupSpecific, trainingSessionCreated: $trainingSessionCreated, trainingMinParticipantsReached: $trainingMinParticipantsReached, trainingFeedbackReceived: $trainingFeedbackReceived, trainingSessionCancelled: $trainingSessionCancelled, championship: $championship)';
 }
 
 
@@ -49,7 +50,7 @@ abstract mixin class $NotificationPreferencesEntityCopyWith<$Res>  {
   factory $NotificationPreferencesEntityCopyWith(NotificationPreferencesEntity value, $Res Function(NotificationPreferencesEntity) _then) = _$NotificationPreferencesEntityCopyWithImpl;
 @useResult
 $Res call({
- bool groupInvitations, bool invitationAccepted, bool gameCreated, bool memberJoined, bool memberLeft, bool roleChanged, bool friendRequestReceived, bool friendRequestAccepted, bool friendRemoved, bool quietHoursEnabled, String? quietHoursStart, String? quietHoursEnd, Map<String, bool> groupSpecific, bool trainingSessionCreated, bool trainingMinParticipantsReached, bool trainingFeedbackReceived, bool trainingSessionCancelled
+ bool groupInvitations, bool invitationAccepted, bool gameCreated, bool memberJoined, bool memberLeft, bool roleChanged, bool friendRequestReceived, bool friendRequestAccepted, bool friendRemoved, bool quietHoursEnabled, String? quietHoursStart, String? quietHoursEnd, Map<String, bool> groupSpecific, bool trainingSessionCreated, bool trainingMinParticipantsReached, bool trainingFeedbackReceived, bool trainingSessionCancelled, bool championship
 });
 
 
@@ -66,7 +67,7 @@ class _$NotificationPreferencesEntityCopyWithImpl<$Res>
 
 /// Create a copy of NotificationPreferencesEntity
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? groupInvitations = null,Object? invitationAccepted = null,Object? gameCreated = null,Object? memberJoined = null,Object? memberLeft = null,Object? roleChanged = null,Object? friendRequestReceived = null,Object? friendRequestAccepted = null,Object? friendRemoved = null,Object? quietHoursEnabled = null,Object? quietHoursStart = freezed,Object? quietHoursEnd = freezed,Object? groupSpecific = null,Object? trainingSessionCreated = null,Object? trainingMinParticipantsReached = null,Object? trainingFeedbackReceived = null,Object? trainingSessionCancelled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? groupInvitations = null,Object? invitationAccepted = null,Object? gameCreated = null,Object? memberJoined = null,Object? memberLeft = null,Object? roleChanged = null,Object? friendRequestReceived = null,Object? friendRequestAccepted = null,Object? friendRemoved = null,Object? quietHoursEnabled = null,Object? quietHoursStart = freezed,Object? quietHoursEnd = freezed,Object? groupSpecific = null,Object? trainingSessionCreated = null,Object? trainingMinParticipantsReached = null,Object? trainingFeedbackReceived = null,Object? trainingSessionCancelled = null,Object? championship = null,}) {
   return _then(_self.copyWith(
 groupInvitations: null == groupInvitations ? _self.groupInvitations : groupInvitations // ignore: cast_nullable_to_non_nullable
 as bool,invitationAccepted: null == invitationAccepted ? _self.invitationAccepted : invitationAccepted // ignore: cast_nullable_to_non_nullable
@@ -85,6 +86,7 @@ as Map<String, bool>,trainingSessionCreated: null == trainingSessionCreated ? _s
 as bool,trainingMinParticipantsReached: null == trainingMinParticipantsReached ? _self.trainingMinParticipantsReached : trainingMinParticipantsReached // ignore: cast_nullable_to_non_nullable
 as bool,trainingFeedbackReceived: null == trainingFeedbackReceived ? _self.trainingFeedbackReceived : trainingFeedbackReceived // ignore: cast_nullable_to_non_nullable
 as bool,trainingSessionCancelled: null == trainingSessionCancelled ? _self.trainingSessionCancelled : trainingSessionCancelled // ignore: cast_nullable_to_non_nullable
+as bool,championship: null == championship ? _self.championship : championship // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -170,10 +172,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled,  bool championship)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationPreferencesEntity() when $default != null:
-return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled);case _:
+return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled,_that.championship);case _:
   return orElse();
 
 }
@@ -191,10 +193,10 @@ return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreate
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled,  bool championship)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationPreferencesEntity():
-return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled);case _:
+return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled,_that.championship);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -211,10 +213,10 @@ return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreate
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool groupInvitations,  bool invitationAccepted,  bool gameCreated,  bool memberJoined,  bool memberLeft,  bool roleChanged,  bool friendRequestReceived,  bool friendRequestAccepted,  bool friendRemoved,  bool quietHoursEnabled,  String? quietHoursStart,  String? quietHoursEnd,  Map<String, bool> groupSpecific,  bool trainingSessionCreated,  bool trainingMinParticipantsReached,  bool trainingFeedbackReceived,  bool trainingSessionCancelled,  bool championship)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationPreferencesEntity() when $default != null:
-return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled);case _:
+return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreated,_that.memberJoined,_that.memberLeft,_that.roleChanged,_that.friendRequestReceived,_that.friendRequestAccepted,_that.friendRemoved,_that.quietHoursEnabled,_that.quietHoursStart,_that.quietHoursEnd,_that.groupSpecific,_that.trainingSessionCreated,_that.trainingMinParticipantsReached,_that.trainingFeedbackReceived,_that.trainingSessionCancelled,_that.championship);case _:
   return null;
 
 }
@@ -226,7 +228,7 @@ return $default(_that.groupInvitations,_that.invitationAccepted,_that.gameCreate
 @JsonSerializable()
 
 class _NotificationPreferencesEntity extends NotificationPreferencesEntity {
-  const _NotificationPreferencesEntity({this.groupInvitations = true, this.invitationAccepted = true, this.gameCreated = true, this.memberJoined = false, this.memberLeft = false, this.roleChanged = true, this.friendRequestReceived = true, this.friendRequestAccepted = true, this.friendRemoved = false, this.quietHoursEnabled = false, this.quietHoursStart, this.quietHoursEnd, final  Map<String, bool> groupSpecific = const {}, this.trainingSessionCreated = true, this.trainingMinParticipantsReached = true, this.trainingFeedbackReceived = true, this.trainingSessionCancelled = true}): _groupSpecific = groupSpecific,super._();
+  const _NotificationPreferencesEntity({this.groupInvitations = true, this.invitationAccepted = true, this.gameCreated = true, this.memberJoined = false, this.memberLeft = false, this.roleChanged = true, this.friendRequestReceived = true, this.friendRequestAccepted = true, this.friendRemoved = false, this.quietHoursEnabled = false, this.quietHoursStart, this.quietHoursEnd, final  Map<String, bool> groupSpecific = const {}, this.trainingSessionCreated = true, this.trainingMinParticipantsReached = true, this.trainingFeedbackReceived = true, this.trainingSessionCancelled = true, this.championship = true}): _groupSpecific = groupSpecific,super._();
   factory _NotificationPreferencesEntity.fromJson(Map<String, dynamic> json) => _$NotificationPreferencesEntityFromJson(json);
 
 @override@JsonKey() final  bool groupInvitations;
@@ -253,6 +255,8 @@ class _NotificationPreferencesEntity extends NotificationPreferencesEntity {
 @override@JsonKey() final  bool trainingMinParticipantsReached;
 @override@JsonKey() final  bool trainingFeedbackReceived;
 @override@JsonKey() final  bool trainingSessionCancelled;
+// Championship notification preferences (Story 30.13)
+@override@JsonKey() final  bool championship;
 
 /// Create a copy of NotificationPreferencesEntity
 /// with the given fields replaced by the non-null parameter values.
@@ -267,16 +271,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationPreferencesEntity&&(identical(other.groupInvitations, groupInvitations) || other.groupInvitations == groupInvitations)&&(identical(other.invitationAccepted, invitationAccepted) || other.invitationAccepted == invitationAccepted)&&(identical(other.gameCreated, gameCreated) || other.gameCreated == gameCreated)&&(identical(other.memberJoined, memberJoined) || other.memberJoined == memberJoined)&&(identical(other.memberLeft, memberLeft) || other.memberLeft == memberLeft)&&(identical(other.roleChanged, roleChanged) || other.roleChanged == roleChanged)&&(identical(other.friendRequestReceived, friendRequestReceived) || other.friendRequestReceived == friendRequestReceived)&&(identical(other.friendRequestAccepted, friendRequestAccepted) || other.friendRequestAccepted == friendRequestAccepted)&&(identical(other.friendRemoved, friendRemoved) || other.friendRemoved == friendRemoved)&&(identical(other.quietHoursEnabled, quietHoursEnabled) || other.quietHoursEnabled == quietHoursEnabled)&&(identical(other.quietHoursStart, quietHoursStart) || other.quietHoursStart == quietHoursStart)&&(identical(other.quietHoursEnd, quietHoursEnd) || other.quietHoursEnd == quietHoursEnd)&&const DeepCollectionEquality().equals(other._groupSpecific, _groupSpecific)&&(identical(other.trainingSessionCreated, trainingSessionCreated) || other.trainingSessionCreated == trainingSessionCreated)&&(identical(other.trainingMinParticipantsReached, trainingMinParticipantsReached) || other.trainingMinParticipantsReached == trainingMinParticipantsReached)&&(identical(other.trainingFeedbackReceived, trainingFeedbackReceived) || other.trainingFeedbackReceived == trainingFeedbackReceived)&&(identical(other.trainingSessionCancelled, trainingSessionCancelled) || other.trainingSessionCancelled == trainingSessionCancelled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationPreferencesEntity&&(identical(other.groupInvitations, groupInvitations) || other.groupInvitations == groupInvitations)&&(identical(other.invitationAccepted, invitationAccepted) || other.invitationAccepted == invitationAccepted)&&(identical(other.gameCreated, gameCreated) || other.gameCreated == gameCreated)&&(identical(other.memberJoined, memberJoined) || other.memberJoined == memberJoined)&&(identical(other.memberLeft, memberLeft) || other.memberLeft == memberLeft)&&(identical(other.roleChanged, roleChanged) || other.roleChanged == roleChanged)&&(identical(other.friendRequestReceived, friendRequestReceived) || other.friendRequestReceived == friendRequestReceived)&&(identical(other.friendRequestAccepted, friendRequestAccepted) || other.friendRequestAccepted == friendRequestAccepted)&&(identical(other.friendRemoved, friendRemoved) || other.friendRemoved == friendRemoved)&&(identical(other.quietHoursEnabled, quietHoursEnabled) || other.quietHoursEnabled == quietHoursEnabled)&&(identical(other.quietHoursStart, quietHoursStart) || other.quietHoursStart == quietHoursStart)&&(identical(other.quietHoursEnd, quietHoursEnd) || other.quietHoursEnd == quietHoursEnd)&&const DeepCollectionEquality().equals(other._groupSpecific, _groupSpecific)&&(identical(other.trainingSessionCreated, trainingSessionCreated) || other.trainingSessionCreated == trainingSessionCreated)&&(identical(other.trainingMinParticipantsReached, trainingMinParticipantsReached) || other.trainingMinParticipantsReached == trainingMinParticipantsReached)&&(identical(other.trainingFeedbackReceived, trainingFeedbackReceived) || other.trainingFeedbackReceived == trainingFeedbackReceived)&&(identical(other.trainingSessionCancelled, trainingSessionCancelled) || other.trainingSessionCancelled == trainingSessionCancelled)&&(identical(other.championship, championship) || other.championship == championship));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,groupInvitations,invitationAccepted,gameCreated,memberJoined,memberLeft,roleChanged,friendRequestReceived,friendRequestAccepted,friendRemoved,quietHoursEnabled,quietHoursStart,quietHoursEnd,const DeepCollectionEquality().hash(_groupSpecific),trainingSessionCreated,trainingMinParticipantsReached,trainingFeedbackReceived,trainingSessionCancelled);
+int get hashCode => Object.hash(runtimeType,groupInvitations,invitationAccepted,gameCreated,memberJoined,memberLeft,roleChanged,friendRequestReceived,friendRequestAccepted,friendRemoved,quietHoursEnabled,quietHoursStart,quietHoursEnd,const DeepCollectionEquality().hash(_groupSpecific),trainingSessionCreated,trainingMinParticipantsReached,trainingFeedbackReceived,trainingSessionCancelled,championship);
 
 @override
 String toString() {
-  return 'NotificationPreferencesEntity(groupInvitations: $groupInvitations, invitationAccepted: $invitationAccepted, gameCreated: $gameCreated, memberJoined: $memberJoined, memberLeft: $memberLeft, roleChanged: $roleChanged, friendRequestReceived: $friendRequestReceived, friendRequestAccepted: $friendRequestAccepted, friendRemoved: $friendRemoved, quietHoursEnabled: $quietHoursEnabled, quietHoursStart: $quietHoursStart, quietHoursEnd: $quietHoursEnd, groupSpecific: $groupSpecific, trainingSessionCreated: $trainingSessionCreated, trainingMinParticipantsReached: $trainingMinParticipantsReached, trainingFeedbackReceived: $trainingFeedbackReceived, trainingSessionCancelled: $trainingSessionCancelled)';
+  return 'NotificationPreferencesEntity(groupInvitations: $groupInvitations, invitationAccepted: $invitationAccepted, gameCreated: $gameCreated, memberJoined: $memberJoined, memberLeft: $memberLeft, roleChanged: $roleChanged, friendRequestReceived: $friendRequestReceived, friendRequestAccepted: $friendRequestAccepted, friendRemoved: $friendRemoved, quietHoursEnabled: $quietHoursEnabled, quietHoursStart: $quietHoursStart, quietHoursEnd: $quietHoursEnd, groupSpecific: $groupSpecific, trainingSessionCreated: $trainingSessionCreated, trainingMinParticipantsReached: $trainingMinParticipantsReached, trainingFeedbackReceived: $trainingFeedbackReceived, trainingSessionCancelled: $trainingSessionCancelled, championship: $championship)';
 }
 
 
@@ -287,7 +291,7 @@ abstract mixin class _$NotificationPreferencesEntityCopyWith<$Res> implements $N
   factory _$NotificationPreferencesEntityCopyWith(_NotificationPreferencesEntity value, $Res Function(_NotificationPreferencesEntity) _then) = __$NotificationPreferencesEntityCopyWithImpl;
 @override @useResult
 $Res call({
- bool groupInvitations, bool invitationAccepted, bool gameCreated, bool memberJoined, bool memberLeft, bool roleChanged, bool friendRequestReceived, bool friendRequestAccepted, bool friendRemoved, bool quietHoursEnabled, String? quietHoursStart, String? quietHoursEnd, Map<String, bool> groupSpecific, bool trainingSessionCreated, bool trainingMinParticipantsReached, bool trainingFeedbackReceived, bool trainingSessionCancelled
+ bool groupInvitations, bool invitationAccepted, bool gameCreated, bool memberJoined, bool memberLeft, bool roleChanged, bool friendRequestReceived, bool friendRequestAccepted, bool friendRemoved, bool quietHoursEnabled, String? quietHoursStart, String? quietHoursEnd, Map<String, bool> groupSpecific, bool trainingSessionCreated, bool trainingMinParticipantsReached, bool trainingFeedbackReceived, bool trainingSessionCancelled, bool championship
 });
 
 
@@ -304,7 +308,7 @@ class __$NotificationPreferencesEntityCopyWithImpl<$Res>
 
 /// Create a copy of NotificationPreferencesEntity
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? groupInvitations = null,Object? invitationAccepted = null,Object? gameCreated = null,Object? memberJoined = null,Object? memberLeft = null,Object? roleChanged = null,Object? friendRequestReceived = null,Object? friendRequestAccepted = null,Object? friendRemoved = null,Object? quietHoursEnabled = null,Object? quietHoursStart = freezed,Object? quietHoursEnd = freezed,Object? groupSpecific = null,Object? trainingSessionCreated = null,Object? trainingMinParticipantsReached = null,Object? trainingFeedbackReceived = null,Object? trainingSessionCancelled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? groupInvitations = null,Object? invitationAccepted = null,Object? gameCreated = null,Object? memberJoined = null,Object? memberLeft = null,Object? roleChanged = null,Object? friendRequestReceived = null,Object? friendRequestAccepted = null,Object? friendRemoved = null,Object? quietHoursEnabled = null,Object? quietHoursStart = freezed,Object? quietHoursEnd = freezed,Object? groupSpecific = null,Object? trainingSessionCreated = null,Object? trainingMinParticipantsReached = null,Object? trainingFeedbackReceived = null,Object? trainingSessionCancelled = null,Object? championship = null,}) {
   return _then(_NotificationPreferencesEntity(
 groupInvitations: null == groupInvitations ? _self.groupInvitations : groupInvitations // ignore: cast_nullable_to_non_nullable
 as bool,invitationAccepted: null == invitationAccepted ? _self.invitationAccepted : invitationAccepted // ignore: cast_nullable_to_non_nullable
@@ -323,6 +327,7 @@ as Map<String, bool>,trainingSessionCreated: null == trainingSessionCreated ? _s
 as bool,trainingMinParticipantsReached: null == trainingMinParticipantsReached ? _self.trainingMinParticipantsReached : trainingMinParticipantsReached // ignore: cast_nullable_to_non_nullable
 as bool,trainingFeedbackReceived: null == trainingFeedbackReceived ? _self.trainingFeedbackReceived : trainingFeedbackReceived // ignore: cast_nullable_to_non_nullable
 as bool,trainingSessionCancelled: null == trainingSessionCancelled ? _self.trainingSessionCancelled : trainingSessionCancelled // ignore: cast_nullable_to_non_nullable
+as bool,championship: null == championship ? _self.championship : championship // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/features/notifications/domain/entities/notification_preferences_entity.g.dart
+++ b/lib/features/notifications/domain/entities/notification_preferences_entity.g.dart
@@ -31,6 +31,7 @@ _NotificationPreferencesEntity _$NotificationPreferencesEntityFromJson(
       json['trainingMinParticipantsReached'] as bool? ?? true,
   trainingFeedbackReceived: json['trainingFeedbackReceived'] as bool? ?? true,
   trainingSessionCancelled: json['trainingSessionCancelled'] as bool? ?? true,
+  championship: json['championship'] as bool? ?? true,
 );
 
 Map<String, dynamic> _$NotificationPreferencesEntityToJson(
@@ -53,4 +54,5 @@ Map<String, dynamic> _$NotificationPreferencesEntityToJson(
   'trainingMinParticipantsReached': instance.trainingMinParticipantsReached,
   'trainingFeedbackReceived': instance.trainingFeedbackReceived,
   'trainingSessionCancelled': instance.trainingSessionCancelled,
+  'championship': instance.championship,
 };

--- a/lib/features/notifications/presentation/bloc/notification_bloc.dart
+++ b/lib/features/notifications/presentation/bloc/notification_bloc.dart
@@ -66,6 +66,11 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
           emit,
           (prefs) => prefs.copyWith(trainingSessionCancelled: enabled),
         ),
+        // Championship notification toggle handler (Story 30.13)
+        toggleChampionship: (enabled) => _handleToggle(
+          emit,
+          (prefs) => prefs.copyWith(championship: enabled),
+        ),
       );
     });
   }

--- a/lib/features/notifications/presentation/bloc/notification_event.dart
+++ b/lib/features/notifications/presentation/bloc/notification_event.dart
@@ -41,4 +41,7 @@ abstract class NotificationEvent with _$NotificationEvent {
       _ToggleTrainingFeedbackReceived;
   const factory NotificationEvent.toggleTrainingSessionCancelled(bool enabled) =
       _ToggleTrainingSessionCancelled;
+  // Championship notification toggle event (Story 30.13)
+  const factory NotificationEvent.toggleChampionship(bool enabled) =
+      _ToggleChampionship;
 }

--- a/lib/features/notifications/presentation/bloc/notification_event.freezed.dart
+++ b/lib/features/notifications/presentation/bloc/notification_event.freezed.dart
@@ -55,7 +55,7 @@ extension NotificationEventPatterns on NotificationEvent {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _LoadPreferences value)?  loadPreferences,TResult Function( _UpdatePreferences value)?  updatePreferences,TResult Function( _ToggleGroupInvitations value)?  toggleGroupInvitations,TResult Function( _ToggleInvitationAccepted value)?  toggleInvitationAccepted,TResult Function( _ToggleGameCreated value)?  toggleGameCreated,TResult Function( _ToggleMemberJoined value)?  toggleMemberJoined,TResult Function( _ToggleMemberLeft value)?  toggleMemberLeft,TResult Function( _ToggleRoleChanged value)?  toggleRoleChanged,TResult Function( _ToggleQuietHours value)?  toggleQuietHours,TResult Function( _ToggleGroupSpecific value)?  toggleGroupSpecific,TResult Function( _ToggleTrainingSessionCreated value)?  toggleTrainingSessionCreated,TResult Function( _ToggleTrainingMinParticipantsReached value)?  toggleTrainingMinParticipantsReached,TResult Function( _ToggleTrainingFeedbackReceived value)?  toggleTrainingFeedbackReceived,TResult Function( _ToggleTrainingSessionCancelled value)?  toggleTrainingSessionCancelled,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _LoadPreferences value)?  loadPreferences,TResult Function( _UpdatePreferences value)?  updatePreferences,TResult Function( _ToggleGroupInvitations value)?  toggleGroupInvitations,TResult Function( _ToggleInvitationAccepted value)?  toggleInvitationAccepted,TResult Function( _ToggleGameCreated value)?  toggleGameCreated,TResult Function( _ToggleMemberJoined value)?  toggleMemberJoined,TResult Function( _ToggleMemberLeft value)?  toggleMemberLeft,TResult Function( _ToggleRoleChanged value)?  toggleRoleChanged,TResult Function( _ToggleQuietHours value)?  toggleQuietHours,TResult Function( _ToggleGroupSpecific value)?  toggleGroupSpecific,TResult Function( _ToggleTrainingSessionCreated value)?  toggleTrainingSessionCreated,TResult Function( _ToggleTrainingMinParticipantsReached value)?  toggleTrainingMinParticipantsReached,TResult Function( _ToggleTrainingFeedbackReceived value)?  toggleTrainingFeedbackReceived,TResult Function( _ToggleTrainingSessionCancelled value)?  toggleTrainingSessionCancelled,TResult Function( _ToggleChampionship value)?  toggleChampionship,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case _LoadPreferences() when loadPreferences != null:
@@ -72,7 +72,8 @@ return toggleGroupSpecific(_that);case _ToggleTrainingSessionCreated() when togg
 return toggleTrainingSessionCreated(_that);case _ToggleTrainingMinParticipantsReached() when toggleTrainingMinParticipantsReached != null:
 return toggleTrainingMinParticipantsReached(_that);case _ToggleTrainingFeedbackReceived() when toggleTrainingFeedbackReceived != null:
 return toggleTrainingFeedbackReceived(_that);case _ToggleTrainingSessionCancelled() when toggleTrainingSessionCancelled != null:
-return toggleTrainingSessionCancelled(_that);case _:
+return toggleTrainingSessionCancelled(_that);case _ToggleChampionship() when toggleChampionship != null:
+return toggleChampionship(_that);case _:
   return orElse();
 
 }
@@ -90,7 +91,7 @@ return toggleTrainingSessionCancelled(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _LoadPreferences value)  loadPreferences,required TResult Function( _UpdatePreferences value)  updatePreferences,required TResult Function( _ToggleGroupInvitations value)  toggleGroupInvitations,required TResult Function( _ToggleInvitationAccepted value)  toggleInvitationAccepted,required TResult Function( _ToggleGameCreated value)  toggleGameCreated,required TResult Function( _ToggleMemberJoined value)  toggleMemberJoined,required TResult Function( _ToggleMemberLeft value)  toggleMemberLeft,required TResult Function( _ToggleRoleChanged value)  toggleRoleChanged,required TResult Function( _ToggleQuietHours value)  toggleQuietHours,required TResult Function( _ToggleGroupSpecific value)  toggleGroupSpecific,required TResult Function( _ToggleTrainingSessionCreated value)  toggleTrainingSessionCreated,required TResult Function( _ToggleTrainingMinParticipantsReached value)  toggleTrainingMinParticipantsReached,required TResult Function( _ToggleTrainingFeedbackReceived value)  toggleTrainingFeedbackReceived,required TResult Function( _ToggleTrainingSessionCancelled value)  toggleTrainingSessionCancelled,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _LoadPreferences value)  loadPreferences,required TResult Function( _UpdatePreferences value)  updatePreferences,required TResult Function( _ToggleGroupInvitations value)  toggleGroupInvitations,required TResult Function( _ToggleInvitationAccepted value)  toggleInvitationAccepted,required TResult Function( _ToggleGameCreated value)  toggleGameCreated,required TResult Function( _ToggleMemberJoined value)  toggleMemberJoined,required TResult Function( _ToggleMemberLeft value)  toggleMemberLeft,required TResult Function( _ToggleRoleChanged value)  toggleRoleChanged,required TResult Function( _ToggleQuietHours value)  toggleQuietHours,required TResult Function( _ToggleGroupSpecific value)  toggleGroupSpecific,required TResult Function( _ToggleTrainingSessionCreated value)  toggleTrainingSessionCreated,required TResult Function( _ToggleTrainingMinParticipantsReached value)  toggleTrainingMinParticipantsReached,required TResult Function( _ToggleTrainingFeedbackReceived value)  toggleTrainingFeedbackReceived,required TResult Function( _ToggleTrainingSessionCancelled value)  toggleTrainingSessionCancelled,required TResult Function( _ToggleChampionship value)  toggleChampionship,}){
 final _that = this;
 switch (_that) {
 case _LoadPreferences():
@@ -107,7 +108,8 @@ return toggleGroupSpecific(_that);case _ToggleTrainingSessionCreated():
 return toggleTrainingSessionCreated(_that);case _ToggleTrainingMinParticipantsReached():
 return toggleTrainingMinParticipantsReached(_that);case _ToggleTrainingFeedbackReceived():
 return toggleTrainingFeedbackReceived(_that);case _ToggleTrainingSessionCancelled():
-return toggleTrainingSessionCancelled(_that);case _:
+return toggleTrainingSessionCancelled(_that);case _ToggleChampionship():
+return toggleChampionship(_that);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -124,7 +126,7 @@ return toggleTrainingSessionCancelled(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _LoadPreferences value)?  loadPreferences,TResult? Function( _UpdatePreferences value)?  updatePreferences,TResult? Function( _ToggleGroupInvitations value)?  toggleGroupInvitations,TResult? Function( _ToggleInvitationAccepted value)?  toggleInvitationAccepted,TResult? Function( _ToggleGameCreated value)?  toggleGameCreated,TResult? Function( _ToggleMemberJoined value)?  toggleMemberJoined,TResult? Function( _ToggleMemberLeft value)?  toggleMemberLeft,TResult? Function( _ToggleRoleChanged value)?  toggleRoleChanged,TResult? Function( _ToggleQuietHours value)?  toggleQuietHours,TResult? Function( _ToggleGroupSpecific value)?  toggleGroupSpecific,TResult? Function( _ToggleTrainingSessionCreated value)?  toggleTrainingSessionCreated,TResult? Function( _ToggleTrainingMinParticipantsReached value)?  toggleTrainingMinParticipantsReached,TResult? Function( _ToggleTrainingFeedbackReceived value)?  toggleTrainingFeedbackReceived,TResult? Function( _ToggleTrainingSessionCancelled value)?  toggleTrainingSessionCancelled,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _LoadPreferences value)?  loadPreferences,TResult? Function( _UpdatePreferences value)?  updatePreferences,TResult? Function( _ToggleGroupInvitations value)?  toggleGroupInvitations,TResult? Function( _ToggleInvitationAccepted value)?  toggleInvitationAccepted,TResult? Function( _ToggleGameCreated value)?  toggleGameCreated,TResult? Function( _ToggleMemberJoined value)?  toggleMemberJoined,TResult? Function( _ToggleMemberLeft value)?  toggleMemberLeft,TResult? Function( _ToggleRoleChanged value)?  toggleRoleChanged,TResult? Function( _ToggleQuietHours value)?  toggleQuietHours,TResult? Function( _ToggleGroupSpecific value)?  toggleGroupSpecific,TResult? Function( _ToggleTrainingSessionCreated value)?  toggleTrainingSessionCreated,TResult? Function( _ToggleTrainingMinParticipantsReached value)?  toggleTrainingMinParticipantsReached,TResult? Function( _ToggleTrainingFeedbackReceived value)?  toggleTrainingFeedbackReceived,TResult? Function( _ToggleTrainingSessionCancelled value)?  toggleTrainingSessionCancelled,TResult? Function( _ToggleChampionship value)?  toggleChampionship,}){
 final _that = this;
 switch (_that) {
 case _LoadPreferences() when loadPreferences != null:
@@ -141,7 +143,8 @@ return toggleGroupSpecific(_that);case _ToggleTrainingSessionCreated() when togg
 return toggleTrainingSessionCreated(_that);case _ToggleTrainingMinParticipantsReached() when toggleTrainingMinParticipantsReached != null:
 return toggleTrainingMinParticipantsReached(_that);case _ToggleTrainingFeedbackReceived() when toggleTrainingFeedbackReceived != null:
 return toggleTrainingFeedbackReceived(_that);case _ToggleTrainingSessionCancelled() when toggleTrainingSessionCancelled != null:
-return toggleTrainingSessionCancelled(_that);case _:
+return toggleTrainingSessionCancelled(_that);case _ToggleChampionship() when toggleChampionship != null:
+return toggleChampionship(_that);case _:
   return null;
 
 }
@@ -158,7 +161,7 @@ return toggleTrainingSessionCancelled(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  loadPreferences,TResult Function( NotificationPreferencesEntity preferences)?  updatePreferences,TResult Function( bool enabled)?  toggleGroupInvitations,TResult Function( bool enabled)?  toggleInvitationAccepted,TResult Function( bool enabled)?  toggleGameCreated,TResult Function( bool enabled)?  toggleMemberJoined,TResult Function( bool enabled)?  toggleMemberLeft,TResult Function( bool enabled)?  toggleRoleChanged,TResult Function( bool enabled,  String? start,  String? end)?  toggleQuietHours,TResult Function( String groupId,  bool enabled)?  toggleGroupSpecific,TResult Function( bool enabled)?  toggleTrainingSessionCreated,TResult Function( bool enabled)?  toggleTrainingMinParticipantsReached,TResult Function( bool enabled)?  toggleTrainingFeedbackReceived,TResult Function( bool enabled)?  toggleTrainingSessionCancelled,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  loadPreferences,TResult Function( NotificationPreferencesEntity preferences)?  updatePreferences,TResult Function( bool enabled)?  toggleGroupInvitations,TResult Function( bool enabled)?  toggleInvitationAccepted,TResult Function( bool enabled)?  toggleGameCreated,TResult Function( bool enabled)?  toggleMemberJoined,TResult Function( bool enabled)?  toggleMemberLeft,TResult Function( bool enabled)?  toggleRoleChanged,TResult Function( bool enabled,  String? start,  String? end)?  toggleQuietHours,TResult Function( String groupId,  bool enabled)?  toggleGroupSpecific,TResult Function( bool enabled)?  toggleTrainingSessionCreated,TResult Function( bool enabled)?  toggleTrainingMinParticipantsReached,TResult Function( bool enabled)?  toggleTrainingFeedbackReceived,TResult Function( bool enabled)?  toggleTrainingSessionCancelled,TResult Function( bool enabled)?  toggleChampionship,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _LoadPreferences() when loadPreferences != null:
 return loadPreferences();case _UpdatePreferences() when updatePreferences != null:
@@ -174,7 +177,8 @@ return toggleGroupSpecific(_that.groupId,_that.enabled);case _ToggleTrainingSess
 return toggleTrainingSessionCreated(_that.enabled);case _ToggleTrainingMinParticipantsReached() when toggleTrainingMinParticipantsReached != null:
 return toggleTrainingMinParticipantsReached(_that.enabled);case _ToggleTrainingFeedbackReceived() when toggleTrainingFeedbackReceived != null:
 return toggleTrainingFeedbackReceived(_that.enabled);case _ToggleTrainingSessionCancelled() when toggleTrainingSessionCancelled != null:
-return toggleTrainingSessionCancelled(_that.enabled);case _:
+return toggleTrainingSessionCancelled(_that.enabled);case _ToggleChampionship() when toggleChampionship != null:
+return toggleChampionship(_that.enabled);case _:
   return orElse();
 
 }
@@ -192,7 +196,7 @@ return toggleTrainingSessionCancelled(_that.enabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  loadPreferences,required TResult Function( NotificationPreferencesEntity preferences)  updatePreferences,required TResult Function( bool enabled)  toggleGroupInvitations,required TResult Function( bool enabled)  toggleInvitationAccepted,required TResult Function( bool enabled)  toggleGameCreated,required TResult Function( bool enabled)  toggleMemberJoined,required TResult Function( bool enabled)  toggleMemberLeft,required TResult Function( bool enabled)  toggleRoleChanged,required TResult Function( bool enabled,  String? start,  String? end)  toggleQuietHours,required TResult Function( String groupId,  bool enabled)  toggleGroupSpecific,required TResult Function( bool enabled)  toggleTrainingSessionCreated,required TResult Function( bool enabled)  toggleTrainingMinParticipantsReached,required TResult Function( bool enabled)  toggleTrainingFeedbackReceived,required TResult Function( bool enabled)  toggleTrainingSessionCancelled,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  loadPreferences,required TResult Function( NotificationPreferencesEntity preferences)  updatePreferences,required TResult Function( bool enabled)  toggleGroupInvitations,required TResult Function( bool enabled)  toggleInvitationAccepted,required TResult Function( bool enabled)  toggleGameCreated,required TResult Function( bool enabled)  toggleMemberJoined,required TResult Function( bool enabled)  toggleMemberLeft,required TResult Function( bool enabled)  toggleRoleChanged,required TResult Function( bool enabled,  String? start,  String? end)  toggleQuietHours,required TResult Function( String groupId,  bool enabled)  toggleGroupSpecific,required TResult Function( bool enabled)  toggleTrainingSessionCreated,required TResult Function( bool enabled)  toggleTrainingMinParticipantsReached,required TResult Function( bool enabled)  toggleTrainingFeedbackReceived,required TResult Function( bool enabled)  toggleTrainingSessionCancelled,required TResult Function( bool enabled)  toggleChampionship,}) {final _that = this;
 switch (_that) {
 case _LoadPreferences():
 return loadPreferences();case _UpdatePreferences():
@@ -208,7 +212,8 @@ return toggleGroupSpecific(_that.groupId,_that.enabled);case _ToggleTrainingSess
 return toggleTrainingSessionCreated(_that.enabled);case _ToggleTrainingMinParticipantsReached():
 return toggleTrainingMinParticipantsReached(_that.enabled);case _ToggleTrainingFeedbackReceived():
 return toggleTrainingFeedbackReceived(_that.enabled);case _ToggleTrainingSessionCancelled():
-return toggleTrainingSessionCancelled(_that.enabled);case _:
+return toggleTrainingSessionCancelled(_that.enabled);case _ToggleChampionship():
+return toggleChampionship(_that.enabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -225,7 +230,7 @@ return toggleTrainingSessionCancelled(_that.enabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  loadPreferences,TResult? Function( NotificationPreferencesEntity preferences)?  updatePreferences,TResult? Function( bool enabled)?  toggleGroupInvitations,TResult? Function( bool enabled)?  toggleInvitationAccepted,TResult? Function( bool enabled)?  toggleGameCreated,TResult? Function( bool enabled)?  toggleMemberJoined,TResult? Function( bool enabled)?  toggleMemberLeft,TResult? Function( bool enabled)?  toggleRoleChanged,TResult? Function( bool enabled,  String? start,  String? end)?  toggleQuietHours,TResult? Function( String groupId,  bool enabled)?  toggleGroupSpecific,TResult? Function( bool enabled)?  toggleTrainingSessionCreated,TResult? Function( bool enabled)?  toggleTrainingMinParticipantsReached,TResult? Function( bool enabled)?  toggleTrainingFeedbackReceived,TResult? Function( bool enabled)?  toggleTrainingSessionCancelled,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  loadPreferences,TResult? Function( NotificationPreferencesEntity preferences)?  updatePreferences,TResult? Function( bool enabled)?  toggleGroupInvitations,TResult? Function( bool enabled)?  toggleInvitationAccepted,TResult? Function( bool enabled)?  toggleGameCreated,TResult? Function( bool enabled)?  toggleMemberJoined,TResult? Function( bool enabled)?  toggleMemberLeft,TResult? Function( bool enabled)?  toggleRoleChanged,TResult? Function( bool enabled,  String? start,  String? end)?  toggleQuietHours,TResult? Function( String groupId,  bool enabled)?  toggleGroupSpecific,TResult? Function( bool enabled)?  toggleTrainingSessionCreated,TResult? Function( bool enabled)?  toggleTrainingMinParticipantsReached,TResult? Function( bool enabled)?  toggleTrainingFeedbackReceived,TResult? Function( bool enabled)?  toggleTrainingSessionCancelled,TResult? Function( bool enabled)?  toggleChampionship,}) {final _that = this;
 switch (_that) {
 case _LoadPreferences() when loadPreferences != null:
 return loadPreferences();case _UpdatePreferences() when updatePreferences != null:
@@ -241,7 +246,8 @@ return toggleGroupSpecific(_that.groupId,_that.enabled);case _ToggleTrainingSess
 return toggleTrainingSessionCreated(_that.enabled);case _ToggleTrainingMinParticipantsReached() when toggleTrainingMinParticipantsReached != null:
 return toggleTrainingMinParticipantsReached(_that.enabled);case _ToggleTrainingFeedbackReceived() when toggleTrainingFeedbackReceived != null:
 return toggleTrainingFeedbackReceived(_that.enabled);case _ToggleTrainingSessionCancelled() when toggleTrainingSessionCancelled != null:
-return toggleTrainingSessionCancelled(_that.enabled);case _:
+return toggleTrainingSessionCancelled(_that.enabled);case _ToggleChampionship() when toggleChampionship != null:
+return toggleChampionship(_that.enabled);case _:
   return null;
 
 }
@@ -1146,6 +1152,72 @@ class __$ToggleTrainingSessionCancelledCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
   return _then(_ToggleTrainingSessionCancelled(
+null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class _ToggleChampionship implements NotificationEvent {
+  const _ToggleChampionship(this.enabled);
+  
+
+ final  bool enabled;
+
+/// Create a copy of NotificationEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ToggleChampionshipCopyWith<_ToggleChampionship> get copyWith => __$ToggleChampionshipCopyWithImpl<_ToggleChampionship>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ToggleChampionship&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString() {
+  return 'NotificationEvent.toggleChampionship(enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ToggleChampionshipCopyWith<$Res> implements $NotificationEventCopyWith<$Res> {
+  factory _$ToggleChampionshipCopyWith(_ToggleChampionship value, $Res Function(_ToggleChampionship) _then) = __$ToggleChampionshipCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$ToggleChampionshipCopyWithImpl<$Res>
+    implements _$ToggleChampionshipCopyWith<$Res> {
+  __$ToggleChampionshipCopyWithImpl(this._self, this._then);
+
+  final _ToggleChampionship _self;
+  final $Res Function(_ToggleChampionship) _then;
+
+/// Create a copy of NotificationEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
+  return _then(_ToggleChampionship(
 null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));

--- a/lib/features/notifications/presentation/pages/notification_settings_page.dart
+++ b/lib/features/notifications/presentation/pages/notification_settings_page.dart
@@ -142,6 +142,23 @@ class _NotificationSettingsView extends StatelessWidget {
 
                 const Divider(height: 32),
 
+                // Championships Section (Story 30.13)
+                _SectionHeader(title: 'Championships'),
+                SwitchListTile(
+                  title: const Text('Championship Events'),
+                  subtitle: const Text(
+                    'Result submissions, verifications, disputes and deadline warnings',
+                  ),
+                  value: preferences.championship,
+                  onChanged: (value) {
+                    context.read<NotificationBloc>().add(
+                      NotificationEvent.toggleChampionship(value),
+                    );
+                  },
+                ),
+
+                const Divider(height: 32),
+
                 // Admin Notifications Section
                 _SectionHeader(title: 'Admin Notifications'),
                 const Padding(

--- a/test/widget/features/notifications/presentation/pages/notification_settings_page_test.dart
+++ b/test/widget/features/notifications/presentation/pages/notification_settings_page_test.dart
@@ -165,8 +165,8 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      // Scroll down to find Admin Notifications section (after Training Sessions)
-      await tester.drag(find.byType(ListView), const Offset(0, -400));
+      // Scroll down to find Admin Notifications section (after Training Sessions + Championships)
+      await tester.drag(find.byType(ListView), const Offset(0, -700));
       await tester.pumpAndSettle();
 
       // Assert
@@ -218,8 +218,8 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      // Scroll down to find Admin Notifications section (after Training Sessions)
-      await tester.drag(find.byType(ListView), const Offset(0, -400));
+      // Scroll down to find Admin Notifications section (after Training Sessions + Championships)
+      await tester.drag(find.byType(ListView), const Offset(0, -700));
       await tester.pumpAndSettle();
 
       // Assert


### PR DESCRIPTION
## Summary

- **3 Firestore `onUpdate` triggers** on `championships/{id}/matches/{id}`: notify opposing team on result submission, notify admins on dispute, notify both teams on admin decision
- **Verified notification** added to `onChampionshipMatchVerified`: both teams notified when result is confirmed
- **Daily Pub/Sub scheduled function** (`checkChampionshipDeadlines`): sends personalised 48h deadline warnings per team with idempotency flag (`deadlineWarning48hSent`) to prevent duplicate sends
- **Notification preference** `championship` (default `true`) added to `NotificationPreferencesEntity`, BLoC, and Settings UI (Championships section between Training and Admin sections)
- **Stale token cleanup**: failed FCM responses remove expired tokens via `FieldValue.arrayRemove`

## Test plan

- [x] 11 CF unit tests for `championshipNotifications.ts` handlers (all branches)
- [x] 5 CF unit tests for `checkChampionshipDeadlines.ts` (no championships, both teams, idempotency, empty team, multiple championships)
- [x] CF full suite: 739/739 passing
- [x] Widget tests for `NotificationSettingsPage` updated for new section: 14/14 passing
- [x] Full Flutter suite: 3720/3720 passing
- [x] `flutter analyze` clean
- [x] TypeScript compiles clean