### PR TITLE
fix(ui): match FAB styles + invite card width to member cards

### DIFF
--- a/lib/features/friends/presentation/pages/my_community_page.dart
+++ b/lib/features/friends/presentation/pages/my_community_page.dart
@@ -301,6 +301,8 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
   Widget _buildAddFriendButton(BuildContext context, AppLocalizations l10n) {
     return FloatingActionButton.extended(
       heroTag: 'add_friend_fab', // Unique tag to avoid Hero conflicts
+      backgroundColor: AppColors.primary.withValues(alpha: 0.25),
+      foregroundColor: AppColors.secondary,
       elevation: 0,
       highlightElevation: 0,
       onPressed: () {

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -613,6 +613,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                     if (index == 1) {
                       final l10n = AppLocalizations.of(context)!;
                       return AccentCard(
+                        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
                         onTap: () => _navigateToInvitePage(context),
                         child: Row(
                           children: [
@@ -632,6 +633,7 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                       final isGenerating =
                           inviteLinkState is GroupInviteLinkLoading;
                       return AccentCard(
+                        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
                         onTap: isGenerating ? null : () => context.read<GroupInviteLinkBloc>().add(GenerateInvite(groupId: widget.groupId)),
                         child: Row(
                           children: [


### PR DESCRIPTION
## Changes

### FABs — unified style
- **Add Friend** FAB now matches **Create Group** FAB exactly:
  `backgroundColor: AppColors.primary.withValues(alpha: 0.25)`
  `foregroundColor: AppColors.secondary`
  Previously Add Friend had no explicit colors, showing the theme default.

### Group Details — Invite cards width
- **Invite Member** and **Invite with Link** `AccentCard`s were missing a horizontal margin, making them stretch edge-to-edge while member list cards have 16px margins.
- Added `margin: EdgeInsets.symmetric(horizontal: 16, vertical: 5)` to both — matches member list card margins exactly.

## Test plan
- [ ] Create Group FAB and Add Friend FAB look identical (translucent gold, teal text/icon)
- [ ] In Group Details → Members tab: Invite Member and Invite with Link cards are the same width as member rows
- [ ] CI passes