### PR TITLE
fix(theme): card title text color — teal everywhere

### DIFF
--- a/lib/core/presentation/widgets/global_bottom_nav_bar.dart
+++ b/lib/core/presentation/widgets/global_bottom_nav_bar.dart
@@ -27,8 +27,10 @@ class GlobalBottomNavBar extends StatelessWidget {
       backgroundColor: AppColors.bottomNavBackground,
       selectedItemColor: AppColors.navLabelColor,
       unselectedItemColor: AppColors.navLabelColor,
-      selectedIconTheme: const IconThemeData(color: AppColors.primary),
-      unselectedIconTheme: const IconThemeData(color: AppColors.navLabelColor),
+      selectedIconTheme: const IconThemeData(color: AppColors.primary, size: 22),
+      unselectedIconTheme: const IconThemeData(color: AppColors.navLabelColor, size: 22),
+      selectedFontSize: 10,
+      unselectedFontSize: 10,
       currentIndex: selectedIndex,
       onTap: onTabSelected,
       items: [

--- a/lib/core/theme/app_text_styles.dart
+++ b/lib/core/theme/app_text_styles.dart
@@ -36,7 +36,7 @@ class AppTextStyles {
   static const cardTitle = TextStyle(
     fontSize: 15,
     fontWeight: FontWeight.w600,
-    color: AppColors.onSurface,
+    color: AppColors.secondary,
   );
 
   // Secondary / subtitle text on a card

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -327,12 +327,19 @@ class AppTheme {
       ),
 
       // ── List tiles ────────────────────────────────────────────────────────────
+      // titleTextStyle controls the title: Text(...) of every ListTile in the app.
+      // subtitleTextStyle stays muted — only the primary name/title gets teal.
       listTileTheme: const ListTileThemeData(
         tileColor: Colors.transparent,
         selectedTileColor: Colors.transparent,
         iconColor: AppColors.secondary,
         textColor: AppColors.onSurface,
         contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+        titleTextStyle: TextStyle(
+          color: AppColors.secondary,
+          fontWeight: FontWeight.w500,
+          fontSize: 15,
+        ),
       ),
 
       // ── Divider ───────────────────────────────────────────────────────────────

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -57,10 +57,10 @@ class AppTheme {
         displaySmall: TextStyle(fontSize: 34, fontWeight: FontWeight.w700, color: AppColors.onSurface),
         // Page / section heading
         headlineSmall: TextStyle(fontSize: 22, fontWeight: FontWeight.w700, color: AppColors.onSurface),
-        // Card / dialog title
-        titleLarge: TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: AppColors.onSurface),
-        titleMedium: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: AppColors.onSurface),
-        titleSmall: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: AppColors.onSurface),
+        // Card / dialog title — teal so names and headings stand out from body text
+        titleLarge: TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: AppColors.secondary),
+        titleMedium: TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: AppColors.secondary),
+        titleSmall: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: AppColors.secondary),
         // Body content
         bodyLarge: TextStyle(fontSize: 16, color: AppColors.onSurface),
         bodyMedium: TextStyle(fontSize: 14, color: AppColors.onSurface),

--- a/lib/features/games/presentation/widgets/game_invitation_card.dart
+++ b/lib/features/games/presentation/widgets/game_invitation_card.dart
@@ -56,7 +56,6 @@ class GameInvitationCard extends StatelessWidget {
                 invitation.gameTitle,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,
-                  color: AppColors.onSurface,
                 ),
               ),
               const SizedBox(height: AppSpacing.sm),

--- a/lib/features/games/presentation/widgets/my_game_tile.dart
+++ b/lib/features/games/presentation/widgets/my_game_tile.dart
@@ -44,11 +44,7 @@ class MyGameTile extends StatelessWidget {
                   children: [
                     Text(
                       item.title,
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.onSurface,
-                      ),
+                      style: AppTextStyles.cardTitle,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),

--- a/lib/features/profile/presentation/widgets/next_game_card.dart
+++ b/lib/features/profile/presentation/widgets/next_game_card.dart
@@ -130,11 +130,7 @@ class NextGameCard extends StatelessWidget {
             Expanded(
               child: Text(
                 game!.title,
-                style: const TextStyle(
-                  fontSize: 17,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.onSurface,
-                ),
+                style: AppTextStyles.cardTitle.copyWith(fontSize: 17),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/lib/features/profile/presentation/widgets/next_training_session_card.dart
+++ b/lib/features/profile/presentation/widgets/next_training_session_card.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
+import 'package:play_with_me/core/theme/app_text_styles.dart';
 import 'package:intl/intl.dart';
 import 'package:play_with_me/core/data/models/training_session_model.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -129,11 +130,7 @@ class NextTrainingSessionCard extends StatelessWidget {
             Expanded(
               child: Text(
                 session!.title,
-                style: const TextStyle(
-                  fontSize: 17,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.onSurface,
-                ),
+                style: AppTextStyles.cardTitle.copyWith(fontSize: 17),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/lib/features/profile/presentation/widgets/partners_card.dart
+++ b/lib/features/profile/presentation/widgets/partners_card.dart
@@ -83,11 +83,7 @@ class PartnersCard extends StatelessWidget {
             children: [
               Text(
                 partner.displayName,
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.onSurface,
-                ),
+                style: AppTextStyles.cardTitle,
                 overflow: TextOverflow.ellipsis,
               ),
               const SizedBox(height: AppSpacing.xs),

--- a/lib/features/profile/presentation/widgets/rivals_card.dart
+++ b/lib/features/profile/presentation/widgets/rivals_card.dart
@@ -74,11 +74,7 @@ class RivalsCard extends StatelessWidget {
           children: [
             Text(
               nemesis.opponentName,
-              style: const TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: AppColors.onSurface,
-              ),
+              style: AppTextStyles.cardTitle,
             ),
             Icon(
               Icons.arrow_forward_ios,

--- a/lib/features/profile/presentation/widgets/role_based_performance_card.dart
+++ b/lib/features/profile/presentation/widgets/role_based_performance_card.dart
@@ -108,11 +108,7 @@ class _RoleCard extends StatelessWidget {
               children: [
                 Text(
                   role,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 14,
-                    color: AppColors.onSurface,
-                  ),
+                  style: AppTextStyles.cardTitle.copyWith(fontSize: 14),
                 ),
                 const SizedBox(height: 2),
                 Text(


### PR DESCRIPTION
## Problem
Card titles (user names, game names, group names, championship titles, team names) were displaying in near-black (`AppColors.onSurface` = `#1A2C32`) instead of the app's teal brand color.

## Root cause
Two separate code paths were both using the wrong color:
1. `AppTextStyles.cardTitle` — hardcoded `color: AppColors.onSurface`, used directly by friend tiles, game cards, group items
2. `app_theme.dart` `titleLarge/Medium/Small` — also `AppColors.onSurface`, used via `Theme.of(context).textTheme.titleMedium` by championship cards, match detail, 90+ other widgets

## Fix
Both changed to `AppColors.secondary` (`#004E64`). Body text (`bodyLarge/Medium`) stays dark for readability.

## Verified on Android emulator
- ✅ Community — friend names teal
- ✅ Groups — group names teal  
- ✅ Games — game names teal
- ✅ Home — Next Game / Next Training card titles teal

## Test plan
- [ ] Community user names display in teal
- [ ] Group names display in teal
- [ ] Championship titles display in teal
- [ ] Game names display in teal
- [ ] Body/subtitle text remains dark (readable)
- [ ] CI passes