### PR TITLE
fix(nav): show full 'Championship' label in bottom nav

### DIFF
--- a/lib/core/presentation/widgets/global_bottom_nav_bar.dart
+++ b/lib/core/presentation/widgets/global_bottom_nav_bar.dart
@@ -27,8 +27,10 @@ class GlobalBottomNavBar extends StatelessWidget {
       backgroundColor: AppColors.bottomNavBackground,
       selectedItemColor: AppColors.navLabelColor,
       unselectedItemColor: AppColors.navLabelColor,
-      selectedIconTheme: const IconThemeData(color: AppColors.primary),
-      unselectedIconTheme: const IconThemeData(color: AppColors.navLabelColor),
+      selectedIconTheme: const IconThemeData(color: AppColors.primary, size: 22),
+      unselectedIconTheme: const IconThemeData(color: AppColors.navLabelColor, size: 22),
+      selectedFontSize: 10,
+      unselectedFontSize: 10,
       currentIndex: selectedIndex,
       onTap: onTabSelected,
       items: [


### PR DESCRIPTION
## Problem
The bottom nav bar truncates 'Championship' to 'Champion…' on standard phone widths. With 5 equal-width tabs on a 375px screen each tab gets ~75px — not enough for 'Championship' at the default 12px label size.

## Fix
- Icon size: 24 → 22px (via `selectedIconTheme` / `unselectedIconTheme`)
- Label size: 14/12 → 10/10px (via `selectedFontSize` / `unselectedFontSize`)

The change is barely perceptible visually but gives enough horizontal room for the full label on all standard phone sizes.

## Test plan
- [ ] Bottom nav shows 'Championship' (not 'Champion…') on iPhone SE, iPhone 16, iPhone 16 Plus
- [ ] All other labels (Home, Stats, Groups, Community) still fully visible
- [ ] Selected/unselected icon colours unchanged
- [ ] CI passes