### PR TITLE
refactor(l10n): rename Championship → League (all 5 languages)

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -576,7 +576,6 @@
   "@loadOlderActivities": {
     "description": "Button label to load activities older than 90 days in the group details activity feed"
   },
-
   "genderSelectionTitle": "Geschlecht",
   "@genderSelectionTitle": {
     "description": "Title of the gender selection onboarding screen"
@@ -605,7 +604,6 @@
   "@genderSelectionError": {
     "description": "Error message shown when saving gender fails"
   },
-
   "deleteAccount": "Konto löschen",
   "deleteAccountConfirmTitle": "Konto löschen?",
   "deleteAccountConfirmMessage": "Ihr Konto und alle zugehörigen Daten werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -620,7 +618,6 @@
   "@registrationGenderTooltip": {
     "description": "Tooltip explaining why gender is asked during registration"
   },
-
   "inviteGuestPlayers": "Personen aus anderen Gruppen einladen",
   "@inviteGuestPlayers": {
     "description": "Title of the invite guest players bottom sheet (Story 28.6)"
@@ -643,7 +640,13 @@
   },
   "inviteGroupSuccess": "Gruppe erfolgreich eingeladen",
   "groupMembersCount": "{count, plural, =1{1 Person} other{{count} Personen}}",
-  "@groupMembersCount": {"placeholders": {"count": {"type": "int"}}},
+  "@groupMembersCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "invitedLabel": "Eingeladen",
   "invitePlayerError": "Einladung konnte nicht gesendet werden",
   "@invitePlayerError": {
@@ -665,7 +668,9 @@
   "@fromGroup": {
     "description": "Label on a game invitation card showing the source group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
   "gameInvitationAccepted": "Einladung angenommen",
@@ -680,12 +685,10 @@
   "@gameInvitationActionError": {
     "description": "Snackbar shown when accepting or declining a game invitation fails"
   },
-
   "upcoming": "Bevorstehend",
   "@upcoming": {
     "description": "Section header for upcoming games in MyGamesPage"
   },
-
   "pastGames": "Vergangene Spiele",
   "open": "Offen",
   "@open": {
@@ -694,7 +697,6 @@
   "@pastGames": {
     "description": "Section header for past games in MyGamesPage"
   },
-
   "teamsForThisGame": "Teams",
   "@teamsForThisGame": {
     "description": "Section label for per-game team picker"
@@ -707,7 +709,6 @@
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
   },
-
   "chatSectionTitle": "Chat",
   "@chatSectionTitle": {},
   "chatInputHint": "Nachricht eingeben...",
@@ -718,7 +719,6 @@
   "@chatPlayersOnly": {},
   "chatJoinToView": "Du musst dem Spiel beitreten, um den Chat zu sehen",
   "@chatJoinToView": {},
-
   "createPickupGame": "Spontanspiel erstellen",
   "@createPickupGame": {},
   "pickupGame": "Spontanspiel",
@@ -757,20 +757,20 @@
   },
   "next": "Weiter",
   "@next": {},
-  "championshipsTitle": "Meisterschaften",
+  "championshipsTitle": "Ligen",
   "championshipOpenRegistration": "Anmeldung offen",
   "championshipTeamsCount": "{count, plural, =1{1 Team angemeldet} other{{count} Teams angemeldet}}",
-  "championshipSlotsLeft": "{count, plural, =1{1 Platz frei} other{{count} Pl\u00e4tze frei}}",
+  "championshipSlotsLeft": "{count, plural, =1{1 Platz frei} other{{count} Plätze frei}}",
   "championshipDeadlineLabel": "Frist: {date}",
   "registerTeam": "Team anmelden",
   "leaveTeam": "Team verlassen",
   "leaveTeamConfirmTitle": "Team verlassen?",
-  "leaveTeamConfirmBody": "Ihr Team wird gel\u00f6scht und Ihr Platz freigegeben.",
+  "leaveTeamConfirmBody": "Ihr Team wird gelöscht und Ihr Platz freigegeben.",
   "createTeamTitle": "Team erstellen",
   "teamNameLabel": "Teamname",
-  "teamNameHint": "z.\u00a0B. Beach Wolves",
-  "selectPartnerLabel": "Partner ausw\u00e4hlen",
-  "noFriendsForPartner": "Sie haben noch keine Freunde einzuladen. F\u00fcgen Sie zuerst Freunde aus Meine Community hinzu.",
+  "teamNameHint": "z. B. Beach Wolves",
+  "selectPartnerLabel": "Partner auswählen",
+  "noFriendsForPartner": "Sie haben noch keine Freunde einzuladen. Fügen Sie zuerst Freunde aus Meine Community hinzu.",
   "teamRegisteredSuccess": "Team angemeldet!",
   "teamLeftSuccess": "Sie haben das Team verlassen.",
   "yourTeam": "Ihr Team",
@@ -804,19 +804,19 @@
   "championshipStatusBadgeActive": "Runde {current}/{total}",
   "championshipStatusBadgeCompleted": "Abgeschlossen",
   "championshipMyMatchesTab": "Meine Spiele",
-  "championshipMyMatchesEmpty": "Deine Spiele erscheinen hier, sobald die Meisterschaft beginnt.",
+  "championshipMyMatchesEmpty": "Deine Spiele erscheinen hier, sobald die Liga beginnt.",
   "championshipMyMatchesVs": "vs {opponent}",
   "championshipTabActive": "Aktiv",
   "championshipTabCompleted": "Abgeschlossen",
-  "championshipNoCompletedYet": "Noch keine abgeschlossenen Meisterschaften.",
-  "championshipNoResults": "Derzeit keine Meisterschaften.",
+  "championshipNoCompletedYet": "Noch keine abgeschlossenen Ligen.",
+  "championshipNoResults": "Derzeit keine Ligen.",
   "championshipDeadlineCountdown": "{days, plural, =1{Noch 1 Tag} other{Noch {days} Tage}}",
   "championshipTeamCountOf": "{count} / {max} Teams",
   "championshipGenderMale": "Männer",
   "championshipGenderFemale": "Frauen",
   "championshipGenderBlockNoGender": "Sie müssen Ihr Geschlecht in Ihrem Profil festlegen, um sich anzumelden.",
-  "championshipGenderBlockMaleOnly": "Diese Meisterschaft ist nur für Männer.",
-  "championshipGenderBlockFemaleOnly": "Diese Meisterschaft ist nur für Frauen.",
+  "championshipGenderBlockMaleOnly": "Diese Liga ist nur für Männer.",
+  "championshipGenderBlockFemaleOnly": "Diese Liga ist nur für Frauen.",
   "championshipCreateGenderLabel": "Geschlechtskategorie (optional)",
   "championshipDetailStandingsTab": "Tabelle",
   "championshipDetailMatchesTab": "Spiele",
@@ -846,7 +846,6 @@
   "matchDetailProposeTimeLabel": "Uhrzeit",
   "matchDetailProposeLocationLabel": "Ort (optional)",
   "matchDetailProposeConfirm": "Vorschlagen",
-
   "adminPanelTabLabel": "Admin",
   "adminPanelNoMatchesNeedingAttention": "Keine Spiele erfordern eine Admin-Entscheidung",
   "adminPanelMatchOverdue": "Überfällig",
@@ -862,8 +861,7 @@
   "adminPanelDecisionSuccess": "Entscheidung erfolgreich angewendet",
   "adminPanelDecisionErrorNotesRequired": "Notizen sind erforderlich",
   "adminPanelDecisionErrorWinnerRequired": "Wählen Sie einen Gewinner für den Walkover",
-
-  "championshipCreate": "Meisterschaft erstellen",
+  "championshipCreate": "Liga erstellen",
   "championshipCreateTitleLabel": "Titel",
   "championshipCreateTitleHint": "z.B. Sommer Open 2026",
   "championshipCreateTitleRequired": "Titel ist erforderlich",
@@ -877,33 +875,32 @@
   "championshipCreateMaxTeamsLabel": "Max. Mannschaften",
   "championshipCreateTeamSizeLabel": "Spieler pro Team",
   "championshipCreateTeamSizeOption": "{count} Spieler",
-  "championshipCreateSubmit":"Meisterschaft erstellen",
-  "championshipCreateSuccess": "Meisterschaft erstellt",
+  "championshipCreateSubmit": "Liga erstellen",
+  "championshipCreateSuccess": "Liga erstellt",
   "championshipCreateStartDateLabel": "Startdatum (optional)",
   "championshipCreateEndDateLabel": "Enddatum (optional)",
-  "championshipCreateDatePlaceholder": "Datum auswählen"
-,
+  "championshipCreateDatePlaceholder": "Datum auswählen",
   "myTeamSectionTitle": "Mein Team",
   "myTeamPartnerLabel": "Partner: {name}",
-  "leaveTeamSuccess": "Du hast die Meisterschaft verlassen.",
-  "startChampionshipButton": "Meisterschaft starten",
-  "startChampionshipConfirmTitle": "Meisterschaft starten?",
+  "leaveTeamSuccess": "Du hast die Liga verlassen.",
+  "startChampionshipButton": "Liga starten",
+  "startChampionshipConfirmTitle": "Liga starten?",
   "startChampionshipConfirmBody": "Dies generiert alle Spiele und kann nicht rückgängig gemacht werden. Stelle sicher, dass alle Teams registriert sind.",
-  "startChampionshipSuccess": "Meisterschaft gestartet — {count} Spiele erstellt.",
+  "startChampionshipSuccess": "Liga gestartet — {count} Spiele erstellt.",
   "startChampionshipStartDateLabel": "Spielfenster beginnt",
-    "teamRenameTitle": "Team umbenennen",
-    "teamRenameLabel": "Teamname",
-    "teamRenameSuccess": "Team erfolgreich umbenannt.",
-    "teamRenameError": "Team konnte nicht umbenannt werden",
-    "standingsTiebreakerTitle": "So funktioniert das Ranking",
-    "standingsTiebreakerBody": "Punkte: Sieg 2-0 = 3Pkt · Sieg 2-1 = 2Pkt · Niederlage 1-2 = 1Pkt · Niederlage 0-2 = 0Pkt\n\nKriterium 1: Direktes Duell\nKriterium 2: Satzverhältnis (Sätze gewonnen − verloren)",
+  "teamRenameTitle": "Team umbenennen",
+  "teamRenameLabel": "Teamname",
+  "teamRenameSuccess": "Team erfolgreich umbenannt.",
+  "teamRenameError": "Team konnte nicht umbenannt werden",
+  "standingsTiebreakerTitle": "So funktioniert das Ranking",
+  "standingsTiebreakerBody": "Punkte: Sieg 2-0 = 3Pkt · Sieg 2-1 = 2Pkt · Niederlage 1-2 = 1Pkt · Niederlage 0-2 = 0Pkt\n\nKriterium 1: Direktes Duell\nKriterium 2: Satzverhältnis (Sätze gewonnen − verloren)",
   "editChampionshipButton": "Details bearbeiten",
-  "editChampionshipTitle": "Meisterschaft bearbeiten",
+  "editChampionshipTitle": "Liga bearbeiten",
   "editChampionshipChangeDeadline": "Frist ändern",
   "completeChampionshipButton": "Als abgeschlossen markieren",
-  "completeChampionshipConfirmTitle": "Meisterschaft abschließen?",
+  "completeChampionshipConfirmTitle": "Liga abschließen?",
   "completeChampionshipConfirmBody": "Nur verwenden, wenn alle Spiele abgeschlossen sind. Kann nicht rückgängig gemacht werden.",
-  "completeChampionshipSuccess": "Meisterschaft als abgeschlossen markiert.",
+  "completeChampionshipSuccess": "Liga als abgeschlossen markiert.",
   "championshipChampionLabel": "Champion",
   "championshipMyMatch": "Mein Spiel",
   "matchScheduleWaitingTitle": "Warte auf Bestätigung",
@@ -912,10 +909,8 @@
   "matchScheduleConfirmBody": "{teamName} hat vorgeschlagen: {datetime}",
   "matchScheduleAcceptButton": "Annehmen",
   "matchScheduleRejectButton": "Ablehnen",
-
   "matchDisputedTitle": "Strittiges Spiel",
   "matchDisputedExplanation": "Dieses Ergebnis wurde angefochten. Ein Administrator wird die Punkte prüfen und eine endgültige Entscheidung treffen. Das Ranking wird nach der Entscheidung aktualisiert.",
-
   "notificationSettingsTitle": "Benachrichtigungen",
   "notificationSettingsCategories": "Benachrichtigungskategorien",
   "notifCategorySocial": "Soziales",
@@ -924,7 +919,7 @@
   "notifCategoryGamesSubtitle": "Neue Spiele, Ergebnisse, Absagen, Chat",
   "notifCategoryTraining": "Training",
   "notifCategoryTrainingSubtitle": "Sitzungen erstellt, abgesagt, Feedback",
-  "notifCategoryChampionships": "Meisterschaften",
+  "notifCategoryChampionships": "Ligen",
   "notifCategoryChampionshipsSubtitle": "Ergebnisse, Fristen, Streitigkeiten, Terminplanung",
   "notifQuietHoursTitle": "Ruhezeiten",
   "notifQuietHoursEnable": "Ruhezeiten aktivieren",
@@ -933,4 +928,5 @@
   "notifQuietHoursAdjust": "Ruhezeiten anpassen",
   "retryButton": "Erneut versuchen",
   "groupMuteNotifications": "Benachrichtigungen stummschalten",
-  "groupUnmuteNotifications": "Benachrichtigungen aktivieren"}
+  "groupUnmuteNotifications": "Benachrichtigungen aktivieren"
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,277 +4,222 @@
   "@appTitle": {
     "description": "The application title"
   },
-
   "welcomeMessage": "Welcome to Gatherli!",
   "@welcomeMessage": {
     "description": "Welcome message on home page"
   },
-
   "beachVolleyballOrganizer": "Beach volleyball games organizer",
   "@beachVolleyballOrganizer": {
     "description": "App description subtitle"
   },
-
   "firebaseConnected": "Connected",
   "@firebaseConnected": {
     "description": "Firebase connection status - connected"
   },
-
   "firebaseDisconnected": "Disconnected",
   "@firebaseDisconnected": {
     "description": "Firebase connection status - disconnected"
   },
-
   "firebase": "Firebase",
   "@firebase": {
     "description": "Firebase label"
   },
-
   "environment": "Environment",
   "@environment": {
     "description": "Environment label"
   },
-
   "project": "Project",
   "@project": {
     "description": "Project label"
   },
-
   "loading": "Loading...",
   "@loading": {
     "description": "Loading text"
   },
-
   "profile": "Profile",
   "@profile": {
     "description": "Profile button tooltip and page title"
   },
-
   "signOut": "Sign Out",
   "@signOut": {
     "description": "Sign out button tooltip"
   },
-
   "accountSettings": "Account Settings",
   "@accountSettings": {
     "description": "Account settings page title"
   },
-
   "save": "Save",
   "@save": {
     "description": "Save button text"
   },
-
   "cancel": "Cancel",
   "@cancel": {
     "description": "Cancel button text"
   },
-
   "displayName": "Display Name",
   "@displayName": {
     "description": "Display name field label"
   },
-
   "language": "Language",
   "@language": {
     "description": "Language preference label"
   },
-
   "country": "Country",
   "@country": {
     "description": "Country preference label"
   },
-
   "timezone": "Time Zone",
   "@timezone": {
     "description": "Time zone field label"
   },
-
   "saveChanges": "Save Changes",
   "@saveChanges": {
     "description": "Save changes button text"
   },
-
   "settingsUpdatedSuccessfully": "Settings updated successfully",
   "@settingsUpdatedSuccessfully": {
     "description": "Success message when settings are saved"
   },
-
   "removeAvatar": "Remove Avatar",
   "@removeAvatar": {
     "description": "Remove avatar button text"
   },
-
   "takePhoto": "Take Photo",
   "@takePhoto": {
     "description": "Take photo option in image picker"
   },
-
   "chooseFromGallery": "Choose from Gallery",
   "@chooseFromGallery": {
     "description": "Choose from gallery option in image picker"
   },
-
   "confirmRemoveAvatar": "Are you sure you want to remove your avatar?",
   "@confirmRemoveAvatar": {
     "description": "Confirmation dialog message for removing avatar"
   },
-
   "remove": "Remove",
   "@remove": {
     "description": "Remove button text"
   },
-
   "email": "Email",
   "@email": {
     "description": "Email field label"
   },
-
   "password": "Password",
   "@password": {
     "description": "Password field label"
   },
-
   "login": "Login",
   "@login": {
     "description": "Login button text"
   },
-
   "register": "Register",
   "@register": {
     "description": "Register button text"
   },
-
   "forgotPassword": "Forgot Password?",
   "@forgotPassword": {
     "description": "Forgot password link text"
   },
-
   "unsavedChangesTitle": "Unsaved Changes",
   "@unsavedChangesTitle": {
     "description": "Title for unsaved changes dialog"
   },
-
   "unsavedChangesMessage": "You have unsaved changes. Are you sure you want to leave?",
   "@unsavedChangesMessage": {
     "description": "Message for unsaved changes dialog"
   },
-
   "discard": "Discard",
   "@discard": {
     "description": "Discard button text"
   },
-
   "displayNameHint": "Enter your display name",
   "@displayNameHint": {
     "description": "Hint text for display name field"
   },
-
   "preferredLanguage": "Preferred Language",
   "@preferredLanguage": {
     "description": "Preferred language field label"
   },
-
   "saving": "Saving...",
   "@saving": {
     "description": "Saving indicator text"
   },
-
   "stay": "Stay",
   "@stay": {
     "description": "Stay button in unsaved changes dialog"
   },
-
   "accountInformation": "Account Information",
   "@accountInformation": {
     "description": "Account information section title"
   },
-
   "verify": "Verify",
   "@verify": {
     "description": "Verify email button text"
   },
-
   "accountType": "Account Type",
   "@accountType": {
     "description": "Account type label"
   },
-
   "anonymous": "Anonymous",
   "@anonymous": {
     "description": "Anonymous account type"
   },
-
   "regular": "Regular",
   "@regular": {
     "description": "Regular account type"
   },
-
   "memberSince": "Member Since",
   "@memberSince": {
     "description": "Member since label"
   },
-
   "lastActive": "Last Active",
   "@lastActive": {
     "description": "Last active label"
   },
-
   "signOutConfirm": "Are you sure you want to sign out?",
   "@signOutConfirm": {
     "description": "Sign out confirmation message"
   },
-
   "pleaseLogIn": "Please log in to view your profile",
   "@pleaseLogIn": {
     "description": "Message shown when user is not logged in"
   },
-
   "userId": "User ID",
   "@userId": {
     "description": "User ID label"
   },
-
   "myGroups": "My Groups",
   "@myGroups": {
     "description": "My groups page title"
   },
-
   "pleaseLogInToViewGroups": "Please log in to view your groups",
   "@pleaseLogInToViewGroups": {
     "description": "Message shown when user is not logged in on groups page"
   },
-
   "errorLoadingGroups": "Error Loading Groups",
   "@errorLoadingGroups": {
     "description": "Error message title when groups fail to load"
   },
-
   "retry": "Retry",
   "@retry": {
     "description": "Retry button text"
   },
-
   "createGroup": "Create Group",
   "@createGroup": {
     "description": "Create group button text"
   },
-
   "groupDetailsComingSoon": "Group details page coming soon!",
   "@groupDetailsComingSoon": {
     "description": "Coming soon message for group details"
   },
-
   "noGroupsYet": "You're not part of any group yet",
   "@noGroupsYet": {
     "description": "Empty state title when user has no groups"
   },
-
   "noGroupsMessage": "Create or join groups to start organizing beach volleyball games with your friends!",
   "@noGroupsMessage": {
     "description": "Empty state message when user has no groups"
   },
-
   "memberCount": "{count, plural, =1{1 member} other{{count} members}}",
   "@memberCount": {
     "description": "Member count label with pluralization",
@@ -285,107 +230,86 @@
       }
     }
   },
-
   "publicGroup": "Public",
   "@publicGroup": {
     "description": "Public group privacy label"
   },
-
   "inviteOnlyGroup": "Invite Only",
   "@inviteOnlyGroup": {
     "description": "Invite only group privacy label"
   },
-
   "privateGroup": "Private",
   "@privateGroup": {
     "description": "Private group privacy label"
   },
-
   "createYourFirstGroup": "Create Your First Group",
   "@createYourFirstGroup": {
     "description": "Button text to create first group in empty state"
   },
-
   "useCreateGroupButton": "Use the Create Group button below to get started.",
   "@useCreateGroupButton": {
     "description": "Instruction text for creating groups in empty state"
   },
-
   "home": "Home",
   "@home": {
     "description": "Home navigation tab label"
   },
-
   "groups": "Groups",
   "@groups": {
     "description": "Groups navigation tab label"
   },
-
   "community": "Community",
   "@community": {
     "description": "Community navigation tab label"
   },
-
   "myCommunity": "My Community",
   "@myCommunity": {
     "description": "My Community page title"
   },
-
   "friends": "Friends",
   "@friends": {
     "description": "Friends tab label"
   },
-
   "requests": "Requests",
   "@requests": {
     "description": "Friend requests tab label"
   },
-
   "noFriendsYet": "You don't have any friends yet",
   "@noFriendsYet": {
     "description": "Empty state title when user has no friends"
   },
-
   "searchForFriends": "Search for friends to get started!",
   "@searchForFriends": {
     "description": "Empty state message when user has no friends"
   },
-
   "noPendingRequests": "No pending friend requests",
   "@noPendingRequests": {
     "description": "Empty state message when no pending requests"
   },
-
   "receivedRequests": "Received Requests",
   "@receivedRequests": {
     "description": "Section title for received friend requests"
   },
-
   "sentRequests": "Sent Requests",
   "@sentRequests": {
     "description": "Section title for sent friend requests"
   },
-
   "accept": "Accept",
   "@accept": {
     "description": "Accept friend request button"
   },
-
   "decline": "Decline",
   "@decline": {
     "description": "Decline friend request button"
   },
-
   "pending": "Pending",
   "@pending": {
     "description": "Pending status label"
   },
-
   "removeFriend": "Remove Friend?",
   "@removeFriend": {
     "description": "Remove friend confirmation dialog title"
   },
-
   "removeFriendConfirmation": "Are you sure you want to remove {name} from your friends?",
   "@removeFriendConfirmation": {
     "description": "Remove friend confirmation message",
@@ -395,22 +319,18 @@
       }
     }
   },
-
   "errorLoadingFriends": "Error loading friends",
   "@errorLoadingFriends": {
     "description": "Error message when friends fail to load"
   },
-
   "searchFriendsByEmail": "Search friends by email...",
   "@searchFriendsByEmail": {
     "description": "Hint text for friend search input"
   },
-
   "cannotAddYourself": "You cannot add yourself as a friend",
   "@cannotAddYourself": {
     "description": "Message when user searches for their own email"
   },
-
   "userNotFoundWithEmail": "No user found with email: {email}",
   "@userNotFoundWithEmail": {
     "description": "Message when no user is found with the searched email",
@@ -420,232 +340,186 @@
       }
     }
   },
-
   "makeSureEmailCorrect": "Make sure the email is correct",
   "@makeSureEmailCorrect": {
     "description": "Suggestion message for email not found"
   },
-
   "requestPending": "Pending",
   "@requestPending": {
     "description": "Label for pending friend request"
   },
-
   "acceptRequest": "Accept Request",
   "@acceptRequest": {
     "description": "Button text to accept a friend request"
   },
-
   "sendFriendRequest": "Add",
   "@sendFriendRequest": {
     "description": "Button text to send a friend request"
   },
-
   "search": "Search",
   "@search": {
     "description": "Search button label"
   },
-
   "addFriend": "Add Friend",
   "@addFriend": {
     "description": "Button to add a new friend"
   },
-
   "searchForFriendsToAdd": "Search for friends to add",
   "@searchForFriendsToAdd": {
     "description": "Empty state title on add friend page"
   },
-
   "enterEmailToFindFriends": "Enter an email address to find users",
   "@enterEmailToFindFriends": {
     "description": "Empty state subtitle on add friend page"
   },
-
   "checkRequestsTab": "Check the Requests tab to accept the friend request",
   "@checkRequestsTab": {
     "description": "Message shown when user needs to navigate to requests tab"
   },
-
   "ok": "OK",
   "@ok": {
     "description": "OK button label"
   },
-
   "dontHaveAccount": "Don't have an account? ",
   "@dontHaveAccount": {
     "description": "Text before sign up link on login page"
   },
-
   "signUp": "Sign Up",
   "@signUp": {
     "description": "Sign up button text"
   },
-
   "resetPassword": "Reset Password",
   "@resetPassword": {
     "description": "Reset password page title"
   },
-
   "backToLogin": "Back to Login",
   "@backToLogin": {
     "description": "Back to login button text"
   },
-
   "emailSent": "Email Sent!",
   "@emailSent": {
     "description": "Email sent dialog title"
   },
-
   "createAccount": "Create Account",
   "@createAccount": {
-    "description": "Create account page title"
+    "description": "Button text to create a new account"
   },
-
   "accountCreatedSuccess": "Account created successfully! Please check your email for verification.",
   "@accountCreatedSuccess": {
     "description": "Success message after account creation"
   },
-
   "alreadyHaveAccount": "Already have an account? ",
   "@alreadyHaveAccount": {
     "description": "Text before sign in link on registration page"
   },
-
   "signIn": "Sign In",
   "@signIn": {
     "description": "Sign in button text"
   },
-
   "emailHint": "Email",
   "@emailHint": {
     "description": "Email field hint text"
   },
-
   "passwordHint": "Password",
   "@passwordHint": {
     "description": "Password field hint text"
   },
-
   "displayNameOptionalHint": "Display Name (Optional)",
   "@displayNameOptionalHint": {
     "description": "Display name optional field hint (deprecated - use displayNameHintRequired)"
   },
-
   "confirmPassword": "Confirm Password",
   "@confirmPassword": {
     "description": "Confirm password field hint"
   },
-
   "createGame": "Create Game",
   "@createGame": {
     "description": "Create game page title and button"
   },
-
   "gameCreatedSuccess": "Game created successfully!",
   "@gameCreatedSuccess": {
     "description": "Success message after game creation"
   },
-
   "pleaseLogInToCreateGame": "Please log in to create a game",
   "@pleaseLogInToCreateGame": {
     "description": "Message when user needs to log in to create game"
   },
-
   "group": "Group",
   "@group": {
     "description": "Group field label"
   },
-
   "dateTime": "Date & Time",
   "@dateTime": {
     "description": "Date and time field label"
   },
-
   "tapToSelect": "Tap to select",
   "@tapToSelect": {
     "description": "Tap to select hint text"
   },
-
   "gameDetails": "Game",
   "@gameDetails": {
     "description": "Game details page title"
   },
-
   "goBack": "Go Back",
   "@goBack": {
     "description": "Go back button text"
   },
-
   "organizer": "Organizer",
   "@organizer": {
     "description": "Organizer label"
   },
-
   "enterResults": "Enter Results",
   "@enterResults": {
     "description": "Enter results button label"
   },
-
   "leaveGame": "Leave Game",
   "@leaveGame": {
     "description": "Leave game menu option"
   },
-
   "leaveWaitlist": "Leave Waitlist",
   "@leaveWaitlist": {
     "description": "Leave waitlist menu option"
   },
-
   "confirm": "Confirm",
   "@confirm": {
     "description": "Confirm button text"
   },
-
   "editDispute": "Edit / Dispute",
   "@editDispute": {
     "description": "Edit or dispute button label"
   },
-
   "filterGames": "Filter Games",
   "@filterGames": {
     "description": "Filter games dialog title"
   },
-
   "allGames": "All Games",
   "@allGames": {
     "description": "All games filter option"
   },
-
   "myGamesOnly": "My Games Only",
   "@myGamesOnly": {
     "description": "My games only filter option"
   },
-
   "gameHistory": "Game History",
   "@gameHistory": {
     "description": "Game history page title"
   },
-
   "selectFiltersToView": "Select filters to view game history",
   "@selectFiltersToView": {
     "description": "Message to select filters"
   },
-
   "activeFilters": "Active filters: ",
   "@activeFilters": {
     "description": "Active filters label"
   },
-
   "myGames": "My Games",
   "@myGames": {
     "description": "My games chip label"
   },
-
   "gameResults": "Game Results",
   "@gameResults": {
     "description": "Game results page title"
   },
-
   "groupNameGames": "{groupName} Games",
   "@groupNameGames": {
     "description": "Games list page title with group name",
@@ -655,283 +529,227 @@
       }
     }
   },
-
   "recordResults": "Record Results",
   "@recordResults": {
     "description": "Record results page title"
   },
-
   "teamsSavedSuccess": "Teams saved successfully",
   "@teamsSavedSuccess": {
     "description": "Success message when teams are saved"
   },
-
   "teamA": "Team A",
   "@teamA": {
     "description": "Team A label"
   },
-
   "teamB": "Team B",
   "@teamB": {
     "description": "Team B label"
   },
-
   "enterScores": "Enter Scores",
   "@enterScores": {
     "description": "Enter scores page title"
   },
-
   "scoresSavedSuccess": "Scores saved successfully!",
   "@scoresSavedSuccess": {
     "description": "Success message when scores are saved"
   },
-
   "savingScores": "Saving scores...",
   "@savingScores": {
     "description": "Saving scores loading text"
   },
-
   "oneSet": "1 Set",
   "@oneSet": {
     "description": "One set option"
   },
-
   "bestOfTwo": "Best of 2",
   "@bestOfTwo": {
     "description": "Best of 2 sets option"
   },
-
   "bestOfThree": "Best of 3",
   "@bestOfThree": {
     "description": "Best of 3 sets option"
   },
-
   "gameTitle": "Game Title",
   "@gameTitle": {
     "description": "Game title field label"
   },
-
   "gameTitleHint": "e.g., Beach Volleyball",
   "@gameTitleHint": {
     "description": "Game title hint text"
   },
-
   "descriptionOptional": "Description (Optional)",
   "@descriptionOptional": {
     "description": "Optional description field label"
   },
-
   "gameDescriptionHint": "Add details about the game...",
   "@gameDescriptionHint": {
     "description": "Game description hint text"
   },
-
   "location": "Location",
   "@location": {
     "description": "Location field label"
   },
-
   "locationHint": "e.g., Venice Beach",
   "@locationHint": {
     "description": "Location hint text"
   },
-
   "addressOptional": "Address (Optional)",
   "@addressOptional": {
     "description": "Optional address field label"
   },
-
   "addressHint": "Full address...",
   "@addressHint": {
     "description": "Address hint text"
   },
-
   "filter": "Filter",
   "@filter": {
     "description": "Filter tooltip"
   },
-
   "dateRange": "Date Range",
   "@dateRange": {
     "description": "Date range tooltip"
   },
-
   "removeFromTeam": "Remove from team",
   "@removeFromTeam": {
     "description": "Remove from team tooltip"
   },
-
   "clearFilter": "Clear filter",
   "@clearFilter": {
     "description": "Clear filter tooltip"
   },
-
   "filterByDate": "Filter by date",
   "@filterByDate": {
     "description": "Filter by date tooltip"
   },
-
   "groupNameRequired": "Group Name *",
   "@groupNameRequired": {
     "description": "Required group name field label"
   },
-
   "groupNameHint": "e.g., Beach Volleyball Crew",
   "@groupNameHint": {
     "description": "Group name hint text"
   },
-
   "groupDescriptionHint": "e.g., Weekly beach volleyball games at Santa Monica",
   "@groupDescriptionHint": {
     "description": "Group description hint text"
   },
-
   "pleaseSelectStartTimeFirst": "Please select start time first",
   "@pleaseSelectStartTimeFirst": {
     "description": "Message when end time selected before start time"
   },
-
   "pleaseSelectStartTime": "Please select start time",
   "@pleaseSelectStartTime": {
     "description": "Validation message for start time"
   },
-
   "pleaseSelectEndTime": "Please select end time",
   "@pleaseSelectEndTime": {
     "description": "Validation message for end time"
   },
-
   "trainingCreatedSuccess": "Training session created successfully!",
   "@trainingCreatedSuccess": {
     "description": "Success message after training creation"
   },
-
   "createTrainingSession": "Create Training Session",
   "@createTrainingSession": {
     "description": "Create training session page title and button"
   },
   "createTraining": "Create Training",
-
   "pleaseLogInToCreateTraining": "Please log in to create a training session",
   "@pleaseLogInToCreateTraining": {
     "description": "Message when user needs to log in to create training"
   },
-
   "startTime": "Start Time",
   "@startTime": {
     "description": "Start time field label"
   },
-
   "endTime": "End Time",
   "@endTime": {
     "description": "End time field label"
   },
-
   "title": "Title",
   "@title": {
     "description": "Title field label"
   },
-
   "trainingSession": "Training Session",
   "@trainingSession": {
     "description": "Training session page title"
   },
-
   "trainingNotFound": "Training session not found",
   "@trainingNotFound": {
     "description": "Message when training session is not found"
   },
-
   "trainingCancelled": "Training session cancelled",
   "@trainingCancelled": {
     "description": "Message when training session is cancelled"
   },
-
   "errorLoadingParticipants": "Error loading participants",
   "@errorLoadingParticipants": {
     "description": "Error message when participants fail to load"
   },
-
   "joinedTrainingSuccess": "Successfully joined training session!",
   "@joinedTrainingSuccess": {
     "description": "Success message when joining training"
   },
-
   "leftTraining": "You have left the training session",
   "@leftTraining": {
     "description": "Message when leaving training"
   },
-
   "joinTrainingSession": "Join Training Session",
   "@joinTrainingSession": {
     "description": "Join training dialog title"
   },
-
   "join": "Join",
   "@join": {
     "description": "Join button text"
   },
-
   "leaveTrainingSession": "Leave Training Session",
   "@leaveTrainingSession": {
     "description": "Leave training dialog title"
   },
-
   "leave": "Leave",
   "@leave": {
     "description": "Leave button text"
   },
-
   "cancelTrainingSession": "Cancel Training Session?",
   "@cancelTrainingSession": {
     "description": "Cancel training dialog title"
   },
-
   "keepSession": "Keep Session",
   "@keepSession": {
     "description": "Keep session button text"
   },
-
   "cancelSession": "Cancel Session",
   "@cancelSession": {
     "description": "Cancel session button text"
   },
-
   "sessionFeedback": "Session Feedback",
   "@sessionFeedback": {
     "description": "Session feedback page title"
   },
-
   "thankYouFeedback": "Thank you for your feedback!",
   "@thankYouFeedback": {
     "description": "Thank you message after feedback"
   },
-
   "backToSession": "Back to Session",
   "@backToSession": {
     "description": "Back to session button text"
   },
-
   "needsWork": "Needs work",
   "@needsWork": {
     "description": "Feedback rating label - needs work"
   },
-
   "topLevelTraining": "Top-level training",
   "@topLevelTraining": {
     "description": "Feedback rating label - top level"
   },
-
   "pleaseRateAllCategories": "Please rate all three categories before submitting",
   "@pleaseRateAllCategories": {
     "description": "Validation message for feedback"
   },
-
   "emailVerification": "Email Verification",
   "@emailVerification": {
     "description": "Email verification page title"
   },
-
   "verificationEmailSent": "Verification email sent to {email}",
   "@verificationEmailSent": {
     "description": "Success message when verification email is sent",
@@ -941,192 +759,154 @@
       }
     }
   },
-
   "backToProfile": "Back to Profile",
   "@backToProfile": {
     "description": "Back to profile button text"
   },
-
   "sendVerificationEmail": "Send Verification Email",
   "@sendVerificationEmail": {
     "description": "Send verification email button text"
   },
-
   "refreshStatus": "Refresh Status",
   "@refreshStatus": {
     "description": "Refresh status button text"
   },
-
   "tryAgain": "Try Again",
   "@tryAgain": {
     "description": "Try again button text"
   },
-
   "eloHistory": "ELO History",
   "@eloHistory": {
     "description": "ELO history page title"
   },
-
   "gameDetailsComingSoon": "Game details coming soon!",
   "@gameDetailsComingSoon": {
     "description": "Coming soon message for game details"
   },
-
   "headToHead": "Head-to-Head",
   "@headToHead": {
     "description": "Head to head page title"
   },
-
   "partnerDetails": "Partner Details",
   "@partnerDetails": {
     "description": "Partner details page title"
   },
-
   "invitations": "Invitations",
   "@invitations": {
     "description": "Invitations page title"
   },
-
   "pleaseLogInToViewInvitations": "Please log in to view invitations",
   "@pleaseLogInToViewInvitations": {
     "description": "Message when user needs to log in to view invitations"
   },
-
   "pendingInvitations": "Pending Invitations",
   "@pendingInvitations": {
     "description": "Pending invitations page title"
   },
-
   "notificationSettings": "Notification Settings",
   "@notificationSettings": {
     "description": "Notification settings page title"
   },
-
   "initializing": "Initializing...",
   "@initializing": {
     "description": "Initializing state text"
   },
-
   "groupInvitations": "Group Invitations",
   "@groupInvitations": {
     "description": "Group invitations notification setting title"
   },
-
   "groupInvitationsDesc": "When someone invites you to a group",
   "@groupInvitationsDesc": {
     "description": "Group invitations notification setting description"
   },
-
   "invitationAccepted": "Invitation Accepted",
   "@invitationAccepted": {
     "description": "Invitation accepted notification setting title"
   },
-
   "invitationAcceptedDesc": "When someone accepts your invitation",
   "@invitationAcceptedDesc": {
     "description": "Invitation accepted notification setting description"
   },
-
   "newGames": "New Games",
   "@newGames": {
     "description": "New games notification setting title"
   },
-
   "newGamesDesc": "When a new game is created in your groups",
   "@newGamesDesc": {
     "description": "New games notification setting description"
   },
-
   "roleChanges": "Role Changes",
   "@roleChanges": {
     "description": "Role changes notification setting title"
   },
-
   "roleChangesDesc": "When you are promoted to admin",
   "@roleChangesDesc": {
     "description": "Role changes notification setting description"
   },
-
   "newTrainingSessions": "New Training Sessions",
   "@newTrainingSessions": {
     "description": "New training sessions notification setting title"
   },
-
   "newTrainingSessionsDesc": "When a training session is created in your groups",
   "@newTrainingSessionsDesc": {
     "description": "New training sessions notification setting description"
   },
-
   "minParticipantsReached": "Minimum Participants Reached",
   "@minParticipantsReached": {
     "description": "Min participants reached notification setting title"
   },
-
   "minParticipantsReachedDesc": "When a training session has enough participants",
   "@minParticipantsReachedDesc": {
     "description": "Min participants reached notification setting description"
   },
-
   "feedbackReceived": "Feedback Received",
   "@feedbackReceived": {
     "description": "Feedback received notification setting title"
   },
-
   "feedbackReceivedDesc": "When someone leaves feedback on a training session",
   "@feedbackReceivedDesc": {
     "description": "Feedback received notification setting description"
   },
-
   "sessionCancelled": "Session Cancelled",
   "@sessionCancelled": {
     "description": "Session cancelled notification setting title"
   },
-
   "sessionCancelledDesc": "When a training session you joined is cancelled",
   "@sessionCancelledDesc": {
     "description": "Session cancelled notification setting description"
   },
-
   "memberJoined": "Member Joined",
   "@memberJoined": {
     "description": "Member joined notification setting title"
   },
-
   "memberJoinedDesc": "When someone joins your group",
   "@memberJoinedDesc": {
     "description": "Member joined notification setting description"
   },
-
   "memberLeft": "Member Left",
   "@memberLeft": {
     "description": "Member left notification setting title"
   },
-
   "memberLeftDesc": "When someone leaves your group",
   "@memberLeftDesc": {
     "description": "Member left notification setting description"
   },
-
   "enableQuietHours": "Enable Quiet Hours",
   "@enableQuietHours": {
     "description": "Enable quiet hours toggle title"
   },
-
   "quietHoursDesc": "Pause notifications during specific times",
   "@quietHoursDesc": {
     "description": "Quiet hours toggle description"
   },
-
   "adjustQuietHours": "Adjust Quiet Hours",
   "@adjustQuietHours": {
     "description": "Adjust quiet hours button title"
   },
-
   "setQuietHours": "Set Quiet Hours",
   "@setQuietHours": {
     "description": "Set quiet hours dialog title"
   },
-
   "error": "Error: {message}",
   "@error": {
     "description": "Generic error message with details",
@@ -1136,202 +916,162 @@
       }
     }
   },
-
   "pleaseLogInToAddFriends": "Please log in to add friends",
   "@pleaseLogInToAddFriends": {
     "description": "Message when user needs to log in to add friends"
   },
-
   "welcomeBack": "Welcome!",
   "@welcomeBack": {
     "description": "Welcome back heading on login page"
   },
-
   "signInToContinue": "Sign in to continue organizing your volleyball games",
   "@signInToContinue": {
     "description": "Subtitle on login page"
   },
-
   "emailRequired": "Email is required",
   "@emailRequired": {
     "description": "Validation error when email is empty"
   },
-
   "validEmailRequired": "Please enter a valid email",
   "@validEmailRequired": {
     "description": "Validation error when email format is invalid"
   },
-
   "passwordRequired": "Password is required",
   "@passwordRequired": {
     "description": "Validation error when password is empty"
   },
-
   "continueAsGuest": "Continue as Guest",
   "@continueAsGuest": {
     "description": "Button to continue without account"
   },
-
   "joinPlayWithMe": "Join Gatherli!",
   "@joinPlayWithMe": {
     "description": "Heading on registration page"
   },
-
   "createAccountSubtitle": "Create your account to start organizing volleyball games",
   "@createAccountSubtitle": {
     "description": "Subtitle on registration page"
   },
-
   "displayNameTooLong": "Display name must be less than 50 characters",
   "@displayNameTooLong": {
     "description": "Validation error when display name is too long"
   },
-
   "passwordTooShort": "Password must be at least 6 characters",
   "@passwordTooShort": {
     "description": "Validation error when password is too short"
   },
-
   "pleaseConfirmPassword": "Please confirm your password",
   "@pleaseConfirmPassword": {
     "description": "Validation error when confirm password is empty"
   },
-
   "passwordsDoNotMatch": "Passwords do not match",
   "@passwordsDoNotMatch": {
     "description": "Validation error when passwords don't match"
   },
-
   "termsAgreement": "By creating an account, you agree to our Terms of Service and Privacy Policy.",
   "@termsAgreement": {
     "description": "Terms agreement text on registration page"
   },
-
   "forgotYourPassword": "Forgot Your Password?",
   "@forgotYourPassword": {
     "description": "Heading on password reset page"
   },
-
   "forgotPasswordInstructions": "Enter your email address and we'll send you a link to reset your password.",
   "@forgotPasswordInstructions": {
     "description": "Instructions on password reset page"
   },
-
   "sendResetEmail": "Send Reset Email",
   "@sendResetEmail": {
     "description": "Button to send password reset email"
   },
-
   "resetLinkSentTo": "We've sent a password reset link to:",
   "@resetLinkSentTo": {
     "description": "Message in password reset success dialog"
   },
-
   "checkEmailResetInstructions": "Please check your email and follow the instructions to reset your password.",
   "@checkEmailResetInstructions": {
     "description": "Instructions in password reset success dialog"
   },
-
   "noResultsAvailable": "No results available yet",
   "@noResultsAvailable": {
     "description": "Heading when no game results"
   },
-
   "scoresWillAppear": "Scores will appear here once they are entered",
   "@scoresWillAppear": {
     "description": "Description when no game results"
   },
-
   "individualGames": "Individual Games",
   "@individualGames": {
     "description": "Section title for individual games"
   },
-
   "howManyGamesPlayed": "How many games did you play?",
   "@howManyGamesPlayed": {
     "description": "Question on score entry page"
   },
-
   "assignPlayersToTeams": "Assign Players to Teams",
   "@assignPlayersToTeams": {
     "description": "Heading on record results page"
   },
-
   "dragPlayersToAssign": "Drag players to assign them to Team A or Team B",
   "@dragPlayersToAssign": {
     "description": "Instructions on record results page"
   },
-
   "pendingVerification": "Pending Verification",
   "@pendingVerification": {
     "description": "Status badge for pending verification"
   },
-
   "youreIn": "You're In",
   "@youreIn": {
     "description": "Status badge for confirmed participation"
   },
-
   "onWaitlist": "WAITING LIST",
   "@onWaitlist": {
     "description": "Status badge for waitlist"
   },
-
   "full": "Full",
   "@full": {
     "description": "Status badge when game is full"
   },
-
   "joinGame": "Join Game",
   "@joinGame": {
     "description": "Button to join a game"
   },
-
   "today": "Today",
   "@today": {
     "description": "Date label for today"
   },
-
   "tomorrow": "Tomorrow",
   "@tomorrow": {
     "description": "Date label for tomorrow"
   },
-
   "player": "Player",
   "@player": {
     "description": "Player fallback name"
   },
-
   "noScoresRecorded": "No scores recorded",
   "@noScoresRecorded": {
     "description": "Placeholder when no scores"
   },
-
   "eloUpdated": "ELO Updated",
   "@eloUpdated": {
     "description": "Badge text for ELO update"
   },
-
   "vs": "VS",
   "@vs": {
     "description": "Versus separator"
   },
-
   "cancelled": "CANCELLED",
   "@cancelled": {
     "description": "Status badge for cancelled"
   },
-
   "joined": "JOINED",
   "@joined": {
     "description": "Status badge for joined"
   },
-
   "training": "Training",
   "@training": {
     "description": "Training badge"
   },
-
   "gameLabel": "GAME",
   "@gameLabel": {
     "description": "Game badge label"
@@ -1340,7 +1080,6 @@
   "@mixGameBadge": {
     "description": "Badge label shown on mixed-gender games"
   },
-
   "minParticipants": "Min: {count}",
   "@minParticipants": {
     "description": "Minimum participants label",
@@ -1350,192 +1089,154 @@
       }
     }
   },
-
   "selectGameDate": "Select Game Date",
   "@selectGameDate": {
     "description": "Help text for game date picker"
   },
-
   "selectGameTime": "Select Game Time",
   "@selectGameTime": {
     "description": "Help text for game time picker"
   },
-
   "pleaseTitleRequired": "Please enter a game title",
   "@pleaseTitleRequired": {
     "description": "Validation error when game title is empty"
   },
-
   "titleMinLength": "Title must be at least 3 characters",
   "@titleMinLength": {
     "description": "Validation error when title is too short"
   },
-
   "titleMaxLength": "Title must be less than 100 characters",
   "@titleMaxLength": {
     "description": "Validation error when title is too long"
   },
-
   "pleaseEnterTitle": "Please enter a title",
   "@pleaseEnterTitle": {
     "description": "Validation error when title is empty"
   },
-
   "pleaseEnterLocation": "Please enter a location",
   "@pleaseEnterLocation": {
     "description": "Validation error when location is empty"
   },
-
   "notSelected": "Not selected",
   "@notSelected": {
     "description": "Default text when nothing selected"
   },
-
   "selectStartDate": "Select Start Date",
   "@selectStartDate": {
     "description": "Help text for start date picker"
   },
-
   "selectStartTime": "Select Start Time",
   "@selectStartTime": {
     "description": "Help text for start time picker"
   },
-
   "selectEndTime": "Select End Time",
   "@selectEndTime": {
     "description": "Help text for end time picker"
   },
-
   "participants": "Participants",
   "@participants": {
     "description": "Participants tab label"
   },
-
   "exercises": "Exercises",
   "@exercises": {
     "description": "Exercises tab label"
   },
-
   "feedback": "Feedback",
   "@feedback": {
     "description": "Feedback tab label"
   },
-
   "date": "Date",
   "@date": {
     "description": "Date label"
   },
-
   "time": "Time",
   "@time": {
     "description": "Time label"
   },
-
   "players": "Players",
   "@players": {
     "description": "Players label"
   },
-
   "competitiveGameWithElo": "Competitive game with ELO ratings",
   "@competitiveGameWithElo": {
     "description": "Description for create game option"
   },
-
   "practiceSessionNoElo": "Practice session without ELO impact",
   "@practiceSessionNoElo": {
     "description": "Description for create training option"
   },
-
   "promoteToAdmin": "Promote to Admin",
   "@promoteToAdmin": {
     "description": "Dialog title for promoting member"
   },
-
   "promote": "Promote",
   "@promote": {
     "description": "Promote button text"
   },
-
   "demoteToMember": "Demote to Member",
   "@demoteToMember": {
     "description": "Dialog title for demoting admin"
   },
-
   "demote": "Demote",
   "@demote": {
     "description": "Demote button text"
   },
-
   "removeMember": "Remove Member",
   "@removeMember": {
     "description": "Dialog title for removing member"
   },
-
   "leaveGroup": "Leave Group",
   "@leaveGroup": {
     "description": "Dialog title for leaving group"
   },
-
   "selectAll": "Select All",
   "@selectAll": {
     "description": "Select all button"
   },
-
   "clearAll": "Clear All",
   "@clearAll": {
     "description": "Clear all button"
   },
-
   "upload": "Upload",
   "@upload": {
     "description": "Upload button"
   },
-
   "avatarUploadedSuccess": "Avatar uploaded successfully",
   "@avatarUploadedSuccess": {
     "description": "Success message for avatar upload"
   },
-
   "avatarRemovedSuccess": "Avatar removed successfully",
   "@avatarRemovedSuccess": {
     "description": "Success message for avatar removal"
   },
-
   "bestTeammate": "Best Teammate",
   "@bestTeammate": {
     "description": "Best teammate card title"
   },
-
   "gameNotFound": "Game Not Found",
   "@gameNotFound": {
     "description": "Error heading when game not found"
   },
-
   "noCompletedGamesYet": "No completed games yet",
   "@noCompletedGamesYet": {
     "description": "Empty state title for game history"
   },
-
   "gamesWillAppearAfterCompleted": "Games will appear here after they are completed",
   "@gamesWillAppearAfterCompleted": {
     "description": "Empty state description for game history"
   },
-
   "finalScore": "Final Score",
   "@finalScore": {
     "description": "Final score heading"
   },
-
   "eloRatingChanges": "ELO Rating Changes",
   "@eloRatingChanges": {
     "description": "ELO rating changes section title"
   },
-
   "unknownPlayer": "Unknown Player",
   "@unknownPlayer": {
     "description": "Fallback name for unknown player"
   },
-
   "gameNumber": "Game {number}",
   "@gameNumber": {
     "description": "Game number label",
@@ -1545,7 +1246,6 @@
       }
     }
   },
-
   "setsScore": "Sets: {teamA} - {teamB}",
   "@setsScore": {
     "description": "Sets score display",
@@ -1558,7 +1258,6 @@
       }
     }
   },
-
   "setNumber": "Set {number}",
   "@setNumber": {
     "description": "Set number label",
@@ -1568,37 +1267,30 @@
       }
     }
   },
-
   "format": "Format:",
   "@format": {
     "description": "Format label"
   },
-
   "invalidScore": "Invalid score",
   "@invalidScore": {
     "description": "Validation error for invalid score"
   },
-
   "overallWinnerTeamA": "Overall Winner: Team A",
   "@overallWinnerTeamA": {
     "description": "Overall winner message for Team A"
   },
-
   "overallWinnerTeamB": "Overall Winner: Team B",
   "@overallWinnerTeamB": {
     "description": "Overall winner message for Team B"
   },
-
   "resultTie": "Result: Tie",
   "@resultTie": {
     "description": "Message shown when game result is a tie"
   },
-
   "saveScores": "Save Scores",
   "@saveScores": {
     "description": "Save scores button"
   },
-
   "completeGamesToContinue": "Complete {current}/{total} games to continue",
   "@completeGamesToContinue": {
     "description": "Message to complete games before saving",
@@ -1611,47 +1303,38 @@
       }
     }
   },
-
   "upcomingActivities": "Upcoming Activities",
   "@upcomingActivities": {
     "description": "Section header for upcoming activities"
   },
-
   "pastActivities": "Past Activities",
   "@pastActivities": {
     "description": "Section header for past activities"
   },
-
   "noUpcomingGamesYet": "No upcoming games yet",
   "@noUpcomingGamesYet": {
     "description": "Empty state title for games list"
   },
-
   "createFirstGame": "Create the first game!",
   "@createFirstGame": {
     "description": "Empty state call to action"
   },
-
   "noActivitiesYet": "No activities yet",
   "@noActivitiesYet": {
     "description": "Empty state title for activities list"
   },
-
   "createFirstActivity": "Create the first activity!",
   "@createFirstActivity": {
     "description": "Empty state call to action for activities"
   },
-
   "gamesWon": "games won",
   "@gamesWon": {
     "description": "Games won label"
   },
-
   "playerCountSingular": "1 player",
   "@playerCountSingular": {
     "description": "Single player count"
   },
-
   "playerCountPlural": "{count} players",
   "@playerCountPlural": {
     "description": "Multiple players count",
@@ -1661,7 +1344,6 @@
       }
     }
   },
-
   "wonScoreDescription": "{winner} won {score}",
   "@wonScoreDescription": {
     "description": "Winner and score description",
@@ -1674,7 +1356,6 @@
       }
     }
   },
-
   "playersWaitlisted": "{count} waitlisted",
   "@playersWaitlisted": {
     "description": "Number of players waitlisted",
@@ -1684,7 +1365,6 @@
       }
     }
   },
-
   "playersCount": "{current}/{max} players",
   "@playersCount": {
     "description": "Current vs max players",
@@ -1697,22 +1377,18 @@
       }
     }
   },
-
   "minParticipantsLabel": "Min Participants",
   "@minParticipantsLabel": {
     "description": "Label for minimum participants field"
   },
-
   "maxParticipantsLabel": "Max Participants",
   "@maxParticipantsLabel": {
     "description": "Label for maximum participants field"
   },
-
   "youAreOrganizing": "You are organizing",
   "@youAreOrganizing": {
     "description": "Message shown when user is the organizer"
   },
-
   "organizedBy": "Organized by {name}",
   "@organizedBy": {
     "description": "Message showing who organized the session",
@@ -1722,87 +1398,70 @@
       }
     }
   },
-
   "scheduled": "Scheduled",
   "@scheduled": {
     "description": "Status label for scheduled sessions"
   },
-
   "completed": "Completed",
   "@completed": {
     "description": "Status label for completed sessions"
   },
-
   "verification": "Verification",
   "@verification": {
     "description": "Status label for games awaiting result verification"
   },
-
   "noParticipantsYet": "No participants yet",
   "@noParticipantsYet": {
     "description": "Empty state message when no participants"
   },
-
   "beFirstToJoin": "Be the first to join!",
   "@beFirstToJoin": {
     "description": "Call to action to join empty session"
   },
-
   "participation": "Participation",
   "@participation": {
     "description": "Participation section title"
   },
-
   "current": "Current",
   "@current": {
     "description": "Current count label"
   },
-
   "minimum": "Minimum",
   "@minimum": {
     "description": "Minimum count label"
   },
-
   "maximum": "Maximum",
   "@maximum": {
     "description": "Maximum count label"
   },
-
   "availableSpots": "Available Spots",
   "@availableSpots": {
     "description": "Available spots label"
   },
-
   "you": "You",
   "@you": {
     "description": "Label indicating current user"
   },
-
   "joining": "Joining...",
   "@joining": {
     "description": "Joining in progress text"
   },
-
   "leaving": "Leaving...",
   "@leaving": {
     "description": "Leaving in progress text"
   },
-
   "cannotJoin": "Cannot Join",
   "@cannotJoin": {
     "description": "Message when user cannot join"
   },
-
   "allParticipantsNotified": "All participants will be notified.",
   "@allParticipantsNotified": {
     "description": "Info about notifying participants"
   },
-
   "feedbackAlreadySubmitted": "Feedback Already Submitted",
   "@feedbackAlreadySubmitted": {
     "description": "Title when feedback was already submitted"
   },
-
   "alreadyProvidedFeedback": "You have already provided feedback for \"{sessionTitle}\".",
   "@alreadyProvidedFeedback": {
     "description": "Message when feedback was already provided",
@@ -1812,122 +1471,98 @@
       }
     }
   },
-
   "provideAnonymousFeedback": "Provide Anonymous Feedback",
   "@provideAnonymousFeedback": {
     "description": "Title for feedback form"
   },
-
   "feedbackIsAnonymous": "Your feedback is anonymous and helps improve future training sessions.",
   "@feedbackIsAnonymous": {
     "description": "Info about anonymous feedback"
   },
-
   "exercisesQuality": "Exercises Quality",
   "@exercisesQuality": {
     "description": "Feedback category for exercise quality"
   },
-
   "wereDrillsEffective": "Were the drills effective?",
   "@wereDrillsEffective": {
     "description": "Subtitle for exercises quality rating"
   },
-
   "trainingIntensity": "Training Intensity",
   "@trainingIntensity": {
     "description": "Feedback category for training intensity"
   },
-
   "physicalDemandLevel": "Physical demand level",
   "@physicalDemandLevel": {
     "description": "Subtitle for training intensity rating"
   },
-
   "coachingClarity": "Coaching Clarity",
   "@coachingClarity": {
     "description": "Feedback category for coaching clarity"
   },
-
   "instructionsAndCorrections": "Instructions & corrections?",
   "@instructionsAndCorrections": {
     "description": "Subtitle for coaching clarity rating"
   },
-
   "additionalCommentsOptional": "Additional Comments (Optional)",
   "@additionalCommentsOptional": {
     "description": "Label for optional comments field"
   },
-
   "shareYourThoughts": "Share your thoughts about the session, exercises, or suggestions for improvement...",
   "@shareYourThoughts": {
     "description": "Hint text for feedback comments"
   },
-
   "submitFeedback": "Submit Feedback",
   "@submitFeedback": {
     "description": "Submit feedback button text"
   },
-
   "feedbackPrivacyNotice": "Your feedback is completely anonymous and cannot be traced back to you.",
   "@feedbackPrivacyNotice": {
     "description": "Privacy notice for feedback"
   },
-
   "invite": "Invite",
   "@invite": {
     "description": "Invite label"
   },
-
   "inviteMembers": "Invite Members",
   "@inviteMembers": {
     "description": "Invite members tooltip"
   },
-
   "adminOnly": "Admin only",
   "@adminOnly": {
     "description": "Admin only restriction message"
   },
-
   "create": "Create",
   "@create": {
     "description": "Create label"
   },
-
   "createGameOrTraining": "Create game or training session",
   "@createGameOrTraining": {
     "description": "Tooltip for create button"
   },
-
   "activities": "Activities",
   "@activities": {
     "description": "Activities label"
   },
-
   "members": "Members",
   "@members": {
     "description": "Members tab label"
   },
-
   "inviteMember": "Invite Member",
   "@inviteMember": {
     "description": "Invite member action in members tab"
   },
-
   "inviteWithLink": "Invite with Link",
   "@inviteWithLink": {
     "description": "Invite with link action in members tab"
   },
-
   "viewAllActivities": "View all activities",
   "@viewAllActivities": {
     "description": "Tooltip for activities button"
   },
-
   "removeFromGroup": "Remove from Group",
   "@removeFromGroup": {
     "description": "Remove from group menu item"
   },
-
   "promoteConfirmMessage": "Are you sure you want to promote {name} to admin?\n\nAdmins can:\n• Manage group members\n• Invite new members\n• Modify group settings",
   "@promoteConfirmMessage": {
     "description": "Confirmation message for promoting member",
@@ -1937,7 +1572,6 @@
       }
     }
   },
-
   "demoteConfirmMessage": "Are you sure you want to demote {name} to regular member?\n\nThey will lose admin privileges.",
   "@demoteConfirmMessage": {
     "description": "Confirmation message for demoting admin",
@@ -1947,7 +1581,6 @@
       }
     }
   },
-
   "removeConfirmMessage": "Are you sure you want to remove {name} from the group?\n\nThis action cannot be undone. They will need to be re-invited to rejoin.",
   "@removeConfirmMessage": {
     "description": "Confirmation message for removing member",
@@ -1957,7 +1590,6 @@
       }
     }
   },
-
   "leaveGroupConfirmMessage": "Are you sure you want to leave \"{groupName}\"?\n\nYou will need to be re-invited to rejoin this group.",
   "@leaveGroupConfirmMessage": {
     "description": "Confirmation message for leaving group",
@@ -1967,17 +1599,14 @@
       }
     }
   },
-
   "performanceStats": "Performance Stats",
   "@performanceStats": {
     "description": "Performance stats section title"
   },
-
   "eloRatingLabel": "ELO Rating",
   "@eloRatingLabel": {
     "description": "ELO rating stat label"
   },
-
   "peak": "Peak: {value}",
   "@peak": {
     "description": "Peak rating label",
@@ -1987,12 +1616,10 @@
       }
     }
   },
-
   "winRate": "Win Rate",
   "@winRate": {
     "description": "Win rate stat label"
   },
-
   "winsLosses": "{wins}W - {losses}L",
   "@winsLosses": {
     "description": "Wins and losses display",
@@ -2005,72 +1632,59 @@
       }
     }
   },
-
   "streakLabel": "Streak",
   "@streakLabel": {
     "description": "Streak stat label"
   },
-
   "winning": "Winning",
   "@winning": {
     "description": "Winning streak label"
   },
-
   "losingStreak": "Losing",
   "@losingStreak": {
     "description": "Losing streak label"
   },
-
   "noStreak": "None",
   "@noStreak": {
     "description": "No streak label"
   },
-
   "gamesPlayedLabel": "Games Played",
   "@gamesPlayedLabel": {
     "description": "Games played stat label"
   },
-
   "noPlayersAssigned": "No players assigned",
   "@noPlayersAssigned": {
     "description": "Empty state for team with no players"
   },
-
   "unassignedPlayers": "Unassigned Players",
   "@unassignedPlayers": {
     "description": "Section title for unassigned players"
   },
-
   "allPlayersAssigned": "All players assigned!",
   "@allPlayersAssigned": {
     "description": "Success message when all players assigned"
   },
-
   "saveTeams": "Save Teams",
   "@saveTeams": {
     "description": "Save teams button text"
   },
-
   "assignAllPlayersToContinue": "Assign All Players to Continue",
   "@assignAllPlayersToContinue": {
     "description": "Message when not all players assigned"
   },
-
   "invitedBy": "Invited by {name}",
   "@invitedBy": {
-    "description": "Invitation info showing inviter name",
+    "description": "Label showing who sent the invite",
     "placeholders": {
       "name": {
         "type": "String"
       }
     }
   },
-
   "errorTitle": "Error",
   "@errorTitle": {
     "description": "Error title"
   },
-
   "participantsCount": "{current}/{max} participants",
   "@participantsCount": {
     "description": "Participants count display",
@@ -2083,7 +1697,6 @@
       }
     }
   },
-
   "doYouWantToJoin": "Do you want to join \"{sessionTitle}\"?\n\nDate: {dateTime}\nLocation: {location}",
   "@doYouWantToJoin": {
     "description": "Join confirmation dialog message",
@@ -2099,7 +1712,6 @@
       }
     }
   },
-
   "areYouSureLeave": "Are you sure you want to leave \"{sessionTitle}\"?",
   "@areYouSureLeave": {
     "description": "Leave confirmation dialog message",
@@ -2109,7 +1721,6 @@
       }
     }
   },
-
   "cancelSessionConfirm": "Are you sure you want to cancel \"{sessionTitle}\"?\n\nAll participants will be notified.",
   "@cancelSessionConfirm": {
     "description": "Cancel session confirmation message",
@@ -2119,7 +1730,6 @@
       }
     }
   },
-
   "durationFormat": "{hours}h {minutes}m",
   "@durationFormat": {
     "description": "Duration display format",
@@ -2132,7 +1742,6 @@
       }
     }
   },
-
   "durationHours": "{hours}h",
   "@durationHours": {
     "description": "Duration in hours only",
@@ -2142,7 +1751,6 @@
       }
     }
   },
-
   "durationMinutes": "{minutes}m",
   "@durationMinutes": {
     "description": "Duration in minutes only",
@@ -2152,56 +1760,66 @@
       }
     }
   },
-
   "bestPartner": "Best Partner",
   "noPartnerDataYet": "No partner data yet",
   "playGamesWithTeammate": "Play 5+ games with a teammate",
   "winRatePercent": "{rate}% Win Rate",
   "@winRatePercent": {
     "placeholders": {
-      "rate": {"type": "String"}
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "gamesCount": "{count} games",
   "@gamesCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "winsLossesGames": "{wins}W - {losses}L • {total} games",
   "@winsLossesGames": {
     "placeholders": {
-      "wins": {"type": "int"},
-      "losses": {"type": "int"},
-      "total": {"type": "int"}
+      "wins": {
+        "type": "int"
+      },
+      "losses": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
     }
   },
-
   "momentumAndConsistency": "Momentum & Consistency",
   "eloProgress": "ELO Progress",
   "winStreak": "Win Streak",
   "lossStreak": "Loss Streak",
   "noActiveStreak": "No Active Streak",
   "winNextGameToStartStreak": "Win your next game to start a streak!",
-
   "rival": "Rival",
   "matchups": "{count} matchups",
   "@matchups": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "winRateLabel": "Win Rate: {rate}%",
   "@winRateLabel": {
     "placeholders": {
-      "rate": {"type": "String"}
+      "rate": {
+        "type": "String"
+      }
     }
   },
   "tapForFullBreakdown": "Tap for full breakdown",
   "noNemesisYet": "No Nemesis Yet",
   "playGamesAgainstSameOpponent": "Play at least 3 games against the same opponent to track your toughest matchup.",
   "faceOpponentThreeTimes": "Face the same opponent 3+ times",
-
   "noPerformanceData": "No Performance Data",
   "playFirstGameToSeeStats": "Play your first game to see your performance statistics!",
   "playAtLeastOneGame": "Play at least 1 game to unlock",
@@ -2209,7 +1827,6 @@
   "currentElo": "Current ELO",
   "peakElo": "Peak ELO",
   "gamesPlayed": "Games Played",
-  "winRate": "Win Rate",
   "bestWin": "Best Win",
   "winGameToUnlock": "Win a game to unlock",
   "beatOpponentsToTrack": "Beat opponents to track your best victory",
@@ -2222,28 +1839,35 @@
   "setsCount": "{count} sets",
   "@setsCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "teamLabel": "Team: {names}",
   "@teamLabel": {
     "placeholders": {
-      "names": {"type": "String"}
+      "names": {
+        "type": "String"
+      }
     }
   },
   "teamEloLabel": "Team ELO: {elo}",
   "@teamEloLabel": {
     "placeholders": {
-      "elo": {"type": "String"}
+      "elo": {
+        "type": "String"
+      }
     }
   },
   "eloGained": "{amount} ELO gained",
   "@eloGained": {
     "placeholders": {
-      "amount": {"type": "String"}
+      "amount": {
+        "type": "String"
+      }
     }
   },
-
   "adaptabilityStats": "Adaptability Stats",
   "advanced": "Advanced",
   "seeHowYouPerform": "See how you perform in different team roles",
@@ -2255,33 +1879,35 @@
   "whenSimilarlyRatedTeammates": "When playing with similarly-rated teammates",
   "adaptabilityStatsLocked": "Adaptability Stats Locked",
   "playMoreGamesToSeeRoles": "Play more games to see how you perform in different team roles",
-
   "noStatsYet": "No Stats Yet",
   "startPlayingToSeeStats": "Start playing games to see your statistics!",
-
   "playGamesToUnlockRankings": "Play games to unlock rankings",
   "globalRank": "Global Rank",
   "percentile": "Percentile",
   "friendsRank": "Friends Rank",
   "addFriendsAction": "Add friends",
-
   "period30d": "30d",
   "period90d": "90d",
   "period1y": "1y",
   "periodAllTime": "∞",
-
   "monthlyProgressChart": "Monthly Progress Chart",
   "playAtLeastNGames": "Play at least {count} games",
   "@playAtLeastNGames": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "nOfNGames": "{current}/{total} games",
   "@nOfNGames": {
     "placeholders": {
-      "current": {"type": "int"},
-      "total": {"type": "int"}
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
     }
   },
   "startPlayingToTrackProgress": "Start playing to track your progress!",
@@ -2292,7 +1918,9 @@
   "noGamesPlayedInLast": "No games played in the last {period}",
   "@noGamesPlayedInLast": {
     "placeholders": {
-      "period": {"type": "String"}
+      "period": {
+        "type": "String"
+      }
     }
   },
   "trySelectingLongerPeriod": "Try selecting a longer time period",
@@ -2300,32 +1928,35 @@
   "periodLabel90Days": "90 days",
   "periodLabelYear": "year",
   "periodLabelAllTime": "all time",
-
   "bestEloThisMonth": "Best ELO This Month",
   "bestEloPast90Days": "Best ELO Past 90 Days",
   "bestEloThisYear": "Best ELO This Year",
   "bestEloAllTime": "Best ELO All Time",
-
   "lastNGames": "Last {count} games",
   "@lastNGames": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "noGamesPlayedYet": "No games played yet",
   "winsStreakCount": "{count} wins",
   "@winsStreakCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "lossesStreakCount": "{count} losses",
   "@lossesStreakCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "partnerDetailsTitle": "Partner Details",
   "overallRecord": "Overall Record",
   "games": "Games",
@@ -2340,345 +1971,283 @@
   "streakWins": "{count} W Streak",
   "@streakWins": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "streakLosses": "{count} L Streak",
   "@streakLosses": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "noRecentGames": "No recent games",
   "eloLabel": "ELO: {value}",
   "@eloLabel": {
     "placeholders": {
-      "value": {"type": "String"}
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "nextGame": "Next Game",
   "@nextGame": {
     "description": "Header for next upcoming game section on homepage"
   },
-
   "noGamesScheduled": "No games organized yet",
   "@noGamesScheduled": {
     "description": "Message shown when user has no upcoming games"
   },
-
   "nextTrainingSession": "Next Training Session",
   "@nextTrainingSession": {
     "description": "Header for next upcoming training session section on homepage"
   },
-
   "noTrainingSessionsScheduled": "No training sessions scheduled",
   "@noTrainingSessionsScheduled": {
     "description": "Message shown when user has no upcoming training sessions"
   },
-
   "stats": "Stats",
   "@stats": {
     "description": "Stats navigation tab label"
   },
-
   "myStats": "My Stats",
   "@myStats": {
     "description": "My Stats page title"
   },
-
   "generateInviteLink": "Generate Invite Link",
   "@generateInviteLink": {
     "description": "Button label to generate a shareable group invite link"
   },
-
   "copyLink": "Copy Link",
   "@copyLink": {
     "description": "Button label to copy the invite link to clipboard"
   },
-
   "shareLink": "Share",
   "@shareLink": {
     "description": "Button label to open native share sheet for the invite link"
   },
-
   "linkCopied": "Link copied to clipboard",
   "@linkCopied": {
     "description": "Snackbar message after invite link is copied"
   },
-
   "inviteLinkSectionTitle": "Invite Members",
   "@inviteLinkSectionTitle": {
     "description": "Section title for invite link generation area"
   },
-
   "inviteLinkDescription": "Share this link to invite people to join the group.",
   "@inviteLinkDescription": {
     "description": "Description text in the invite link section"
   },
-
   "revokeInvite": "Revoke Invite",
   "@revokeInvite": {
     "description": "Button label to revoke an invite link"
   },
-
   "inviteRevoked": "Invite link revoked",
   "@inviteRevoked": {
     "description": "Snackbar message after invite link is revoked"
   },
-
   "generateInviteError": "Failed to generate invite link",
   "@generateInviteError": {
     "description": "Error message when invite link generation fails"
   },
-
   "revokeInviteError": "Failed to revoke invite link",
   "@revokeInviteError": {
     "description": "Error message when invite link revocation fails"
   },
-
   "inviteLinkShareMessage": "Join my group on Gatherli! {url}",
   "@inviteLinkShareMessage": {
     "description": "Message shared via native share sheet with the invite link",
     "placeholders": {
-      "url": {"type": "String"}
+      "url": {
+        "type": "String"
+      }
     }
   },
-
   "pageNotFound": "Page Not Found",
   "@pageNotFound": {
     "description": "Title shown when navigating to an unknown route"
   },
-
   "pageNotFoundMessage": "The requested page could not be found.",
   "@pageNotFoundMessage": {
     "description": "Message shown when navigating to an unknown route"
   },
-
   "inviteOnboardingTitle": "You've been invited!",
   "@inviteOnboardingTitle": {
     "description": "Title on the invite onboarding page"
   },
-
   "inviteOnboardingSubtitle": "You've been invited to join:",
   "@inviteOnboardingSubtitle": {
     "description": "Subtitle on the invite onboarding page"
   },
-
-  "createAccount": "Create Account",
-  "@createAccount": {
-    "description": "Button text to create a new account"
-  },
-
   "iHaveAnAccount": "I have an account",
   "@iHaveAnAccount": {
     "description": "Button text for existing users to log in"
   },
-
   "joinGroup": "Join Group",
   "@joinGroup": {
     "description": "Button text to join a group via invite"
   },
-
   "joinGroupConfirmation": "Join Group?",
   "@joinGroupConfirmation": {
     "description": "Title on the join group confirmation page"
   },
-
-  "invitedBy": "Invited by {name}",
-  "@invitedBy": {
-    "description": "Label showing who sent the invite",
-    "placeholders": {
-      "name": {"type": "String"}
-    }
-  },
-
   "membersCount": "{count} members",
   "@membersCount": {
     "description": "Label showing the number of group members",
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "inviteExpired": "This invite link has expired",
   "@inviteExpired": {
     "description": "Error message when invite link has expired"
   },
-
   "inviteLinkRevoked": "This invite link is no longer valid",
   "@inviteLinkRevoked": {
     "description": "Error message when invite link has been revoked"
   },
-
   "inviteLimitReached": "This invite link has reached its usage limit",
   "@inviteLimitReached": {
     "description": "Error message when invite link usage limit is reached"
   },
-
   "groupJoinedSuccess": "Welcome to {groupName}!",
   "@groupJoinedSuccess": {
     "description": "Success message after joining a group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
-
   "alreadyAMember": "You're already a member of this group",
   "@alreadyAMember": {
     "description": "Message when user is already a member of the group"
   },
-
   "continueToApp": "Continue to app",
   "@continueToApp": {
     "description": "Button text to continue to the main app"
   },
-
   "validatingInvite": "Validating invite...",
   "@validatingInvite": {
     "description": "Loading message while validating an invite token"
   },
-
   "joiningGroup": "Joining group...",
   "@joiningGroup": {
     "description": "Loading message while joining a group"
   },
-
   "createAccountToJoin": "Create your account to join:",
   "@createAccountToJoin": {
     "description": "Header text on invite registration page"
   },
-
   "fullNameHint": "Full Name",
   "@fullNameHint": {
     "description": "Hint text for full name field"
   },
-
   "fullNameRequired": "Full name is required",
   "@fullNameRequired": {
     "description": "Validation error when full name is empty"
   },
-
   "fullNameTooShort": "Full name must be at least 2 characters",
   "@fullNameTooShort": {
     "description": "Validation error when full name is too short"
   },
-
   "firstNameHint": "First Name",
   "@firstNameHint": {
     "description": "Hint text for first name field"
   },
-
   "firstNameRequired": "First name is required",
   "@firstNameRequired": {
     "description": "Validation error when first name is empty"
   },
-
   "firstNameTooShort": "First name must be at least 2 characters",
   "@firstNameTooShort": {
     "description": "Validation error when first name is too short"
   },
-
   "lastNameHint": "Last Name",
   "@lastNameHint": {
     "description": "Hint text for last name field"
   },
-
   "lastNameRequired": "Last name is required",
   "@lastNameRequired": {
     "description": "Validation error when last name is empty"
   },
-
   "lastNameTooShort": "Last name must be at least 2 characters",
   "@lastNameTooShort": {
     "description": "Validation error when last name is too short"
   },
-
   "displayNameHintRequired": "Display Name",
   "@displayNameHintRequired": {
     "description": "Hint text for required display name field"
   },
-
   "displayNameRequired": "Display name is required",
   "@displayNameRequired": {
     "description": "Validation error when display name is empty"
   },
-
   "displayNameTooShortInvite": "Display name must be at least 3 characters",
   "@displayNameTooShortInvite": {
     "description": "Validation error when display name is too short on invite registration"
   },
-
   "displayNameTooLongInvite": "Display name must be at most 30 characters",
   "@displayNameTooLongInvite": {
     "description": "Validation error when display name is too long on invite registration"
   },
-
   "passwordRequirementsHint": "At least 8 characters, 1 uppercase letter, 1 number",
   "@passwordRequirementsHint": {
     "description": "Helper text explaining password requirements"
   },
-
   "passwordTooShortInvite": "Password must be at least 8 characters",
   "@passwordTooShortInvite": {
     "description": "Validation error when password is too short on invite registration"
   },
-
   "passwordMissingUppercase": "Password must contain at least 1 uppercase letter",
   "@passwordMissingUppercase": {
     "description": "Validation error when password has no uppercase letter"
   },
-
   "passwordMissingNumber": "Password must contain at least 1 number",
   "@passwordMissingNumber": {
     "description": "Validation error when password has no number"
   },
-
   "createAccountAndJoin": "Create Account & Join",
   "@createAccountAndJoin": {
     "description": "Button text to create account and join group"
   },
-
   "alreadyHaveAccountLogin": "Already have an account? Log in",
   "@alreadyHaveAccountLogin": {
     "description": "Link text for existing users on invite registration page"
   },
-
   "accountCreatedJoiningGroup": "Account created! Joining group...",
   "@accountCreatedJoiningGroup": {
     "description": "Loading message after account creation while joining group"
   },
-
   "inviteExpiredDuringRegistration": "The invite link has expired, but your account was created successfully.",
   "@inviteExpiredDuringRegistration": {
     "description": "Message when invite expires during registration"
   },
-
   "emailAlreadyInUse": "An account with this email already exists. Try logging in instead.",
   "@emailAlreadyInUse": {
     "description": "Error when email is already registered"
   },
-
   "weakPasswordError": "Password is too weak. Use at least 8 characters.",
   "@weakPasswordError": {
     "description": "Error when password is too weak"
   },
-
   "invalidEmailError": "Please enter a valid email address.",
   "@invalidEmailError": {
     "description": "Error when email format is invalid"
   },
-
   "networkError": "Unable to connect. Please check your connection and try again.",
   "@networkError": {
     "description": "Error when network connection fails"
   },
-
   "creatingAccount": "Creating account...",
   "@creatingAccount": {
     "description": "Loading message while creating account"
   },
-
   "verifyEmailWarning": "Verify your email to keep your account. {daysRemaining} days left.",
   "@verifyEmailWarning": {
     "description": "Warning banner message for unverified email during grace period",
@@ -2688,22 +2257,18 @@
       }
     }
   },
-
   "verifyNow": "Verify Now",
   "@verifyNow": {
     "description": "Button label to trigger email verification resend"
   },
-
   "dismiss": "Dismiss",
   "@dismiss": {
     "description": "Button label to dismiss the verification warning banner"
   },
-
   "emailVerifiedSuccess": "Email verified successfully!",
   "@emailVerifiedSuccess": {
     "description": "Success message shown when email verification is confirmed"
   },
-
   "accountRestricted": "Your account is restricted. Verify your email to regain full access. {daysUntilDeletion} days until account deletion.",
   "@accountRestricted": {
     "description": "Warning message shown when account is restricted due to unverified email past grace period",
@@ -2714,32 +2279,26 @@
       }
     }
   },
-
   "accountScheduledForDeletion": "Your account is scheduled for deletion. Verify your email now to keep your account.",
   "@accountScheduledForDeletion": {
     "description": "Warning message shown when account is past 30 days without email verification"
   },
-
   "accountStatusActive": "Active",
   "@accountStatusActive": {
     "description": "Label for active account status"
   },
-
   "accountStatusPendingVerification": "Pending Verification",
   "@accountStatusPendingVerification": {
     "description": "Label for pending verification account status"
   },
-
   "accountStatusRestricted": "Restricted",
   "@accountStatusRestricted": {
     "description": "Label for restricted account status"
   },
-
   "accountStatusScheduledForDeletion": "Scheduled for Deletion",
   "@accountStatusScheduledForDeletion": {
     "description": "Label for scheduled-for-deletion account status"
   },
-
   "accountDeletionWarning": "Account will be deleted in {daysRemaining} days.",
   "@accountDeletionWarning": {
     "description": "Warning message showing days until account deletion for restricted users",
@@ -2750,22 +2309,18 @@
       }
     }
   },
-
   "featureRestricted": "This feature requires email verification.",
   "@featureRestricted": {
     "description": "Message shown when a restricted user tries to use a blocked feature"
   },
-
   "verifyToUnlock": "Verify your email to use this feature.",
   "@verifyToUnlock": {
     "description": "Explanation message in the restriction dialog"
   },
-
   "featureRestrictedTitle": "Feature Restricted",
   "@featureRestrictedTitle": {
     "description": "Title of the dialog shown when a restricted user tries a blocked action"
   },
-
   "verifyEmail": "Verify Email",
   "@verifyEmail": {
     "description": "Button label to verify email in restriction dialog"
@@ -2774,12 +2329,10 @@
   "@orLater": {
     "description": "Suffix shown in time picker when today is selected, indicating the minimum selectable time"
   },
-
   "loadOlderActivities": "Load older activities",
   "@loadOlderActivities": {
     "description": "Button label to load activities older than 90 days in the group details activity feed"
   },
-
   "genderSelectionTitle": "Gender",
   "@genderSelectionTitle": {
     "description": "Title of the gender selection onboarding screen"
@@ -2808,7 +2361,6 @@
   "@genderSelectionError": {
     "description": "Error message shown when saving gender fails"
   },
-
   "deleteAccount": "Delete Account",
   "@deleteAccount": {
     "description": "Label for the delete account button"
@@ -2841,7 +2393,6 @@
   "@registrationGenderTooltip": {
     "description": "Tooltip explaining why gender is asked during registration"
   },
-
   "inviteGuestPlayers": "Invite people from other groups",
   "@inviteGuestPlayers": {
     "description": "Title of the invite guest players bottom sheet (Story 28.6)"
@@ -2862,20 +2413,19 @@
   "@invitePlayerSuccess": {
     "description": "Snackbar message after successfully sending a guest invitation (Story 28.6)"
   },
-
   "inviteGroupSuccess": "Group invited successfully",
   "@inviteGroupSuccess": {
     "description": "Snackbar message after inviting all players in a group (Story 28.6)"
   },
-
   "groupMembersCount": "{count, plural, =1{1 person} other{{count} people}}",
   "@groupMembersCount": {
     "description": "Member count label on a group invite card",
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "invitedLabel": "Invited",
   "@invitedLabel": {
     "description": "Label shown on a group card after all its players have been invited"
@@ -2900,7 +2450,9 @@
   "@fromGroup": {
     "description": "Label on a game invitation card showing the source group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
   "gameInvitationAccepted": "Invitation accepted",
@@ -2915,12 +2467,10 @@
   "@gameInvitationActionError": {
     "description": "Snackbar shown when accepting or declining a game invitation fails"
   },
-
   "upcoming": "Upcoming",
   "@upcoming": {
     "description": "Section header for upcoming games in MyGamesPage"
   },
-
   "pastGames": "Past Games",
   "open": "Open",
   "@open": {
@@ -2929,7 +2479,6 @@
   "@pastGames": {
     "description": "Section header for past games in MyGamesPage"
   },
-
   "teamsForThisGame": "Teams",
   "@teamsForThisGame": {
     "description": "Section label for per-game team picker"
@@ -2942,7 +2491,6 @@
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
   },
-
   "chatSectionTitle": "Chat",
   "@chatSectionTitle": {
     "description": "Title of the in-game chat section on the game details page"
@@ -2963,7 +2511,6 @@
   "@chatJoinToView": {
     "description": "Message shown to users who are not in the game and cannot see the chat"
   },
-
   "createPickupGame": "Create Pickup Game",
   "@createPickupGame": {
     "description": "FAB tooltip and button label for creating a pickup game"
@@ -3029,355 +2576,789 @@
   "@next": {
     "description": "Next button in multi-step form"
   },
-  "championshipsTitle": "Championships",
-  "@championshipsTitle": {"description": "Title for the championships list screen"},
+  "championshipsTitle": "Leagues",
+  "@championshipsTitle": {
+    "description": "Title for the championships list screen"
+  },
   "championshipOpenRegistration": "Open registration",
-  "@championshipOpenRegistration": {"description": "Status label when a championship is accepting team registrations"},
+  "@championshipOpenRegistration": {
+    "description": "Status label when a championship is accepting team registrations"
+  },
   "championshipTeamsCount": "{count, plural, =1{1 team registered} other{{count} teams registered}}",
-  "@championshipTeamsCount": {"description": "Number of teams registered in a championship", "placeholders": {"count": {"type": "int"}}},
+  "@championshipTeamsCount": {
+    "description": "Number of teams registered in a championship",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "championshipSlotsLeft": "{count, plural, =1{1 slot left} other{{count} slots left}}",
-  "@championshipSlotsLeft": {"description": "Number of registration slots remaining", "placeholders": {"count": {"type": "int"}}},
+  "@championshipSlotsLeft": {
+    "description": "Number of registration slots remaining",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "championshipDeadlineLabel": "Deadline: {date}",
-  "@championshipDeadlineLabel": {"description": "Registration deadline label", "placeholders": {"date": {"type": "String"}}},
+  "@championshipDeadlineLabel": {
+    "description": "Registration deadline label",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "registerTeam": "Register team",
-  "@registerTeam": {"description": "Button to open the team registration bottom sheet"},
+  "@registerTeam": {
+    "description": "Button to open the team registration bottom sheet"
+  },
   "leaveTeam": "Leave team",
-  "@leaveTeam": {"description": "Button to leave / delete the user's team"},
+  "@leaveTeam": {
+    "description": "Button to leave / delete the user's team"
+  },
   "leaveTeamConfirmTitle": "Leave team?",
-  "@leaveTeamConfirmTitle": {"description": "Confirmation dialog title when leaving a team"},
+  "@leaveTeamConfirmTitle": {
+    "description": "Confirmation dialog title when leaving a team"
+  },
   "leaveTeamConfirmBody": "Your team will be deleted and your slot will be freed.",
-  "@leaveTeamConfirmBody": {"description": "Confirmation dialog body when leaving a team"},
+  "@leaveTeamConfirmBody": {
+    "description": "Confirmation dialog body when leaving a team"
+  },
   "createTeamTitle": "Create your team",
-  "@createTeamTitle": {"description": "Title of the create-team bottom sheet"},
+  "@createTeamTitle": {
+    "description": "Title of the create-team bottom sheet"
+  },
   "teamNameLabel": "Team name",
-  "@teamNameLabel": {"description": "Label for the team name text field"},
+  "@teamNameLabel": {
+    "description": "Label for the team name text field"
+  },
   "teamNameHint": "e.g. Beach Wolves",
-  "@teamNameHint": {"description": "Hint text for the team name input"},
+  "@teamNameHint": {
+    "description": "Hint text for the team name input"
+  },
   "selectPartnerLabel": "Select your partner",
-  "@selectPartnerLabel": {"description": "Section header for the partner picker"},
+  "@selectPartnerLabel": {
+    "description": "Section header for the partner picker"
+  },
   "noFriendsForPartner": "You have no friends to invite yet. Add friends from My Community first.",
-  "@noFriendsForPartner": {"description": "Empty state when the user has no friends to pick as partner"},
+  "@noFriendsForPartner": {
+    "description": "Empty state when the user has no friends to pick as partner"
+  },
   "teamRegisteredSuccess": "Team registered!",
-  "@teamRegisteredSuccess": {"description": "Snackbar message after successfully registering a team"},
+  "@teamRegisteredSuccess": {
+    "description": "Snackbar message after successfully registering a team"
+  },
   "teamLeftSuccess": "You have left the team.",
-  "@teamLeftSuccess": {"description": "Snackbar message after successfully leaving a team"},
+  "@teamLeftSuccess": {
+    "description": "Snackbar message after successfully leaving a team"
+  },
   "yourTeam": "Your team",
-  "@yourTeam": {"description": "Section header showing the user's registered team"},
+  "@yourTeam": {
+    "description": "Section header showing the user's registered team"
+  },
   "matchChatTitle": "Match Chat",
-  "@matchChatTitle": {"description": "Title of the per-match coordination chat section"},
+  "@matchChatTitle": {
+    "description": "Title of the per-match coordination chat section"
+  },
   "matchChatCoordinationHint": "Coordinate date, time & location with the opposing team",
-  "@matchChatCoordinationHint": {"description": "Subtitle under the match chat title explaining its purpose"},
+  "@matchChatCoordinationHint": {
+    "description": "Subtitle under the match chat title explaining its purpose"
+  },
   "matchChatNotMember": "Only team members can participate in this chat.",
-  "@matchChatNotMember": {"description": "Message shown to users who are not part of either team in the match"},
+  "@matchChatNotMember": {
+    "description": "Message shown to users who are not part of either team in the match"
+  },
   "matchChatEmpty": "No messages yet. Start coordinating with the opposing team!",
-  "@matchChatEmpty": {"description": "Empty state message in the match chat when no messages have been sent"},
+  "@matchChatEmpty": {
+    "description": "Empty state message in the match chat when no messages have been sent"
+  },
   "submitResultTitle": "Submit Result",
-  "@submitResultTitle": {"description": "Title of the match result entry form"},
+  "@submitResultTitle": {
+    "description": "Title of the match result entry form"
+  },
   "submitResultSet": "Set {number}",
-  "@submitResultSet": {"description": "Label for a set row in the result form", "placeholders": {"number": {"type": "int"}}},
+  "@submitResultSet": {
+    "description": "Label for a set row in the result form",
+    "placeholders": {
+      "number": {
+        "type": "int"
+      }
+    }
+  },
   "submitResultAddSet3": "+ Add deciding set (set 3)",
-  "@submitResultAddSet3": {"description": "Button to add the optional deciding set to the result form"},
+  "@submitResultAddSet3": {
+    "description": "Button to add the optional deciding set to the result form"
+  },
   "submitResultRemoveSet3": "Remove set 3",
-  "@submitResultRemoveSet3": {"description": "Button to remove the deciding set from the result form"},
+  "@submitResultRemoveSet3": {
+    "description": "Button to remove the deciding set from the result form"
+  },
   "submitResultSubmitButton": "Submit Result",
-  "@submitResultSubmitButton": {"description": "Submit button label on the result entry form"},
+  "@submitResultSubmitButton": {
+    "description": "Submit button label on the result entry form"
+  },
   "submitResultAwaitingVerification": "Result submitted. Awaiting verification by the opposing team.",
-  "@submitResultAwaitingVerification": {"description": "Success message shown after result submission, before verification"},
+  "@submitResultAwaitingVerification": {
+    "description": "Success message shown after result submission, before verification"
+  },
   "submitResultInvalidSetScore": "Invalid score",
-  "@submitResultInvalidSetScore": {"description": "Error prefix shown when a set score fails validation"},
+  "@submitResultInvalidSetScore": {
+    "description": "Error prefix shown when a set score fails validation"
+  },
   "submitResultNoWinner": "One team must win 2 sets.",
-  "@submitResultNoWinner": {"description": "Validation error when the sets entered don't produce a clear winner"},
+  "@submitResultNoWinner": {
+    "description": "Validation error when the sets entered don't produce a clear winner"
+  },
   "verifyResultTitle": "Verify Result",
-  "@verifyResultTitle": {"description": "Title of the match result verification card"},
+  "@verifyResultTitle": {
+    "description": "Title of the match result verification card"
+  },
   "verifyResultSubmittedBy": "Result submitted by {teamName}",
-  "@verifyResultSubmittedBy": {"description": "Subtitle showing which team submitted the result", "placeholders": {"teamName": {"type": "String"}}},
+  "@verifyResultSubmittedBy": {
+    "description": "Subtitle showing which team submitted the result",
+    "placeholders": {
+      "teamName": {
+        "type": "String"
+      }
+    }
+  },
   "verifyResultConfirmButton": "Confirm Result",
-  "@verifyResultConfirmButton": {"description": "Button to verify/confirm the submitted match result"},
+  "@verifyResultConfirmButton": {
+    "description": "Button to verify/confirm the submitted match result"
+  },
   "verifyResultDisputeButton": "Dispute Result",
-  "@verifyResultDisputeButton": {"description": "Button to dispute the submitted match result"},
+  "@verifyResultDisputeButton": {
+    "description": "Button to dispute the submitted match result"
+  },
   "verifyResultDisputeReasonLabel": "Reason for dispute",
-  "@verifyResultDisputeReasonLabel": {"description": "Label above the dispute reason text field"},
+  "@verifyResultDisputeReasonLabel": {
+    "description": "Label above the dispute reason text field"
+  },
   "verifyResultDisputeReasonHint": "Explain why the result is incorrect...",
-  "@verifyResultDisputeReasonHint": {"description": "Hint text inside the dispute reason text field"},
+  "@verifyResultDisputeReasonHint": {
+    "description": "Hint text inside the dispute reason text field"
+  },
   "verifyResultDisputeReasonRequired": "Please provide a reason for the dispute.",
-  "@verifyResultDisputeReasonRequired": {"description": "Validation error shown when the dispute reason field is empty"},
+  "@verifyResultDisputeReasonRequired": {
+    "description": "Validation error shown when the dispute reason field is empty"
+  },
   "verifyResultVerified": "Result confirmed. Standings will be updated shortly.",
-  "@verifyResultVerified": {"description": "Success message shown after the opposing team confirms the match result"},
+  "@verifyResultVerified": {
+    "description": "Success message shown after the opposing team confirms the match result"
+  },
   "verifyResultDisputed": "Result disputed. An admin will review and resolve it.",
-  "@verifyResultDisputed": {"description": "Message shown after the opposing team disputes the match result"},
+  "@verifyResultDisputed": {
+    "description": "Message shown after the opposing team disputes the match result"
+  },
   "championshipFilterAll": "All",
-  "@championshipFilterAll": {"description": "Filter chip label to show all championships"},
+  "@championshipFilterAll": {
+    "description": "Filter chip label to show all championships"
+  },
   "championshipFilterRegistration": "Registration",
-  "@championshipFilterRegistration": {"description": "Filter chip label to show championships in registration phase"},
+  "@championshipFilterRegistration": {
+    "description": "Filter chip label to show championships in registration phase"
+  },
   "championshipFilterActive": "Active",
-  "@championshipFilterActive": {"description": "Filter chip label to show active championships"},
+  "@championshipFilterActive": {
+    "description": "Filter chip label to show active championships"
+  },
   "championshipFilterCompleted": "Completed",
-  "@championshipFilterCompleted": {"description": "Filter chip label to show completed championships"},
+  "@championshipFilterCompleted": {
+    "description": "Filter chip label to show completed championships"
+  },
   "championshipStatusBadgeRegistration": "Registration Open",
-  "@championshipStatusBadgeRegistration": {"description": "Status badge for championships accepting team registrations"},
+  "@championshipStatusBadgeRegistration": {
+    "description": "Status badge for championships accepting team registrations"
+  },
   "championshipStatusBadgeClosed": "Registration Closed",
-  "@championshipStatusBadgeClosed": {"description": "Status badge for championships that closed registration"},
+  "@championshipStatusBadgeClosed": {
+    "description": "Status badge for championships that closed registration"
+  },
   "championshipStatusBadgeActive": "Round {current}/{total}",
-  "@championshipStatusBadgeActive": {"description": "Status badge for active championships showing current round", "placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},
+  "@championshipStatusBadgeActive": {
+    "description": "Status badge for active championships showing current round",
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "championshipStatusBadgeCompleted": "Completed",
-  "@championshipStatusBadgeCompleted": {"description": "Status badge for completed championships"},
+  "@championshipStatusBadgeCompleted": {
+    "description": "Status badge for completed championships"
+  },
   "championshipMyMatchesTab": "My Matches",
-  "@championshipMyMatchesTab": {"description": "Tab label showing the current user's team matches"},
-  "championshipMyMatchesEmpty": "Your matches will appear here once the championship starts.",
-  "@championshipMyMatchesEmpty": {"description": "Empty state in the My Matches tab"},
+  "@championshipMyMatchesTab": {
+    "description": "Tab label showing the current user's team matches"
+  },
+  "championshipMyMatchesEmpty": "Your matches will appear here once the league starts.",
+  "@championshipMyMatchesEmpty": {
+    "description": "Empty state in the My Matches tab"
+  },
   "championshipMyMatchesVs": "vs {opponent}",
-  "@championshipMyMatchesVs": {"description": "Match row label: vs opponent", "placeholders": {"opponent": {"type": "String"}}},
+  "@championshipMyMatchesVs": {
+    "description": "Match row label: vs opponent",
+    "placeholders": {
+      "opponent": {
+        "type": "String"
+      }
+    }
+  },
   "championshipTabActive": "Active",
-  "@championshipTabActive": {"description": "Tab label for active championships (registration / in-progress)"},
+  "@championshipTabActive": {
+    "description": "Tab label for active championships (registration / in-progress)"
+  },
   "championshipTabCompleted": "Completed",
-  "@championshipTabCompleted": {"description": "Tab label for completed championships"},
-  "championshipNoCompletedYet": "No completed championships yet.",
-  "@championshipNoCompletedYet": {"description": "Empty state shown in the Completed tab"},
-  "championshipNoResults": "No championships at the moment.",
-  "@championshipNoResults": {"description": "Empty state message on the championship list screen"},
+  "@championshipTabCompleted": {
+    "description": "Tab label for completed championships"
+  },
+  "championshipNoCompletedYet": "No completed leagues yet.",
+  "@championshipNoCompletedYet": {
+    "description": "Empty state shown in the Completed tab"
+  },
+  "championshipNoResults": "No leagues at the moment.",
+  "@championshipNoResults": {
+    "description": "Empty state message on the championship list screen"
+  },
   "championshipDeadlineCountdown": "{days, plural, =1{1 day left} other{{days} days left}}",
-  "@championshipDeadlineCountdown": {"description": "Countdown until registration deadline", "placeholders": {"days": {"type": "int"}}},
+  "@championshipDeadlineCountdown": {
+    "description": "Countdown until registration deadline",
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
   "championshipTeamCountOf": "{count} / {max} teams",
-  "@championshipTeamCountOf": {"description": "Team count display on championship card", "placeholders": {"count": {"type": "int"}, "max": {"type": "int"}}},
-
+  "@championshipTeamCountOf": {
+    "description": "Team count display on championship card",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
   "championshipGenderMale": "Men",
-  "@championshipGenderMale": {"description": "Label for male-only championship gender category"},
+  "@championshipGenderMale": {
+    "description": "Label for male-only championship gender category"
+  },
   "championshipGenderFemale": "Women",
-  "@championshipGenderFemale": {"description": "Label for female-only championship gender category"},
+  "@championshipGenderFemale": {
+    "description": "Label for female-only championship gender category"
+  },
   "championshipGenderBlockNoGender": "You must set your gender in your profile to register.",
-  "@championshipGenderBlockNoGender": {"description": "Message shown when user has no gender set and tries to register"},
-  "championshipGenderBlockMaleOnly": "This championship is for men only.",
-  "@championshipGenderBlockMaleOnly": {"description": "Message shown when female/no-gender user tries to register in a male championship"},
-  "championshipGenderBlockFemaleOnly": "This championship is for women only.",
-  "@championshipGenderBlockFemaleOnly": {"description": "Message shown when male/no-gender user tries to register in a female championship"},
+  "@championshipGenderBlockNoGender": {
+    "description": "Message shown when user has no gender set and tries to register"
+  },
+  "championshipGenderBlockMaleOnly": "This league is for men only.",
+  "@championshipGenderBlockMaleOnly": {
+    "description": "Message shown when female/no-gender user tries to register in a male championship"
+  },
+  "championshipGenderBlockFemaleOnly": "This league is for women only.",
+  "@championshipGenderBlockFemaleOnly": {
+    "description": "Message shown when male/no-gender user tries to register in a female championship"
+  },
   "championshipCreateGenderLabel": "Gender category (optional)",
-  "@championshipCreateGenderLabel": {"description": "Label for the gender category picker in championship creation form"},
-
+  "@championshipCreateGenderLabel": {
+    "description": "Label for the gender category picker in championship creation form"
+  },
   "championshipDetailStandingsTab": "Standings",
-  "@championshipDetailStandingsTab": {"description": "Label for the standings tab on the championship detail screen"},
+  "@championshipDetailStandingsTab": {
+    "description": "Label for the standings tab on the championship detail screen"
+  },
   "championshipDetailMatchesTab": "Matches",
-  "@championshipDetailMatchesTab": {"description": "Label for the matches tab on the championship detail screen"},
+  "@championshipDetailMatchesTab": {
+    "description": "Label for the matches tab on the championship detail screen"
+  },
   "championshipDetailRound": "Round {round}",
-  "@championshipDetailRound": {"description": "Round label in the matches tab round selector", "placeholders": {"round": {"type": "int"}}},
+  "@championshipDetailRound": {
+    "description": "Round label in the matches tab round selector",
+    "placeholders": {
+      "round": {
+        "type": "int"
+      }
+    }
+  },
   "championshipDetailColPosition": "#",
-  "@championshipDetailColPosition": {"description": "Standings table header for position column"},
+  "@championshipDetailColPosition": {
+    "description": "Standings table header for position column"
+  },
   "championshipDetailColTeam": "Team",
-  "@championshipDetailColTeam": {"description": "Standings table header for team name column"},
+  "@championshipDetailColTeam": {
+    "description": "Standings table header for team name column"
+  },
   "championshipDetailColPlayed": "P",
-  "@championshipDetailColPlayed": {"description": "Standings table header for matches played column"},
+  "@championshipDetailColPlayed": {
+    "description": "Standings table header for matches played column"
+  },
   "championshipDetailColPoints": "Pts",
-  "@championshipDetailColPoints": {"description": "Standings table header for points column"},
+  "@championshipDetailColPoints": {
+    "description": "Standings table header for points column"
+  },
   "championshipDetailColWins": "W",
-  "@championshipDetailColWins": {"description": "Standings table header for wins column"},
+  "@championshipDetailColWins": {
+    "description": "Standings table header for wins column"
+  },
   "championshipDetailColLosses": "L",
-  "@championshipDetailColLosses": {"description": "Standings table header for losses column"},
+  "@championshipDetailColLosses": {
+    "description": "Standings table header for losses column"
+  },
   "championshipDetailColSetRatio": "SR",
-  "@championshipDetailColSetRatio": {"description": "Standings table header for set ratio column"},
+  "@championshipDetailColSetRatio": {
+    "description": "Standings table header for set ratio column"
+  },
   "championshipDetailNoStandings": "No standings yet.",
-  "@championshipDetailNoStandings": {"description": "Empty state when no standings data is available"},
+  "@championshipDetailNoStandings": {
+    "description": "Empty state when no standings data is available"
+  },
   "championshipDetailTeamsTab": "Teams",
-  "@championshipDetailTeamsTab": {"description": "Tab label shown instead of Standings when championship is in registration phase"},
+  "@championshipDetailTeamsTab": {
+    "description": "Tab label shown instead of Standings when championship is in registration phase"
+  },
   "championshipDetailNoTeamsYet": "No teams registered yet.\nBe the first to sign up!",
-  "@championshipDetailNoTeamsYet": {"description": "Empty state shown in the teams list before registration phase has any teams"},
+  "@championshipDetailNoTeamsYet": {
+    "description": "Empty state shown in the teams list before registration phase has any teams"
+  },
   "championshipDetailNoMatchesForRound": "No matches for this round.",
-  "@championshipDetailNoMatchesForRound": {"description": "Empty state when a round has no matches"},
+  "@championshipDetailNoMatchesForRound": {
+    "description": "Empty state when a round has no matches"
+  },
   "championshipMatchVs": "vs",
-  "@championshipMatchVs": {"description": "Separator between two team names in a match card"},
+  "@championshipMatchVs": {
+    "description": "Separator between two team names in a match card"
+  },
   "championshipMatchStatusPending": "Pending",
-  "@championshipMatchStatusPending": {"description": "Match status badge: not yet played"},
+  "@championshipMatchStatusPending": {
+    "description": "Match status badge: not yet played"
+  },
   "championshipMatchStatusPlayed": "Played",
-  "@championshipMatchStatusPlayed": {"description": "Match status badge: result submitted, awaiting verification"},
+  "@championshipMatchStatusPlayed": {
+    "description": "Match status badge: result submitted, awaiting verification"
+  },
   "championshipMatchStatusVerified": "Verified",
-  "@championshipMatchStatusVerified": {"description": "Match status badge: result verified by both teams"},
+  "@championshipMatchStatusVerified": {
+    "description": "Match status badge: result verified by both teams"
+  },
   "championshipMatchStatusDisputed": "Disputed",
-  "@championshipMatchStatusDisputed": {"description": "Match status badge: result disputed by opposing team"},
+  "@championshipMatchStatusDisputed": {
+    "description": "Match status badge: result disputed by opposing team"
+  },
   "championshipMatchStatusAdminDecided": "Decided",
-  "@championshipMatchStatusAdminDecided": {"description": "Match status badge: result decided by admin"},
+  "@championshipMatchStatusAdminDecided": {
+    "description": "Match status badge: result decided by admin"
+  },
   "championshipMatchStatusScheduled": "Scheduled",
-  "@championshipMatchStatusScheduled": {"description": "Match status badge: match has a proposed schedule"},
+  "@championshipMatchStatusScheduled": {
+    "description": "Match status badge: match has a proposed schedule"
+  },
   "matchDetailTitle": "Match Detail",
-  "@matchDetailTitle": {"description": "AppBar title for the match detail screen"},
+  "@matchDetailTitle": {
+    "description": "AppBar title for the match detail screen"
+  },
   "matchDetailScheduledAt": "Scheduled: {datetime}",
-  "@matchDetailScheduledAt": {"description": "Shows the proposed match date/time", "placeholders": {"datetime": {"type": "String"}}},
+  "@matchDetailScheduledAt": {
+    "description": "Shows the proposed match date/time",
+    "placeholders": {
+      "datetime": {
+        "type": "String"
+      }
+    }
+  },
   "matchDetailProposeSchedule": "Propose Schedule",
-  "@matchDetailProposeSchedule": {"description": "Button to open the propose schedule dialog"},
+  "@matchDetailProposeSchedule": {
+    "description": "Button to open the propose schedule dialog"
+  },
   "matchDetailProposeDateLabel": "Date",
-  "@matchDetailProposeDateLabel": {"description": "Label for the date picker in the propose schedule dialog"},
+  "@matchDetailProposeDateLabel": {
+    "description": "Label for the date picker in the propose schedule dialog"
+  },
   "matchDetailProposeTimeLabel": "Time",
-  "@matchDetailProposeTimeLabel": {"description": "Label for the time picker in the propose schedule dialog"},
+  "@matchDetailProposeTimeLabel": {
+    "description": "Label for the time picker in the propose schedule dialog"
+  },
   "matchDetailProposeLocationLabel": "Location (optional)",
-  "@matchDetailProposeLocationLabel": {"description": "Label for the location field in the propose schedule dialog"},
+  "@matchDetailProposeLocationLabel": {
+    "description": "Label for the location field in the propose schedule dialog"
+  },
   "matchDetailProposeConfirm": "Propose",
-  "@matchDetailProposeConfirm": {"description": "Confirm button in the propose schedule dialog"},
-
+  "@matchDetailProposeConfirm": {
+    "description": "Confirm button in the propose schedule dialog"
+  },
   "adminPanelTabLabel": "Admin",
-  "@adminPanelTabLabel": {"description": "Label for the admin tab in championship detail"},
+  "@adminPanelTabLabel": {
+    "description": "Label for the admin tab in championship detail"
+  },
   "adminPanelNoMatchesNeedingAttention": "No matches requiring admin attention",
-  "@adminPanelNoMatchesNeedingAttention": {"description": "Empty state for admin panel when no matches need a decision"},
+  "@adminPanelNoMatchesNeedingAttention": {
+    "description": "Empty state for admin panel when no matches need a decision"
+  },
   "adminPanelMatchOverdue": "Overdue",
-  "@adminPanelMatchOverdue": {"description": "Badge shown on overdue matches in the admin panel"},
+  "@adminPanelMatchOverdue": {
+    "description": "Badge shown on overdue matches in the admin panel"
+  },
   "adminPanelMatchDisputed": "Disputed",
-  "@adminPanelMatchDisputed": {"description": "Badge shown on disputed matches in the admin panel"},
+  "@adminPanelMatchDisputed": {
+    "description": "Badge shown on disputed matches in the admin panel"
+  },
   "adminPanelDecisionTitle": "Match Decision",
-  "@adminPanelDecisionTitle": {"description": "Title of the admin decision bottom sheet"},
+  "@adminPanelDecisionTitle": {
+    "description": "Title of the admin decision bottom sheet"
+  },
   "adminPanelDecisionSetResult": "Set result",
-  "@adminPanelDecisionSetResult": {"description": "Admin decision option: manually enter the match result"},
+  "@adminPanelDecisionSetResult": {
+    "description": "Admin decision option: manually enter the match result"
+  },
   "adminPanelDecisionAwardWalkover": "Award walkover",
-  "@adminPanelDecisionAwardWalkover": {"description": "Admin decision option: award a 2-0 walkover to one team"},
+  "@adminPanelDecisionAwardWalkover": {
+    "description": "Admin decision option: award a 2-0 walkover to one team"
+  },
   "adminPanelDecisionCancel": "Cancel match",
-  "@adminPanelDecisionCancel": {"description": "Admin decision option: cancel the match with no result"},
+  "@adminPanelDecisionCancel": {
+    "description": "Admin decision option: cancel the match with no result"
+  },
   "adminPanelDecisionWinnerLabel": "Winner",
-  "@adminPanelDecisionWinnerLabel": {"description": "Label for the winner selector in admin decision form"},
+  "@adminPanelDecisionWinnerLabel": {
+    "description": "Label for the winner selector in admin decision form"
+  },
   "adminPanelDecisionNotesLabel": "Admin notes",
-  "@adminPanelDecisionNotesLabel": {"description": "Label for the notes field in admin decision form"},
+  "@adminPanelDecisionNotesLabel": {
+    "description": "Label for the notes field in admin decision form"
+  },
   "adminPanelDecisionNotesHint": "Reason for this decision…",
-  "@adminPanelDecisionNotesHint": {"description": "Hint text for the notes field in admin decision form"},
+  "@adminPanelDecisionNotesHint": {
+    "description": "Hint text for the notes field in admin decision form"
+  },
   "adminPanelDecisionConfirm": "Apply Decision",
-  "@adminPanelDecisionConfirm": {"description": "Confirm button in the admin decision form"},
+  "@adminPanelDecisionConfirm": {
+    "description": "Confirm button in the admin decision form"
+  },
   "adminPanelDecisionSuccess": "Decision applied successfully",
-  "@adminPanelDecisionSuccess": {"description": "Snackbar message after a successful admin decision"},
+  "@adminPanelDecisionSuccess": {
+    "description": "Snackbar message after a successful admin decision"
+  },
   "adminPanelDecisionErrorNotesRequired": "Notes are required",
-  "@adminPanelDecisionErrorNotesRequired": {"description": "Validation error when notes are empty in admin decision form"},
+  "@adminPanelDecisionErrorNotesRequired": {
+    "description": "Validation error when notes are empty in admin decision form"
+  },
   "adminPanelDecisionErrorWinnerRequired": "Select a winner for walkover",
-  "@adminPanelDecisionErrorWinnerRequired": {"description": "Validation error when no winner is selected for walkover decision"},
-
-  "championshipCreate": "Create Championship",
-  "@championshipCreate": {"description": "Page title and FAB tooltip for championship creation"},
+  "@adminPanelDecisionErrorWinnerRequired": {
+    "description": "Validation error when no winner is selected for walkover decision"
+  },
+  "championshipCreate": "Create League",
+  "@championshipCreate": {
+    "description": "Page title and FAB tooltip for championship creation"
+  },
   "championshipCreateTitleLabel": "Title",
-  "@championshipCreateTitleLabel": {"description": "Form field label for championship title"},
+  "@championshipCreateTitleLabel": {
+    "description": "Form field label for championship title"
+  },
   "championshipCreateTitleHint": "e.g. Summer Open 2026",
-  "@championshipCreateTitleHint": {"description": "Hint text for championship title field"},
+  "@championshipCreateTitleHint": {
+    "description": "Hint text for championship title field"
+  },
   "championshipCreateTitleRequired": "Title is required",
-  "@championshipCreateTitleRequired": {"description": "Validation error when championship title is empty"},
+  "@championshipCreateTitleRequired": {
+    "description": "Validation error when championship title is empty"
+  },
   "championshipCreateTitleTooShort": "Title must be at least 3 characters",
-  "@championshipCreateTitleTooShort": {"description": "Validation error when championship title is too short"},
+  "@championshipCreateTitleTooShort": {
+    "description": "Validation error when championship title is too short"
+  },
   "championshipCreateDeadlineLabel": "Registration Deadline",
-  "@championshipCreateDeadlineLabel": {"description": "Form field label for registration deadline date picker"},
+  "@championshipCreateDeadlineLabel": {
+    "description": "Form field label for registration deadline date picker"
+  },
   "championshipCreateDeadlinePlaceholder": "Select a date",
-  "@championshipCreateDeadlinePlaceholder": {"description": "Placeholder shown in deadline picker before a date is chosen"},
+  "@championshipCreateDeadlinePlaceholder": {
+    "description": "Placeholder shown in deadline picker before a date is chosen"
+  },
   "championshipCreateCountryLabel": "Country (optional)",
-  "@championshipCreateCountryLabel": {"description": "Form field label for optional country code"},
+  "@championshipCreateCountryLabel": {
+    "description": "Form field label for optional country code"
+  },
   "championshipCreateCountryHint": "e.g. FR",
-  "@championshipCreateCountryHint": {"description": "Hint text for country code field"},
+  "@championshipCreateCountryHint": {
+    "description": "Hint text for country code field"
+  },
   "championshipCreateRegionLabel": "Region (optional)",
-  "@championshipCreateRegionLabel": {"description": "Form field label for optional region"},
+  "@championshipCreateRegionLabel": {
+    "description": "Form field label for optional region"
+  },
   "championshipCreateRegionHint": "e.g. Alsace",
-  "@championshipCreateRegionHint": {"description": "Hint text for region field"},
+  "@championshipCreateRegionHint": {
+    "description": "Hint text for region field"
+  },
   "championshipCreateMaxTeamsLabel": "Max teams",
-  "@championshipCreateMaxTeamsLabel": {"description": "Label for the max teams segmented selector on the championship creation form"},
+  "@championshipCreateMaxTeamsLabel": {
+    "description": "Label for the max teams segmented selector on the championship creation form"
+  },
   "championshipCreateTeamSizeLabel": "Players per team",
-  "@championshipCreateTeamSizeLabel": {"description": "Label for the team size segmented selector on the championship creation form"},
+  "@championshipCreateTeamSizeLabel": {
+    "description": "Label for the team size segmented selector on the championship creation form"
+  },
   "championshipCreateTeamSizeOption": "{count} players",
-  "@championshipCreateTeamSizeOption": {"description": "Label for a team size option", "placeholders": {"count": {"type": "int"}}},
-  "championshipCreateSubmit": "Create Championship",
-  "@championshipCreateSubmit": {"description": "Submit button label on championship creation form"},
-  "championshipCreateSuccess": "Championship created",
-  "@championshipCreateSuccess": {"description": "Snackbar message after a championship is created successfully"},
+  "@championshipCreateTeamSizeOption": {
+    "description": "Label for a team size option",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "championshipCreateSubmit": "Create League",
+  "@championshipCreateSubmit": {
+    "description": "Submit button label on championship creation form"
+  },
+  "championshipCreateSuccess": "League created",
+  "@championshipCreateSuccess": {
+    "description": "Snackbar message after a championship is created successfully"
+  },
   "championshipCreateStartDateLabel": "Start Date (optional)",
-  "@championshipCreateStartDateLabel": {"description": "Form field label for optional championship start date"},
+  "@championshipCreateStartDateLabel": {
+    "description": "Form field label for optional championship start date"
+  },
   "championshipCreateEndDateLabel": "End Date (optional)",
-  "@championshipCreateEndDateLabel": {"description": "Form field label for optional championship end date"},
+  "@championshipCreateEndDateLabel": {
+    "description": "Form field label for optional championship end date"
+  },
   "championshipCreateDatePlaceholder": "Select a date",
-  "@championshipCreateDatePlaceholder": {"description": "Placeholder shown in date pickers before a date is chosen"},
+  "@championshipCreateDatePlaceholder": {
+    "description": "Placeholder shown in date pickers before a date is chosen"
+  },
   "myTeamSectionTitle": "My Team",
-  "@myTeamSectionTitle": {"description": "Section header for the user's registered championship team"},
+  "@myTeamSectionTitle": {
+    "description": "Section header for the user's registered championship team"
+  },
   "myTeamPartnerLabel": "Partner: {name}",
-  "@myTeamPartnerLabel": {"description": "Shows the user's partner name in the my team section", "placeholders": {"name": {"type": "String"}}},
-  "leaveTeamSuccess": "You have left the championship.",
-  "@leaveTeamSuccess": {"description": "Snackbar message after successfully leaving a championship team"},
-  "startChampionshipButton": "Start Championship",
-  "@startChampionshipButton": {"description": "Admin button to launch the active phase of a championship"},
-  "startChampionshipConfirmTitle": "Start championship?",
-  "@startChampionshipConfirmTitle": {"description": "Confirmation dialog title when starting a championship"},
+  "@myTeamPartnerLabel": {
+    "description": "Shows the user's partner name in the my team section",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "leaveTeamSuccess": "You have left the league.",
+  "@leaveTeamSuccess": {
+    "description": "Snackbar message after successfully leaving a championship team"
+  },
+  "startChampionshipButton": "Start League",
+  "@startChampionshipButton": {
+    "description": "Admin button to launch the active phase of a championship"
+  },
+  "startChampionshipConfirmTitle": "Start league?",
+  "@startChampionshipConfirmTitle": {
+    "description": "Confirmation dialog title when starting a championship"
+  },
   "startChampionshipConfirmBody": "This will generate all round-robin fixtures and cannot be undone. Make sure all teams are registered.",
-  "@startChampionshipConfirmBody": {"description": "Confirmation dialog body when starting a championship"},
-  "startChampionshipSuccess": "Championship started — {count} matches generated.",
-  "@startChampionshipSuccess": {"description": "Snackbar after a championship is successfully started", "placeholders": {"count": {"type": "int"}}},
+  "@startChampionshipConfirmBody": {
+    "description": "Confirmation dialog body when starting a championship"
+  },
+  "startChampionshipSuccess": "League started — {count} matches generated.",
+  "@startChampionshipSuccess": {
+    "description": "Snackbar after a championship is successfully started",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "startChampionshipStartDateLabel": "First match window starts",
-  "@startChampionshipStartDateLabel": {"description": "Label for the start date picker when starting a championship"},
+  "@startChampionshipStartDateLabel": {
+    "description": "Label for the start date picker when starting a championship"
+  },
   "completeChampionshipButton": "Mark as Complete",
   "teamRenameTitle": "Rename Team",
-  "@teamRenameTitle": {"description": "Dialog title for renaming a team"},
+  "@teamRenameTitle": {
+    "description": "Dialog title for renaming a team"
+  },
   "teamRenameLabel": "Team name",
-  "@teamRenameLabel": {"description": "Text field label in the rename dialog"},
+  "@teamRenameLabel": {
+    "description": "Text field label in the rename dialog"
+  },
   "teamRenameSuccess": "Team renamed successfully.",
-  "@teamRenameSuccess": {"description": "Snackbar shown after successful rename"},
+  "@teamRenameSuccess": {
+    "description": "Snackbar shown after successful rename"
+  },
   "teamRenameError": "Failed to rename team",
-  "@teamRenameError": {"description": "Snackbar prefix shown when rename fails"},
+  "@teamRenameError": {
+    "description": "Snackbar prefix shown when rename fails"
+  },
   "standingsTiebreakerTitle": "How standings work",
-  "@standingsTiebreakerTitle": {"description": "Title of the tiebreaker info dialog"},
+  "@standingsTiebreakerTitle": {
+    "description": "Title of the tiebreaker info dialog"
+  },
   "standingsTiebreakerBody": "Points: Win 2-0 = 3pts · Win 2-1 = 2pts · Loss 1-2 = 1pt · Loss 0-2 = 0pts\n\nTiebreaker 1: Head-to-head result\nTiebreaker 2: Set ratio (sets won − sets lost)",
-  "@standingsTiebreakerBody": {"description": "Explanation of the championship scoring and tiebreaker rules"},
+  "@standingsTiebreakerBody": {
+    "description": "Explanation of the championship scoring and tiebreaker rules"
+  },
   "editChampionshipButton": "Edit Details",
-  "@editChampionshipButton": {"description": "Admin panel button to open the edit championship dialog"},
-  "editChampionshipTitle": "Edit Championship",
-  "@editChampionshipTitle": {"description": "Title of the edit championship dialog"},
+  "@editChampionshipButton": {
+    "description": "Admin panel button to open the edit championship dialog"
+  },
+  "editChampionshipTitle": "Edit League",
+  "@editChampionshipTitle": {
+    "description": "Title of the edit championship dialog"
+  },
   "editChampionshipChangeDeadline": "Change deadline",
-  "@editChampionshipChangeDeadline": {"description": "Placeholder shown on the deadline button in the edit dialog when no new deadline is selected"},
-  "@completeChampionshipButton": {"description": "Admin button to mark a championship as complete"},
-  "completeChampionshipConfirmTitle": "Mark championship complete?",
-  "@completeChampionshipConfirmTitle": {"description": "Confirmation dialog title when completing a championship"},
+  "@editChampionshipChangeDeadline": {
+    "description": "Placeholder shown on the deadline button in the edit dialog when no new deadline is selected"
+  },
+  "@completeChampionshipButton": {
+    "description": "Admin button to mark a championship as complete"
+  },
+  "completeChampionshipConfirmTitle": "Mark league complete?",
+  "@completeChampionshipConfirmTitle": {
+    "description": "Confirmation dialog title when completing a championship"
+  },
   "completeChampionshipConfirmBody": "Use this only when all matches have been resolved. This cannot be undone.",
-  "@completeChampionshipConfirmBody": {"description": "Confirmation dialog body when completing a championship"},
-  "completeChampionshipSuccess": "Championship marked as complete.",
-  "@completeChampionshipSuccess": {"description": "Snackbar after a championship is successfully marked complete"},
+  "@completeChampionshipConfirmBody": {
+    "description": "Confirmation dialog body when completing a championship"
+  },
+  "completeChampionshipSuccess": "League marked as complete.",
+  "@completeChampionshipSuccess": {
+    "description": "Snackbar after a championship is successfully marked complete"
+  },
   "championshipChampionLabel": "Champion",
-  "@championshipChampionLabel": {"description": "Label shown above the winning team name on a completed championship"},
+  "@championshipChampionLabel": {
+    "description": "Label shown above the winning team name on a completed championship"
+  },
   "championshipMyMatch": "My match",
-  "@championshipMyMatch": {"description": "Badge shown on the current user's match in the matches list"},
+  "@championshipMyMatch": {
+    "description": "Badge shown on the current user's match in the matches list"
+  },
   "matchScheduleWaitingTitle": "Waiting for Confirmation",
-  "@matchScheduleWaitingTitle": {"description": "Banner title shown to the proposer while awaiting the opponent's response"},
+  "@matchScheduleWaitingTitle": {
+    "description": "Banner title shown to the proposer while awaiting the opponent's response"
+  },
   "matchScheduleWaitingBody": "Your proposal ({datetime}) is awaiting the other team's response.",
-  "@matchScheduleWaitingBody": {"description": "Banner body shown to the proposer", "placeholders": {"datetime": {"type": "String"}}},
+  "@matchScheduleWaitingBody": {
+    "description": "Banner body shown to the proposer",
+    "placeholders": {
+      "datetime": {
+        "type": "String"
+      }
+    }
+  },
   "matchScheduleConfirmTitle": "Schedule Proposed",
-  "@matchScheduleConfirmTitle": {"description": "Card title shown to the opposing team when a schedule proposal is pending"},
+  "@matchScheduleConfirmTitle": {
+    "description": "Card title shown to the opposing team when a schedule proposal is pending"
+  },
   "matchScheduleConfirmBody": "{teamName} proposed: {datetime}",
-  "@matchScheduleConfirmBody": {"description": "Card body showing who proposed and the date/time", "placeholders": {"teamName": {"type": "String"}, "datetime": {"type": "String"}}},
+  "@matchScheduleConfirmBody": {
+    "description": "Card body showing who proposed and the date/time",
+    "placeholders": {
+      "teamName": {
+        "type": "String"
+      },
+      "datetime": {
+        "type": "String"
+      }
+    }
+  },
   "matchScheduleAcceptButton": "Accept",
-  "@matchScheduleAcceptButton": {"description": "Button to accept the proposed schedule"},
+  "@matchScheduleAcceptButton": {
+    "description": "Button to accept the proposed schedule"
+  },
   "matchScheduleRejectButton": "Reject",
-  "@matchScheduleRejectButton": {"description": "Button to reject the proposed schedule"},
-
+  "@matchScheduleRejectButton": {
+    "description": "Button to reject the proposed schedule"
+  },
   "matchDisputedTitle": "Match Disputed",
-  "@matchDisputedTitle": {"description": "Section title shown in match detail when match is disputed"},
+  "@matchDisputedTitle": {
+    "description": "Section title shown in match detail when match is disputed"
+  },
   "matchDisputedExplanation": "This result was disputed. An admin will review the scores and make a final decision. Standings will update once resolved.",
-  "@matchDisputedExplanation": {"description": "Explanation text shown in match detail when match is in disputed state"},
-
+  "@matchDisputedExplanation": {
+    "description": "Explanation text shown in match detail when match is in disputed state"
+  },
   "notificationSettingsTitle": "Notifications",
-  "@notificationSettingsTitle": {"description": "AppBar title for the notification settings screen"},
+  "@notificationSettingsTitle": {
+    "description": "AppBar title for the notification settings screen"
+  },
   "notificationSettingsCategories": "Notification Categories",
-  "@notificationSettingsCategories": {"description": "Section header above the 4 category toggles"},
+  "@notificationSettingsCategories": {
+    "description": "Section header above the 4 category toggles"
+  },
   "notifCategorySocial": "Social",
-  "@notifCategorySocial": {"description": "Category toggle label — social notifications"},
+  "@notifCategorySocial": {
+    "description": "Category toggle label — social notifications"
+  },
   "notifCategorySocialSubtitle": "Friend requests, group invitations",
-  "@notifCategorySocialSubtitle": {"description": "Subtitle for the social category toggle"},
+  "@notifCategorySocialSubtitle": {
+    "description": "Subtitle for the social category toggle"
+  },
   "notifCategoryGames": "Games",
-  "@notifCategoryGames": {"description": "Category toggle label — game notifications"},
+  "@notifCategoryGames": {
+    "description": "Category toggle label — game notifications"
+  },
   "notifCategoryGamesSubtitle": "New games, results, cancellations, chat",
-  "@notifCategoryGamesSubtitle": {"description": "Subtitle for the games category toggle"},
+  "@notifCategoryGamesSubtitle": {
+    "description": "Subtitle for the games category toggle"
+  },
   "notifCategoryTraining": "Training",
-  "@notifCategoryTraining": {"description": "Category toggle label — training notifications"},
+  "@notifCategoryTraining": {
+    "description": "Category toggle label — training notifications"
+  },
   "notifCategoryTrainingSubtitle": "Sessions created, cancelled, feedback",
-  "@notifCategoryTrainingSubtitle": {"description": "Subtitle for the training category toggle"},
-  "notifCategoryChampionships": "Championships",
-  "@notifCategoryChampionships": {"description": "Category toggle label — championship notifications"},
+  "@notifCategoryTrainingSubtitle": {
+    "description": "Subtitle for the training category toggle"
+  },
+  "notifCategoryChampionships": "Leagues",
+  "@notifCategoryChampionships": {
+    "description": "Category toggle label — championship notifications"
+  },
   "notifCategoryChampionshipsSubtitle": "Results, deadlines, disputes, schedule",
-  "@notifCategoryChampionshipsSubtitle": {"description": "Subtitle for the championships category toggle"},
+  "@notifCategoryChampionshipsSubtitle": {
+    "description": "Subtitle for the championships category toggle"
+  },
   "notifQuietHoursTitle": "Quiet Hours",
-  "@notifQuietHoursTitle": {"description": "Section header for quiet hours"},
+  "@notifQuietHoursTitle": {
+    "description": "Section header for quiet hours"
+  },
   "notifQuietHoursEnable": "Enable Quiet Hours",
-  "@notifQuietHoursEnable": {"description": "Toggle label to enable quiet hours"},
+  "@notifQuietHoursEnable": {
+    "description": "Toggle label to enable quiet hours"
+  },
   "notifQuietHoursSubtitle": "Pause notifications during specific times",
-  "@notifQuietHoursSubtitle": {"description": "Subtitle shown when quiet hours are disabled"},
+  "@notifQuietHoursSubtitle": {
+    "description": "Subtitle shown when quiet hours are disabled"
+  },
   "notifQuietHoursRange": "No notifications from {start} to {end}",
-  "@notifQuietHoursRange": {"description": "Subtitle shown when quiet hours are enabled", "placeholders": {"start": {"type": "String"}, "end": {"type": "String"}}},
+  "@notifQuietHoursRange": {
+    "description": "Subtitle shown when quiet hours are enabled",
+    "placeholders": {
+      "start": {
+        "type": "String"
+      },
+      "end": {
+        "type": "String"
+      }
+    }
+  },
   "notifQuietHoursAdjust": "Adjust Quiet Hours",
-  "@notifQuietHoursAdjust": {"description": "List tile label to open the quiet hours time picker"},
+  "@notifQuietHoursAdjust": {
+    "description": "List tile label to open the quiet hours time picker"
+  },
   "retryButton": "Retry",
-  "@retryButton": {"description": "Generic retry button label"},
-
+  "@retryButton": {
+    "description": "Generic retry button label"
+  },
   "groupMuteNotifications": "Mute notifications",
-  "@groupMuteNotifications": {"description": "Popup menu item to mute notifications for a group"},
+  "@groupMuteNotifications": {
+    "description": "Popup menu item to mute notifications for a group"
+  },
   "groupUnmuteNotifications": "Unmute notifications",
-  "@groupUnmuteNotifications": {"description": "Popup menu item to unmute notifications for a group"}
+  "@groupUnmuteNotifications": {
+    "description": "Popup menu item to unmute notifications for a group"
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -576,7 +576,6 @@
   "@loadOlderActivities": {
     "description": "Button label to load activities older than 90 days in the group details activity feed"
   },
-
   "genderSelectionTitle": "Género",
   "@genderSelectionTitle": {
     "description": "Title of the gender selection onboarding screen"
@@ -605,7 +604,6 @@
   "@genderSelectionError": {
     "description": "Error message shown when saving gender fails"
   },
-
   "deleteAccount": "Eliminar cuenta",
   "deleteAccountConfirmTitle": "¿Eliminar tu cuenta?",
   "deleteAccountConfirmMessage": "Tu cuenta y todos tus datos se eliminarán de forma permanente. Esta acción no se puede deshacer.",
@@ -620,7 +618,6 @@
   "@registrationGenderTooltip": {
     "description": "Tooltip explaining why gender is asked during registration"
   },
-
   "inviteGuestPlayers": "Invitar personas de otros grupos",
   "@inviteGuestPlayers": {
     "description": "Title of the invite guest players bottom sheet (Story 28.6)"
@@ -643,7 +640,13 @@
   },
   "inviteGroupSuccess": "Grupo invitado correctamente",
   "groupMembersCount": "{count, plural, =1{1 persona} other{{count} personas}}",
-  "@groupMembersCount": {"placeholders": {"count": {"type": "int"}}},
+  "@groupMembersCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "invitedLabel": "Invitado",
   "invitePlayerError": "Error al enviar la invitación",
   "@invitePlayerError": {
@@ -665,7 +668,9 @@
   "@fromGroup": {
     "description": "Label on a game invitation card showing the source group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
   "gameInvitationAccepted": "Invitación aceptada",
@@ -680,12 +685,10 @@
   "@gameInvitationActionError": {
     "description": "Snackbar shown when accepting or declining a game invitation fails"
   },
-
   "upcoming": "Próximamente",
   "@upcoming": {
     "description": "Section header for upcoming games in MyGamesPage"
   },
-
   "pastGames": "Partidos pasados",
   "open": "Abierto",
   "@open": {
@@ -694,7 +697,6 @@
   "@pastGames": {
     "description": "Section header for past games in MyGamesPage"
   },
-
   "teamsForThisGame": "Equipos",
   "@teamsForThisGame": {
     "description": "Section label for per-game team picker"
@@ -707,7 +709,6 @@
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
   },
-
   "chatSectionTitle": "Chat",
   "@chatSectionTitle": {},
   "chatInputHint": "Escribe un mensaje...",
@@ -718,7 +719,6 @@
   "@chatPlayersOnly": {},
   "chatJoinToView": "Debes unirte al juego para ver el chat",
   "@chatJoinToView": {},
-
   "createPickupGame": "Crear partido informal",
   "@createPickupGame": {},
   "pickupGame": "Partido informal",
@@ -757,21 +757,21 @@
   },
   "next": "Siguiente",
   "@next": {},
-  "championshipsTitle": "Campeonatos",
-  "championshipOpenRegistration": "Inscripci\u00f3n abierta",
+  "championshipsTitle": "Ligas",
+  "championshipOpenRegistration": "Inscripción abierta",
   "championshipTeamsCount": "{count, plural, =1{1 equipo inscrito} other{{count} equipos inscritos}}",
   "championshipSlotsLeft": "{count, plural, =1{1 plaza restante} other{{count} plazas restantes}}",
   "championshipDeadlineLabel": "Plazo: {date}",
   "registerTeam": "Inscribir equipo",
   "leaveTeam": "Abandonar equipo",
-  "leaveTeamConfirmTitle": "\u00bfAbandonar equipo?",
-  "leaveTeamConfirmBody": "Tu equipo se eliminar\u00e1 y tu plaza quedar\u00e1 libre.",
+  "leaveTeamConfirmTitle": "¿Abandonar equipo?",
+  "leaveTeamConfirmBody": "Tu equipo se eliminará y tu plaza quedará libre.",
   "createTeamTitle": "Crea tu equipo",
   "teamNameLabel": "Nombre del equipo",
   "teamNameHint": "p. ej. Beach Wolves",
-  "selectPartnerLabel": "Elige a tu compa\u00f1ero/a",
-  "noFriendsForPartner": "A\u00fan no tienes amigos para invitar. A\u00f1ade amigos desde Mi comunidad primero.",
-  "teamRegisteredSuccess": "\u00a1Equipo inscrito!",
+  "selectPartnerLabel": "Elige a tu compañero/a",
+  "noFriendsForPartner": "Aún no tienes amigos para invitar. Añade amigos desde Mi comunidad primero.",
+  "teamRegisteredSuccess": "¡Equipo inscrito!",
   "teamLeftSuccess": "Has abandonado el equipo.",
   "yourTeam": "Tu equipo",
   "matchChatTitle": "Chat del partido",
@@ -804,19 +804,19 @@
   "championshipStatusBadgeActive": "Ronda {current}/{total}",
   "championshipStatusBadgeCompleted": "Completado",
   "championshipMyMatchesTab": "Mis partidos",
-  "championshipMyMatchesEmpty": "Tus partidos aparecerán aquí cuando comience el campeonato.",
+  "championshipMyMatchesEmpty": "Tus partidos aparecerán aquí cuando comience el liga.",
   "championshipMyMatchesVs": "vs {opponent}",
   "championshipTabActive": "Activos",
   "championshipTabCompleted": "Completados",
-  "championshipNoCompletedYet": "Aún no hay campeonatos completados.",
-  "championshipNoResults": "No hay campeonatos en este momento.",
+  "championshipNoCompletedYet": "Aún no hay ligas completados.",
+  "championshipNoResults": "No hay ligas en este momento.",
   "championshipDeadlineCountdown": "{days, plural, =1{1 día restante} other{{days} días restantes}}",
   "championshipTeamCountOf": "{count} / {max} equipos",
   "championshipGenderMale": "Hombres",
   "championshipGenderFemale": "Mujeres",
   "championshipGenderBlockNoGender": "Debes establecer tu género en tu perfil para registrarte.",
-  "championshipGenderBlockMaleOnly": "Este campeonato es solo para hombres.",
-  "championshipGenderBlockFemaleOnly": "Este campeonato es solo para mujeres.",
+  "championshipGenderBlockMaleOnly": "Este liga es solo para hombres.",
+  "championshipGenderBlockFemaleOnly": "Este liga es solo para mujeres.",
   "championshipCreateGenderLabel": "Categoría de género (opcional)",
   "championshipDetailStandingsTab": "Clasificación",
   "championshipDetailMatchesTab": "Partidos",
@@ -846,7 +846,6 @@
   "matchDetailProposeTimeLabel": "Hora",
   "matchDetailProposeLocationLabel": "Ubicación (opcional)",
   "matchDetailProposeConfirm": "Proponer",
-
   "adminPanelTabLabel": "Admin",
   "adminPanelNoMatchesNeedingAttention": "No hay partidos que requieran atención",
   "adminPanelMatchOverdue": "Vencido",
@@ -862,8 +861,7 @@
   "adminPanelDecisionSuccess": "Decisión aplicada con éxito",
   "adminPanelDecisionErrorNotesRequired": "Las notas son obligatorias",
   "adminPanelDecisionErrorWinnerRequired": "Selecciona un ganador para el walkover",
-
-  "championshipCreate": "Crear campeonato",
+  "championshipCreate": "Crear liga",
   "championshipCreateTitleLabel": "Título",
   "championshipCreateTitleHint": "ej. Open de Verano 2026",
   "championshipCreateTitleRequired": "El título es obligatorio",
@@ -877,33 +875,32 @@
   "championshipCreateMaxTeamsLabel": "Máx. equipos",
   "championshipCreateTeamSizeLabel": "Jugadores por equipo",
   "championshipCreateTeamSizeOption": "{count} jugadores",
-  "championshipCreateSubmit":"Crear campeonato",
-  "championshipCreateSuccess": "Campeonato creado",
+  "championshipCreateSubmit": "Crear liga",
+  "championshipCreateSuccess": "Liga creado",
   "championshipCreateStartDateLabel": "Fecha de inicio (opcional)",
   "championshipCreateEndDateLabel": "Fecha de fin (opcional)",
-  "championshipCreateDatePlaceholder": "Seleccionar fecha"
-,
+  "championshipCreateDatePlaceholder": "Seleccionar fecha",
   "myTeamSectionTitle": "Mi equipo",
   "myTeamPartnerLabel": "Compañero: {name}",
-  "leaveTeamSuccess": "Has abandonado el campeonato.",
-  "startChampionshipButton": "Iniciar campeonato",
-  "startChampionshipConfirmTitle": "¿Iniciar el campeonato?",
+  "leaveTeamSuccess": "Has abandonado el liga.",
+  "startChampionshipButton": "Iniciar liga",
+  "startChampionshipConfirmTitle": "¿Iniciar el liga?",
   "startChampionshipConfirmBody": "Esto generará todos los partidos y no se podrá deshacer. Asegúrate de que todos los equipos estén inscritos.",
-  "startChampionshipSuccess": "Campeonato iniciado — {count} partidos generados.",
+  "startChampionshipSuccess": "Liga iniciado — {count} partidos generados.",
   "startChampionshipStartDateLabel": "Inicio de los partidos",
-    "teamRenameTitle": "Renombrar equipo",
-    "teamRenameLabel": "Nombre del equipo",
-    "teamRenameSuccess": "Equipo renombrado correctamente.",
-    "teamRenameError": "No se pudo renombrar el equipo",
-    "standingsTiebreakerTitle": "Cómo funciona la clasificación",
-    "standingsTiebreakerBody": "Puntos: Victoria 2-0 = 3pts · Victoria 2-1 = 2pts · Derrota 1-2 = 1pt · Derrota 0-2 = 0pts\n\nCriterio 1: Resultado directo\nCriterio 2: Ratio de sets (sets ganados − sets perdidos)",
+  "teamRenameTitle": "Renombrar equipo",
+  "teamRenameLabel": "Nombre del equipo",
+  "teamRenameSuccess": "Equipo renombrado correctamente.",
+  "teamRenameError": "No se pudo renombrar el equipo",
+  "standingsTiebreakerTitle": "Cómo funciona la clasificación",
+  "standingsTiebreakerBody": "Puntos: Victoria 2-0 = 3pts · Victoria 2-1 = 2pts · Derrota 1-2 = 1pt · Derrota 0-2 = 0pts\n\nCriterio 1: Resultado directo\nCriterio 2: Ratio de sets (sets ganados − sets perdidos)",
   "editChampionshipButton": "Editar detalles",
-  "editChampionshipTitle": "Editar campeonato",
+  "editChampionshipTitle": "Editar liga",
   "editChampionshipChangeDeadline": "Cambiar fecha límite",
   "completeChampionshipButton": "Marcar como completado",
-  "completeChampionshipConfirmTitle": "¿Completar el campeonato?",
+  "completeChampionshipConfirmTitle": "¿Completar el liga?",
   "completeChampionshipConfirmBody": "Úsalo solo cuando todos los partidos estén resueltos. Esta acción es irreversible.",
-  "completeChampionshipSuccess": "Campeonato marcado como completado.",
+  "completeChampionshipSuccess": "Liga marcado como completado.",
   "championshipChampionLabel": "Campeón",
   "championshipMyMatch": "Mi partido",
   "matchScheduleWaitingTitle": "Esperando confirmación",
@@ -912,10 +909,8 @@
   "matchScheduleConfirmBody": "{teamName} propuso: {datetime}",
   "matchScheduleAcceptButton": "Aceptar",
   "matchScheduleRejectButton": "Rechazar",
-
   "matchDisputedTitle": "Partido en disputa",
   "matchDisputedExplanation": "Este resultado fue disputado. Un administrador revisará los marcadores y tomará una decisión final. La clasificación se actualizará tras la resolución.",
-
   "notificationSettingsTitle": "Notificaciones",
   "notificationSettingsCategories": "Categorías de notificaciones",
   "notifCategorySocial": "Social",
@@ -924,7 +919,7 @@
   "notifCategoryGamesSubtitle": "Nuevos partidos, resultados, cancelaciones, chat",
   "notifCategoryTraining": "Entrenamiento",
   "notifCategoryTrainingSubtitle": "Sesiones creadas, canceladas, comentarios",
-  "notifCategoryChampionships": "Campeonatos",
+  "notifCategoryChampionships": "Ligas",
   "notifCategoryChampionshipsSubtitle": "Resultados, plazos, disputas, horarios",
   "notifQuietHoursTitle": "Horas de silencio",
   "notifQuietHoursEnable": "Activar horas de silencio",
@@ -933,4 +928,5 @@
   "notifQuietHoursAdjust": "Ajustar horas de silencio",
   "retryButton": "Reintentar",
   "groupMuteNotifications": "Silenciar notificaciones",
-  "groupUnmuteNotifications": "Activar notificaciones"}
+  "groupUnmuteNotifications": "Activar notificaciones"
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -576,7 +576,6 @@
   "@loadOlderActivities": {
     "description": "Button label to load activities older than 90 days in the group details activity feed"
   },
-
   "genderSelectionTitle": "Genre",
   "@genderSelectionTitle": {
     "description": "Title of the gender selection onboarding screen"
@@ -605,7 +604,6 @@
   "@genderSelectionError": {
     "description": "Error message shown when saving gender fails"
   },
-
   "deleteAccount": "Supprimer le compte",
   "deleteAccountConfirmTitle": "Supprimer votre compte ?",
   "deleteAccountConfirmMessage": "Cette action supprimera définitivement votre compte et toutes vos données. Elle est irréversible.",
@@ -620,7 +618,6 @@
   "@registrationGenderTooltip": {
     "description": "Tooltip explaining why gender is asked during registration"
   },
-
   "inviteGuestPlayers": "Inviter des personnes d'autres groupes",
   "@inviteGuestPlayers": {
     "description": "Title of the invite guest players bottom sheet (Story 28.6)"
@@ -643,7 +640,13 @@
   },
   "inviteGroupSuccess": "Groupe invité avec succès",
   "groupMembersCount": "{count, plural, =1{1 personne} other{{count} personnes}}",
-  "@groupMembersCount": {"placeholders": {"count": {"type": "int"}}},
+  "@groupMembersCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "invitedLabel": "Invité",
   "invitePlayerError": "Échec de l'envoi de l'invitation",
   "@invitePlayerError": {
@@ -665,7 +668,9 @@
   "@fromGroup": {
     "description": "Label on a game invitation card showing the source group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
   "gameInvitationAccepted": "Invitation acceptée",
@@ -680,12 +685,10 @@
   "@gameInvitationActionError": {
     "description": "Snackbar shown when accepting or declining a game invitation fails"
   },
-
   "upcoming": "À venir",
   "@upcoming": {
     "description": "Section header for upcoming games in MyGamesPage"
   },
-
   "pastGames": "Parties passées",
   "open": "Ouvert",
   "@open": {
@@ -694,7 +697,6 @@
   "@pastGames": {
     "description": "Section header for past games in MyGamesPage"
   },
-
   "teamsForThisGame": "Équipes",
   "@teamsForThisGame": {
     "description": "Section label for per-game team picker"
@@ -707,7 +709,6 @@
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
   },
-
   "chatSectionTitle": "Chat",
   "@chatSectionTitle": {},
   "chatInputHint": "Écris un message...",
@@ -718,7 +719,6 @@
   "@chatPlayersOnly": {},
   "chatJoinToView": "Vous devez rejoindre la partie pour voir le chat",
   "@chatJoinToView": {},
-
   "createPickupGame": "Créer une partie improvisée",
   "@createPickupGame": {},
   "pickupGame": "Partie improvisée",
@@ -757,23 +757,23 @@
   },
   "next": "Suivant",
   "@next": {},
-  "championshipsTitle": "Championnats",
+  "championshipsTitle": "Ligues",
   "championshipOpenRegistration": "Inscriptions ouvertes",
-  "championshipTeamsCount": "{count, plural, =1{1 \u00e9quipe inscrite} other{{count} \u00e9quipes inscrites}}",
+  "championshipTeamsCount": "{count, plural, =1{1 équipe inscrite} other{{count} équipes inscrites}}",
   "championshipSlotsLeft": "{count, plural, =1{1 place restante} other{{count} places restantes}}",
-  "championshipDeadlineLabel": "Date limite\u00a0: {date}",
-  "registerTeam": "Inscrire une \u00e9quipe",
-  "leaveTeam": "Quitter l'\u00e9quipe",
-  "leaveTeamConfirmTitle": "Quitter l'\u00e9quipe\u00a0?",
-  "leaveTeamConfirmBody": "Votre \u00e9quipe sera supprim\u00e9e et votre place lib\u00e9r\u00e9e.",
-  "createTeamTitle": "Cr\u00e9er votre \u00e9quipe",
-  "teamNameLabel": "Nom de l'\u00e9quipe",
-  "teamNameHint": "ex.\u00a0: Beach Wolves",
+  "championshipDeadlineLabel": "Date limite : {date}",
+  "registerTeam": "Inscrire une équipe",
+  "leaveTeam": "Quitter l'équipe",
+  "leaveTeamConfirmTitle": "Quitter l'équipe ?",
+  "leaveTeamConfirmBody": "Votre équipe sera supprimée et votre place libérée.",
+  "createTeamTitle": "Créer votre équipe",
+  "teamNameLabel": "Nom de l'équipe",
+  "teamNameHint": "ex. : Beach Wolves",
   "selectPartnerLabel": "Choisir votre partenaire",
-  "noFriendsForPartner": "Vous n'avez pas encore d'amis \u00e0 inviter. Ajoutez des amis depuis Ma communaut\u00e9.",
-  "teamRegisteredSuccess": "\u00c9quipe inscrite\u00a0!",
-  "teamLeftSuccess": "Vous avez quitt\u00e9 l'\u00e9quipe.",
-  "yourTeam": "Votre \u00e9quipe",
+  "noFriendsForPartner": "Vous n'avez pas encore d'amis à inviter. Ajoutez des amis depuis Ma communauté.",
+  "teamRegisteredSuccess": "Équipe inscrite !",
+  "teamLeftSuccess": "Vous avez quitté l'équipe.",
+  "yourTeam": "Votre équipe",
   "matchChatTitle": "Chat du match",
   "matchChatCoordinationHint": "Coordonnez la date, l’heure et le lieu avec l’équipe adverse",
   "matchChatNotMember": "Seuls les membres des équipes peuvent participer à ce chat.",
@@ -804,19 +804,19 @@
   "championshipStatusBadgeActive": "Tour {current}/{total}",
   "championshipStatusBadgeCompleted": "Terminé",
   "championshipMyMatchesTab": "Mes matchs",
-  "championshipMyMatchesEmpty": "Vos matchs apparaîtront ici une fois le championnat lancé.",
+  "championshipMyMatchesEmpty": "Vos matchs apparaîtront ici une fois le ligue lancé.",
   "championshipMyMatchesVs": "vs {opponent}",
   "championshipTabActive": "Actifs",
   "championshipTabCompleted": "Terminés",
-  "championshipNoCompletedYet": "Aucun championnat terminé pour le moment.",
-  "championshipNoResults": "Aucun championnat pour le moment.",
+  "championshipNoCompletedYet": "Aucun ligue terminé pour le moment.",
+  "championshipNoResults": "Aucun ligue pour le moment.",
   "championshipDeadlineCountdown": "{days, plural, =1{1 jour restant} other{{days} jours restants}}",
   "championshipTeamCountOf": "{count} / {max} équipes",
   "championshipGenderMale": "Hommes",
   "championshipGenderFemale": "Femmes",
   "championshipGenderBlockNoGender": "Vous devez définir votre genre dans votre profil pour vous inscrire.",
-  "championshipGenderBlockMaleOnly": "Ce championnat est réservé aux hommes.",
-  "championshipGenderBlockFemaleOnly": "Ce championnat est réservé aux femmes.",
+  "championshipGenderBlockMaleOnly": "Ce ligue est réservé aux hommes.",
+  "championshipGenderBlockFemaleOnly": "Ce ligue est réservé aux femmes.",
   "championshipCreateGenderLabel": "Catégorie de genre (optionnel)",
   "championshipDetailStandingsTab": "Classement",
   "championshipDetailMatchesTab": "Matchs",
@@ -846,7 +846,6 @@
   "matchDetailProposeTimeLabel": "Heure",
   "matchDetailProposeLocationLabel": "Lieu (optionnel)",
   "matchDetailProposeConfirm": "Proposer",
-
   "adminPanelTabLabel": "Admin",
   "adminPanelNoMatchesNeedingAttention": "Aucun match ne nécessite d'intervention",
   "adminPanelMatchOverdue": "En retard",
@@ -862,8 +861,7 @@
   "adminPanelDecisionSuccess": "Décision appliquée avec succès",
   "adminPanelDecisionErrorNotesRequired": "Les notes sont obligatoires",
   "adminPanelDecisionErrorWinnerRequired": "Sélectionnez un vainqueur pour le forfait",
-
-  "championshipCreate": "Créer un championnat",
+  "championshipCreate": "Créer un ligue",
   "championshipCreateTitleLabel": "Titre",
   "championshipCreateTitleHint": "ex. Open d'Été 2026",
   "championshipCreateTitleRequired": "Le titre est obligatoire",
@@ -877,33 +875,32 @@
   "championshipCreateMaxTeamsLabel": "Nombre max d'équipes",
   "championshipCreateTeamSizeLabel": "Joueurs par équipe",
   "championshipCreateTeamSizeOption": "{count} joueurs",
-  "championshipCreateSubmit":"Créer le championnat",
-  "championshipCreateSuccess": "Championnat créé",
+  "championshipCreateSubmit": "Créer le ligue",
+  "championshipCreateSuccess": "Ligue créé",
   "championshipCreateStartDateLabel": "Date de début (optionnel)",
   "championshipCreateEndDateLabel": "Date de fin (optionnel)",
-  "championshipCreateDatePlaceholder": "Sélectionner une date"
-,
+  "championshipCreateDatePlaceholder": "Sélectionner une date",
   "myTeamSectionTitle": "Mon équipe",
   "myTeamPartnerLabel": "Partenaire : {name}",
-  "leaveTeamSuccess": "Vous avez quitté le championnat.",
-  "startChampionshipButton": "Démarrer le championnat",
-  "startChampionshipConfirmTitle": "Démarrer le championnat ?",
+  "leaveTeamSuccess": "Vous avez quitté le ligue.",
+  "startChampionshipButton": "Démarrer le ligue",
+  "startChampionshipConfirmTitle": "Démarrer le ligue ?",
   "startChampionshipConfirmBody": "Cela générera tous les matchs et ne pourra pas être annulé. Vérifiez que toutes les équipes sont inscrites.",
-  "startChampionshipSuccess": "Championnat démarré — {count} matchs générés.",
+  "startChampionshipSuccess": "Ligue démarré — {count} matchs générés.",
   "startChampionshipStartDateLabel": "Début des matchs",
-    "teamRenameTitle": "Renommer l'équipe",
-    "teamRenameLabel": "Nom de l'équipe",
-    "teamRenameSuccess": "Équipe renommée avec succès.",
-    "teamRenameError": "Impossible de renommer l'équipe",
-    "standingsTiebreakerTitle": "Comment fonctionne le classement",
-    "standingsTiebreakerBody": "Points : Victoire 2-0 = 3pts · Victoire 2-1 = 2pts · Défaite 1-2 = 1pt · Défaite 0-2 = 0pt\n\nDépartage 1 : Résultat entre les équipes\nDépartage 2 : Ratio de sets (sets gagnés − sets perdus)",
+  "teamRenameTitle": "Renommer l'équipe",
+  "teamRenameLabel": "Nom de l'équipe",
+  "teamRenameSuccess": "Équipe renommée avec succès.",
+  "teamRenameError": "Impossible de renommer l'équipe",
+  "standingsTiebreakerTitle": "Comment fonctionne le classement",
+  "standingsTiebreakerBody": "Points : Victoire 2-0 = 3pts · Victoire 2-1 = 2pts · Défaite 1-2 = 1pt · Défaite 0-2 = 0pt\n\nDépartage 1 : Résultat entre les équipes\nDépartage 2 : Ratio de sets (sets gagnés − sets perdus)",
   "editChampionshipButton": "Modifier les détails",
-  "editChampionshipTitle": "Modifier le championnat",
+  "editChampionshipTitle": "Modifier le ligue",
   "editChampionshipChangeDeadline": "Changer la date limite",
   "completeChampionshipButton": "Marquer comme terminé",
-  "completeChampionshipConfirmTitle": "Terminer le championnat ?",
+  "completeChampionshipConfirmTitle": "Terminer le ligue ?",
   "completeChampionshipConfirmBody": "À utiliser uniquement lorsque tous les matchs sont résolus. Irréversible.",
-  "completeChampionshipSuccess": "Championnat marqué comme terminé.",
+  "completeChampionshipSuccess": "Ligue marqué comme terminé.",
   "championshipChampionLabel": "Champion",
   "championshipMyMatch": "Mon match",
   "matchScheduleWaitingTitle": "En attente de confirmation",
@@ -912,10 +909,8 @@
   "matchScheduleConfirmBody": "{teamName} a proposé : {datetime}",
   "matchScheduleAcceptButton": "Accepter",
   "matchScheduleRejectButton": "Refuser",
-
   "matchDisputedTitle": "Match contesté",
   "matchDisputedExplanation": "Ce résultat est contesté. Un administrateur examinera les scores et rendra une décision. Le classement sera mis à jour après résolution.",
-
   "notificationSettingsTitle": "Notifications",
   "notificationSettingsCategories": "Catégories de notifications",
   "notifCategorySocial": "Social",
@@ -924,7 +919,7 @@
   "notifCategoryGamesSubtitle": "Nouveaux matchs, résultats, annulations, chat",
   "notifCategoryTraining": "Entraînements",
   "notifCategoryTrainingSubtitle": "Sessions créées, annulées, retours",
-  "notifCategoryChampionships": "Championnats",
+  "notifCategoryChampionships": "Ligues",
   "notifCategoryChampionshipsSubtitle": "Résultats, délais, litiges, planning",
   "notifQuietHoursTitle": "Heures de silence",
   "notifQuietHoursEnable": "Activer les heures de silence",
@@ -933,4 +928,5 @@
   "notifQuietHoursAdjust": "Modifier les heures de silence",
   "retryButton": "Réessayer",
   "groupMuteNotifications": "Désactiver les notifications",
-  "groupUnmuteNotifications": "Activer les notifications"}
+  "groupUnmuteNotifications": "Activer les notifications"
+}

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -576,7 +576,6 @@
   "@loadOlderActivities": {
     "description": "Button label to load activities older than 90 days in the group details activity feed"
   },
-
   "genderSelectionTitle": "Genere",
   "@genderSelectionTitle": {
     "description": "Title of the gender selection onboarding screen"
@@ -605,7 +604,6 @@
   "@genderSelectionError": {
     "description": "Error message shown when saving gender fails"
   },
-
   "deleteAccount": "Elimina account",
   "deleteAccountConfirmTitle": "Eliminare il tuo account?",
   "deleteAccountConfirmMessage": "Il tuo account e tutti i tuoi dati verranno eliminati definitivamente. Questa azione è irreversibile.",
@@ -620,7 +618,6 @@
   "@registrationGenderTooltip": {
     "description": "Tooltip explaining why gender is asked during registration"
   },
-
   "inviteGuestPlayers": "Invita persone da altri gruppi",
   "@inviteGuestPlayers": {
     "description": "Title of the invite guest players bottom sheet (Story 28.6)"
@@ -643,7 +640,13 @@
   },
   "inviteGroupSuccess": "Gruppo invitato con successo",
   "groupMembersCount": "{count, plural, =1{1 persona} other{{count} persone}}",
-  "@groupMembersCount": {"placeholders": {"count": {"type": "int"}}},
+  "@groupMembersCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "invitedLabel": "Invitato",
   "invitePlayerError": "Invio dell'invito non riuscito",
   "@invitePlayerError": {
@@ -665,7 +668,9 @@
   "@fromGroup": {
     "description": "Label on a game invitation card showing the source group",
     "placeholders": {
-      "groupName": {"type": "String"}
+      "groupName": {
+        "type": "String"
+      }
     }
   },
   "gameInvitationAccepted": "Invito accettato",
@@ -680,12 +685,10 @@
   "@gameInvitationActionError": {
     "description": "Snackbar shown when accepting or declining a game invitation fails"
   },
-
   "upcoming": "In arrivo",
   "@upcoming": {
     "description": "Section header for upcoming games in MyGamesPage"
   },
-
   "pastGames": "Partite passate",
   "open": "Aperto",
   "@open": {
@@ -694,7 +697,6 @@
   "@pastGames": {
     "description": "Section header for past games in MyGamesPage"
   },
-
   "teamsForThisGame": "Squadre",
   "@teamsForThisGame": {
     "description": "Section label for per-game team picker"
@@ -707,7 +709,6 @@
   "@vsLabel": {
     "description": "Label between two teams in a matchup, e.g. Alice & Bob vs Carol & Dave"
   },
-
   "chatSectionTitle": "Chat",
   "@chatSectionTitle": {},
   "chatInputHint": "Scrivi un messaggio...",
@@ -718,7 +719,6 @@
   "@chatPlayersOnly": {},
   "chatJoinToView": "Devi unirti alla partita per vedere la chat",
   "@chatJoinToView": {},
-
   "createPickupGame": "Crea partita al volo",
   "@createPickupGame": {},
   "pickupGame": "Partita al volo",
@@ -757,7 +757,7 @@
   },
   "next": "Avanti",
   "@next": {},
-  "championshipsTitle": "Campionati",
+  "championshipsTitle": "Leghe",
   "championshipOpenRegistration": "Iscrizioni aperte",
   "championshipTeamsCount": "{count, plural, =1{1 squadra iscritta} other{{count} squadre iscritte}}",
   "championshipSlotsLeft": "{count, plural, =1{1 posto rimasto} other{{count} posti rimasti}}",
@@ -765,7 +765,7 @@
   "registerTeam": "Iscriviti con la squadra",
   "leaveTeam": "Lascia la squadra",
   "leaveTeamConfirmTitle": "Lasciare la squadra?",
-  "leaveTeamConfirmBody": "La tua squadra verr\u00e0 eliminata e il posto liberato.",
+  "leaveTeamConfirmBody": "La tua squadra verrà eliminata e il posto liberato.",
   "createTeamTitle": "Crea la tua squadra",
   "teamNameLabel": "Nome della squadra",
   "teamNameHint": "es. Beach Wolves",
@@ -804,19 +804,19 @@
   "championshipStatusBadgeActive": "Turno {current}/{total}",
   "championshipStatusBadgeCompleted": "Completato",
   "championshipMyMatchesTab": "I miei match",
-  "championshipMyMatchesEmpty": "I tuoi match appariranno qui quando il campionato inizierà.",
+  "championshipMyMatchesEmpty": "I tuoi match appariranno qui quando il lega inizierà.",
   "championshipMyMatchesVs": "vs {opponent}",
   "championshipTabActive": "Attivi",
   "championshipTabCompleted": "Completati",
-  "championshipNoCompletedYet": "Nessun campionato completato ancora.",
-  "championshipNoResults": "Nessun campionato al momento.",
+  "championshipNoCompletedYet": "Nessun lega completato ancora.",
+  "championshipNoResults": "Nessun lega al momento.",
   "championshipDeadlineCountdown": "{days, plural, =1{1 giorno rimasto} other{{days} giorni rimasti}}",
   "championshipTeamCountOf": "{count} / {max} squadre",
   "championshipGenderMale": "Uomini",
   "championshipGenderFemale": "Donne",
   "championshipGenderBlockNoGender": "Devi impostare il tuo genere nel profilo per registrarti.",
-  "championshipGenderBlockMaleOnly": "Questo campionato è solo per uomini.",
-  "championshipGenderBlockFemaleOnly": "Questo campionato è solo per donne.",
+  "championshipGenderBlockMaleOnly": "Questo lega è solo per uomini.",
+  "championshipGenderBlockFemaleOnly": "Questo lega è solo per donne.",
   "championshipCreateGenderLabel": "Categoria di genere (opzionale)",
   "championshipDetailStandingsTab": "Classifica",
   "championshipDetailMatchesTab": "Partite",
@@ -846,7 +846,6 @@
   "matchDetailProposeTimeLabel": "Ora",
   "matchDetailProposeLocationLabel": "Luogo (opzionale)",
   "matchDetailProposeConfirm": "Proponi",
-
   "adminPanelTabLabel": "Admin",
   "adminPanelNoMatchesNeedingAttention": "Nessuna partita richiede attenzione",
   "adminPanelMatchOverdue": "Scaduto",
@@ -862,8 +861,7 @@
   "adminPanelDecisionSuccess": "Decisione applicata con successo",
   "adminPanelDecisionErrorNotesRequired": "Le note sono obbligatorie",
   "adminPanelDecisionErrorWinnerRequired": "Seleziona un vincitore per il walkover",
-
-  "championshipCreate": "Crea campionato",
+  "championshipCreate": "Crea lega",
   "championshipCreateTitleLabel": "Titolo",
   "championshipCreateTitleHint": "es. Open Estivo 2026",
   "championshipCreateTitleRequired": "Il titolo è obbligatorio",
@@ -877,33 +875,32 @@
   "championshipCreateMaxTeamsLabel": "Max squadre",
   "championshipCreateTeamSizeLabel": "Giocatori per squadra",
   "championshipCreateTeamSizeOption": "{count} giocatori",
-  "championshipCreateSubmit":"Crea campionato",
-  "championshipCreateSuccess": "Campionato creato",
+  "championshipCreateSubmit": "Crea lega",
+  "championshipCreateSuccess": "Lega creato",
   "championshipCreateStartDateLabel": "Data di inizio (opzionale)",
   "championshipCreateEndDateLabel": "Data di fine (opzionale)",
-  "championshipCreateDatePlaceholder": "Seleziona una data"
-,
+  "championshipCreateDatePlaceholder": "Seleziona una data",
   "myTeamSectionTitle": "Il mio team",
   "myTeamPartnerLabel": "Partner: {name}",
-  "leaveTeamSuccess": "Hai abbandonato il campionato.",
-  "startChampionshipButton": "Avvia campionato",
-  "startChampionshipConfirmTitle": "Avviare il campionato?",
+  "leaveTeamSuccess": "Hai abbandonato il lega.",
+  "startChampionshipButton": "Avvia lega",
+  "startChampionshipConfirmTitle": "Avviare il lega?",
   "startChampionshipConfirmBody": "Verranno generati tutti i match e l'operazione non potrà essere annullata. Assicurati che tutti i team siano iscritti.",
-  "startChampionshipSuccess": "Campionato avviato — {count} match generati.",
+  "startChampionshipSuccess": "Lega avviato — {count} match generati.",
   "startChampionshipStartDateLabel": "Inizio dei match",
-    "teamRenameTitle": "Rinomina squadra",
-    "teamRenameLabel": "Nome della squadra",
-    "teamRenameSuccess": "Squadra rinominata con successo.",
-    "teamRenameError": "Impossibile rinominare la squadra",
-    "standingsTiebreakerTitle": "Come funziona la classifica",
-    "standingsTiebreakerBody": "Punti: Vittoria 2-0 = 3pts · Vittoria 2-1 = 2pts · Sconfitta 1-2 = 1pt · Sconfitta 0-2 = 0pts\n\nSpareggio 1: Risultato testa a testa\nSpareggio 2: Rapporto set (set vinti − set persi)",
+  "teamRenameTitle": "Rinomina squadra",
+  "teamRenameLabel": "Nome della squadra",
+  "teamRenameSuccess": "Squadra rinominata con successo.",
+  "teamRenameError": "Impossibile rinominare la squadra",
+  "standingsTiebreakerTitle": "Come funziona la classifica",
+  "standingsTiebreakerBody": "Punti: Vittoria 2-0 = 3pts · Vittoria 2-1 = 2pts · Sconfitta 1-2 = 1pt · Sconfitta 0-2 = 0pts\n\nSpareggio 1: Risultato testa a testa\nSpareggio 2: Rapporto set (set vinti − set persi)",
   "editChampionshipButton": "Modifica dettagli",
-  "editChampionshipTitle": "Modifica campionato",
+  "editChampionshipTitle": "Modifica lega",
   "editChampionshipChangeDeadline": "Cambia scadenza",
   "completeChampionshipButton": "Segna come completato",
-  "completeChampionshipConfirmTitle": "Completare il campionato?",
+  "completeChampionshipConfirmTitle": "Completare il lega?",
   "completeChampionshipConfirmBody": "Usa questa opzione solo quando tutti i match sono stati risolti. L'operazione è irreversibile.",
-  "completeChampionshipSuccess": "Campionato segnato come completato.",
+  "completeChampionshipSuccess": "Lega segnato come completato.",
   "championshipChampionLabel": "Campione",
   "championshipMyMatch": "Il mio match",
   "matchScheduleWaitingTitle": "In attesa di conferma",
@@ -912,10 +909,8 @@
   "matchScheduleConfirmBody": "{teamName} ha proposto: {datetime}",
   "matchScheduleAcceptButton": "Accetta",
   "matchScheduleRejectButton": "Rifiuta",
-
   "matchDisputedTitle": "Match contestato",
   "matchDisputedExplanation": "Questo risultato è stato contestato. Un amministratore esaminerà i punteggi e prenderà una decisione finale. La classifica verrà aggiornata dopo la risoluzione.",
-
   "notificationSettingsTitle": "Notifiche",
   "notificationSettingsCategories": "Categorie di notifiche",
   "notifCategorySocial": "Social",
@@ -924,7 +919,7 @@
   "notifCategoryGamesSubtitle": "Nuove partite, risultati, cancellazioni, chat",
   "notifCategoryTraining": "Allenamento",
   "notifCategoryTrainingSubtitle": "Sessioni create, cancellate, feedback",
-  "notifCategoryChampionships": "Campionati",
+  "notifCategoryChampionships": "Leghe",
   "notifCategoryChampionshipsSubtitle": "Risultati, scadenze, contestazioni, orari",
   "notifQuietHoursTitle": "Ore silenziose",
   "notifQuietHoursEnable": "Attiva ore silenziose",
@@ -933,4 +928,5 @@
   "notifQuietHoursAdjust": "Modifica ore silenziose",
   "retryButton": "Riprova",
   "groupMuteNotifications": "Silenzia le notifiche",
-  "groupUnmuteNotifications": "Attiva le notifiche"}
+  "groupUnmuteNotifications": "Attiva le notifiche"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3869,7 +3869,7 @@ abstract class AppLocalizations {
   /// Title for the championships list screen
   ///
   /// In en, this message translates to:
-  /// **'Championships'**
+  /// **'Leagues'**
   String get championshipsTitle;
 
   /// Status label when a championship is accepting team registrations
@@ -4151,7 +4151,7 @@ abstract class AppLocalizations {
   /// Empty state in the My Matches tab
   ///
   /// In en, this message translates to:
-  /// **'Your matches will appear here once the championship starts.'**
+  /// **'Your matches will appear here once the league starts.'**
   String get championshipMyMatchesEmpty;
 
   /// Match row label: vs opponent
@@ -4175,13 +4175,13 @@ abstract class AppLocalizations {
   /// Empty state shown in the Completed tab
   ///
   /// In en, this message translates to:
-  /// **'No completed championships yet.'**
+  /// **'No completed leagues yet.'**
   String get championshipNoCompletedYet;
 
   /// Empty state message on the championship list screen
   ///
   /// In en, this message translates to:
-  /// **'No championships at the moment.'**
+  /// **'No leagues at the moment.'**
   String get championshipNoResults;
 
   /// Countdown until registration deadline
@@ -4217,13 +4217,13 @@ abstract class AppLocalizations {
   /// Message shown when female/no-gender user tries to register in a male championship
   ///
   /// In en, this message translates to:
-  /// **'This championship is for men only.'**
+  /// **'This league is for men only.'**
   String get championshipGenderBlockMaleOnly;
 
   /// Message shown when male/no-gender user tries to register in a female championship
   ///
   /// In en, this message translates to:
-  /// **'This championship is for women only.'**
+  /// **'This league is for women only.'**
   String get championshipGenderBlockFemaleOnly;
 
   /// Label for the gender category picker in championship creation form
@@ -4493,7 +4493,7 @@ abstract class AppLocalizations {
   /// Page title and FAB tooltip for championship creation
   ///
   /// In en, this message translates to:
-  /// **'Create Championship'**
+  /// **'Create League'**
   String get championshipCreate;
 
   /// Form field label for championship title
@@ -4577,13 +4577,13 @@ abstract class AppLocalizations {
   /// Submit button label on championship creation form
   ///
   /// In en, this message translates to:
-  /// **'Create Championship'**
+  /// **'Create League'**
   String get championshipCreateSubmit;
 
   /// Snackbar message after a championship is created successfully
   ///
   /// In en, this message translates to:
-  /// **'Championship created'**
+  /// **'League created'**
   String get championshipCreateSuccess;
 
   /// Form field label for optional championship start date
@@ -4619,19 +4619,19 @@ abstract class AppLocalizations {
   /// Snackbar message after successfully leaving a championship team
   ///
   /// In en, this message translates to:
-  /// **'You have left the championship.'**
+  /// **'You have left the league.'**
   String get leaveTeamSuccess;
 
   /// Admin button to launch the active phase of a championship
   ///
   /// In en, this message translates to:
-  /// **'Start Championship'**
+  /// **'Start League'**
   String get startChampionshipButton;
 
   /// Confirmation dialog title when starting a championship
   ///
   /// In en, this message translates to:
-  /// **'Start championship?'**
+  /// **'Start league?'**
   String get startChampionshipConfirmTitle;
 
   /// Confirmation dialog body when starting a championship
@@ -4643,7 +4643,7 @@ abstract class AppLocalizations {
   /// Snackbar after a championship is successfully started
   ///
   /// In en, this message translates to:
-  /// **'Championship started — {count} matches generated.'**
+  /// **'League started — {count} matches generated.'**
   String startChampionshipSuccess(int count);
 
   /// Label for the start date picker when starting a championship
@@ -4703,7 +4703,7 @@ abstract class AppLocalizations {
   /// Title of the edit championship dialog
   ///
   /// In en, this message translates to:
-  /// **'Edit Championship'**
+  /// **'Edit League'**
   String get editChampionshipTitle;
 
   /// Placeholder shown on the deadline button in the edit dialog when no new deadline is selected
@@ -4715,7 +4715,7 @@ abstract class AppLocalizations {
   /// Confirmation dialog title when completing a championship
   ///
   /// In en, this message translates to:
-  /// **'Mark championship complete?'**
+  /// **'Mark league complete?'**
   String get completeChampionshipConfirmTitle;
 
   /// Confirmation dialog body when completing a championship
@@ -4727,7 +4727,7 @@ abstract class AppLocalizations {
   /// Snackbar after a championship is successfully marked complete
   ///
   /// In en, this message translates to:
-  /// **'Championship marked as complete.'**
+  /// **'League marked as complete.'**
   String get completeChampionshipSuccess;
 
   /// Label shown above the winning team name on a completed championship
@@ -4841,7 +4841,7 @@ abstract class AppLocalizations {
   /// Category toggle label — championship notifications
   ///
   /// In en, this message translates to:
-  /// **'Championships'**
+  /// **'Leagues'**
   String get notifCategoryChampionships;
 
   /// Subtitle for the championships category toggle

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2125,7 +2125,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get next => 'Weiter';
 
   @override
-  String get championshipsTitle => 'Meisterschaften';
+  String get championshipsTitle => 'Ligen';
 
   @override
   String get championshipOpenRegistration => 'Anmeldung offen';
@@ -2301,7 +2301,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get championshipMyMatchesEmpty =>
-      'Deine Spiele erscheinen hier, sobald die Meisterschaft beginnt.';
+      'Deine Spiele erscheinen hier, sobald die Liga beginnt.';
 
   @override
   String championshipMyMatchesVs(String opponent) {
@@ -2315,11 +2315,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get championshipTabCompleted => 'Abgeschlossen';
 
   @override
-  String get championshipNoCompletedYet =>
-      'Noch keine abgeschlossenen Meisterschaften.';
+  String get championshipNoCompletedYet => 'Noch keine abgeschlossenen Ligen.';
 
   @override
-  String get championshipNoResults => 'Derzeit keine Meisterschaften.';
+  String get championshipNoResults => 'Derzeit keine Ligen.';
 
   @override
   String championshipDeadlineCountdown(int days) {
@@ -2349,11 +2348,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get championshipGenderBlockMaleOnly =>
-      'Diese Meisterschaft ist nur für Männer.';
+      'Diese Liga ist nur für Männer.';
 
   @override
   String get championshipGenderBlockFemaleOnly =>
-      'Diese Meisterschaft ist nur für Frauen.';
+      'Diese Liga ist nur für Frauen.';
 
   @override
   String get championshipCreateGenderLabel => 'Geschlechtskategorie (optional)';
@@ -2498,7 +2497,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wählen Sie einen Gewinner für den Walkover';
 
   @override
-  String get championshipCreate => 'Meisterschaft erstellen';
+  String get championshipCreate => 'Liga erstellen';
 
   @override
   String get championshipCreateTitleLabel => 'Titel';
@@ -2543,10 +2542,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get championshipCreateSubmit => 'Meisterschaft erstellen';
+  String get championshipCreateSubmit => 'Liga erstellen';
 
   @override
-  String get championshipCreateSuccess => 'Meisterschaft erstellt';
+  String get championshipCreateSuccess => 'Liga erstellt';
 
   @override
   String get championshipCreateStartDateLabel => 'Startdatum (optional)';
@@ -2566,13 +2565,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get leaveTeamSuccess => 'Du hast die Meisterschaft verlassen.';
+  String get leaveTeamSuccess => 'Du hast die Liga verlassen.';
 
   @override
-  String get startChampionshipButton => 'Meisterschaft starten';
+  String get startChampionshipButton => 'Liga starten';
 
   @override
-  String get startChampionshipConfirmTitle => 'Meisterschaft starten?';
+  String get startChampionshipConfirmTitle => 'Liga starten?';
 
   @override
   String get startChampionshipConfirmBody =>
@@ -2580,7 +2579,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String startChampionshipSuccess(int count) {
-    return 'Meisterschaft gestartet — $count Spiele erstellt.';
+    return 'Liga gestartet — $count Spiele erstellt.';
   }
 
   @override
@@ -2612,21 +2611,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editChampionshipButton => 'Details bearbeiten';
 
   @override
-  String get editChampionshipTitle => 'Meisterschaft bearbeiten';
+  String get editChampionshipTitle => 'Liga bearbeiten';
 
   @override
   String get editChampionshipChangeDeadline => 'Frist ändern';
 
   @override
-  String get completeChampionshipConfirmTitle => 'Meisterschaft abschließen?';
+  String get completeChampionshipConfirmTitle => 'Liga abschließen?';
 
   @override
   String get completeChampionshipConfirmBody =>
       'Nur verwenden, wenn alle Spiele abgeschlossen sind. Kann nicht rückgängig gemacht werden.';
 
   @override
-  String get completeChampionshipSuccess =>
-      'Meisterschaft als abgeschlossen markiert.';
+  String get completeChampionshipSuccess => 'Liga als abgeschlossen markiert.';
 
   @override
   String get championshipChampionLabel => 'Champion';
@@ -2691,7 +2689,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Sitzungen erstellt, abgesagt, Feedback';
 
   @override
-  String get notifCategoryChampionships => 'Meisterschaften';
+  String get notifCategoryChampionships => 'Ligen';
 
   @override
   String get notifCategoryChampionshipsSubtitle =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2086,7 +2086,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get next => 'Next';
 
   @override
-  String get championshipsTitle => 'Championships';
+  String get championshipsTitle => 'Leagues';
 
   @override
   String get championshipOpenRegistration => 'Open registration';
@@ -2262,7 +2262,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get championshipMyMatchesEmpty =>
-      'Your matches will appear here once the championship starts.';
+      'Your matches will appear here once the league starts.';
 
   @override
   String championshipMyMatchesVs(String opponent) {
@@ -2276,10 +2276,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get championshipTabCompleted => 'Completed';
 
   @override
-  String get championshipNoCompletedYet => 'No completed championships yet.';
+  String get championshipNoCompletedYet => 'No completed leagues yet.';
 
   @override
-  String get championshipNoResults => 'No championships at the moment.';
+  String get championshipNoResults => 'No leagues at the moment.';
 
   @override
   String championshipDeadlineCountdown(int days) {
@@ -2308,12 +2308,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'You must set your gender in your profile to register.';
 
   @override
-  String get championshipGenderBlockMaleOnly =>
-      'This championship is for men only.';
+  String get championshipGenderBlockMaleOnly => 'This league is for men only.';
 
   @override
   String get championshipGenderBlockFemaleOnly =>
-      'This championship is for women only.';
+      'This league is for women only.';
 
   @override
   String get championshipCreateGenderLabel => 'Gender category (optional)';
@@ -2456,7 +2455,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Select a winner for walkover';
 
   @override
-  String get championshipCreate => 'Create Championship';
+  String get championshipCreate => 'Create League';
 
   @override
   String get championshipCreateTitleLabel => 'Title';
@@ -2501,10 +2500,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get championshipCreateSubmit => 'Create Championship';
+  String get championshipCreateSubmit => 'Create League';
 
   @override
-  String get championshipCreateSuccess => 'Championship created';
+  String get championshipCreateSuccess => 'League created';
 
   @override
   String get championshipCreateStartDateLabel => 'Start Date (optional)';
@@ -2524,13 +2523,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get leaveTeamSuccess => 'You have left the championship.';
+  String get leaveTeamSuccess => 'You have left the league.';
 
   @override
-  String get startChampionshipButton => 'Start Championship';
+  String get startChampionshipButton => 'Start League';
 
   @override
-  String get startChampionshipConfirmTitle => 'Start championship?';
+  String get startChampionshipConfirmTitle => 'Start league?';
 
   @override
   String get startChampionshipConfirmBody =>
@@ -2538,7 +2537,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String startChampionshipSuccess(int count) {
-    return 'Championship started — $count matches generated.';
+    return 'League started — $count matches generated.';
   }
 
   @override
@@ -2570,20 +2569,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editChampionshipButton => 'Edit Details';
 
   @override
-  String get editChampionshipTitle => 'Edit Championship';
+  String get editChampionshipTitle => 'Edit League';
 
   @override
   String get editChampionshipChangeDeadline => 'Change deadline';
 
   @override
-  String get completeChampionshipConfirmTitle => 'Mark championship complete?';
+  String get completeChampionshipConfirmTitle => 'Mark league complete?';
 
   @override
   String get completeChampionshipConfirmBody =>
       'Use this only when all matches have been resolved. This cannot be undone.';
 
   @override
-  String get completeChampionshipSuccess => 'Championship marked as complete.';
+  String get completeChampionshipSuccess => 'League marked as complete.';
 
   @override
   String get championshipChampionLabel => 'Champion';
@@ -2648,7 +2647,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Sessions created, cancelled, feedback';
 
   @override
-  String get notifCategoryChampionships => 'Championships';
+  String get notifCategoryChampionships => 'Leagues';
 
   @override
   String get notifCategoryChampionshipsSubtitle =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2114,7 +2114,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get next => 'Siguiente';
 
   @override
-  String get championshipsTitle => 'Campeonatos';
+  String get championshipsTitle => 'Ligas';
 
   @override
   String get championshipOpenRegistration => 'Inscripción abierta';
@@ -2290,7 +2290,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get championshipMyMatchesEmpty =>
-      'Tus partidos aparecerán aquí cuando comience el campeonato.';
+      'Tus partidos aparecerán aquí cuando comience el liga.';
 
   @override
   String championshipMyMatchesVs(String opponent) {
@@ -2304,11 +2304,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get championshipTabCompleted => 'Completados';
 
   @override
-  String get championshipNoCompletedYet =>
-      'Aún no hay campeonatos completados.';
+  String get championshipNoCompletedYet => 'Aún no hay ligas completados.';
 
   @override
-  String get championshipNoResults => 'No hay campeonatos en este momento.';
+  String get championshipNoResults => 'No hay ligas en este momento.';
 
   @override
   String championshipDeadlineCountdown(int days) {
@@ -2338,11 +2337,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get championshipGenderBlockMaleOnly =>
-      'Este campeonato es solo para hombres.';
+      'Este liga es solo para hombres.';
 
   @override
   String get championshipGenderBlockFemaleOnly =>
-      'Este campeonato es solo para mujeres.';
+      'Este liga es solo para mujeres.';
 
   @override
   String get championshipCreateGenderLabel => 'Categoría de género (opcional)';
@@ -2486,7 +2485,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Selecciona un ganador para el walkover';
 
   @override
-  String get championshipCreate => 'Crear campeonato';
+  String get championshipCreate => 'Crear liga';
 
   @override
   String get championshipCreateTitleLabel => 'Título';
@@ -2531,10 +2530,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get championshipCreateSubmit => 'Crear campeonato';
+  String get championshipCreateSubmit => 'Crear liga';
 
   @override
-  String get championshipCreateSuccess => 'Campeonato creado';
+  String get championshipCreateSuccess => 'Liga creado';
 
   @override
   String get championshipCreateStartDateLabel => 'Fecha de inicio (opcional)';
@@ -2554,13 +2553,13 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get leaveTeamSuccess => 'Has abandonado el campeonato.';
+  String get leaveTeamSuccess => 'Has abandonado el liga.';
 
   @override
-  String get startChampionshipButton => 'Iniciar campeonato';
+  String get startChampionshipButton => 'Iniciar liga';
 
   @override
-  String get startChampionshipConfirmTitle => '¿Iniciar el campeonato?';
+  String get startChampionshipConfirmTitle => '¿Iniciar el liga?';
 
   @override
   String get startChampionshipConfirmBody =>
@@ -2568,7 +2567,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String startChampionshipSuccess(int count) {
-    return 'Campeonato iniciado — $count partidos generados.';
+    return 'Liga iniciado — $count partidos generados.';
   }
 
   @override
@@ -2600,21 +2599,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editChampionshipButton => 'Editar detalles';
 
   @override
-  String get editChampionshipTitle => 'Editar campeonato';
+  String get editChampionshipTitle => 'Editar liga';
 
   @override
   String get editChampionshipChangeDeadline => 'Cambiar fecha límite';
 
   @override
-  String get completeChampionshipConfirmTitle => '¿Completar el campeonato?';
+  String get completeChampionshipConfirmTitle => '¿Completar el liga?';
 
   @override
   String get completeChampionshipConfirmBody =>
       'Úsalo solo cuando todos los partidos estén resueltos. Esta acción es irreversible.';
 
   @override
-  String get completeChampionshipSuccess =>
-      'Campeonato marcado como completado.';
+  String get completeChampionshipSuccess => 'Liga marcado como completado.';
 
   @override
   String get championshipChampionLabel => 'Campeón';
@@ -2679,7 +2677,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Sesiones creadas, canceladas, comentarios';
 
   @override
-  String get notifCategoryChampionships => 'Campeonatos';
+  String get notifCategoryChampionships => 'Ligas';
 
   @override
   String get notifCategoryChampionshipsSubtitle =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2131,7 +2131,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get next => 'Suivant';
 
   @override
-  String get championshipsTitle => 'Championnats';
+  String get championshipsTitle => 'Ligues';
 
   @override
   String get championshipOpenRegistration => 'Inscriptions ouvertes';
@@ -2307,7 +2307,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipMyMatchesEmpty =>
-      'Vos matchs apparaîtront ici une fois le championnat lancé.';
+      'Vos matchs apparaîtront ici une fois le ligue lancé.';
 
   @override
   String championshipMyMatchesVs(String opponent) {
@@ -2322,10 +2322,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipNoCompletedYet =>
-      'Aucun championnat terminé pour le moment.';
+      'Aucun ligue terminé pour le moment.';
 
   @override
-  String get championshipNoResults => 'Aucun championnat pour le moment.';
+  String get championshipNoResults => 'Aucun ligue pour le moment.';
 
   @override
   String championshipDeadlineCountdown(int days) {
@@ -2355,11 +2355,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipGenderBlockMaleOnly =>
-      'Ce championnat est réservé aux hommes.';
+      'Ce ligue est réservé aux hommes.';
 
   @override
   String get championshipGenderBlockFemaleOnly =>
-      'Ce championnat est réservé aux femmes.';
+      'Ce ligue est réservé aux femmes.';
 
   @override
   String get championshipCreateGenderLabel => 'Catégorie de genre (optionnel)';
@@ -2503,7 +2503,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Sélectionnez un vainqueur pour le forfait';
 
   @override
-  String get championshipCreate => 'Créer un championnat';
+  String get championshipCreate => 'Créer un ligue';
 
   @override
   String get championshipCreateTitleLabel => 'Titre';
@@ -2548,10 +2548,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get championshipCreateSubmit => 'Créer le championnat';
+  String get championshipCreateSubmit => 'Créer le ligue';
 
   @override
-  String get championshipCreateSuccess => 'Championnat créé';
+  String get championshipCreateSuccess => 'Ligue créé';
 
   @override
   String get championshipCreateStartDateLabel => 'Date de début (optionnel)';
@@ -2571,13 +2571,13 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get leaveTeamSuccess => 'Vous avez quitté le championnat.';
+  String get leaveTeamSuccess => 'Vous avez quitté le ligue.';
 
   @override
-  String get startChampionshipButton => 'Démarrer le championnat';
+  String get startChampionshipButton => 'Démarrer le ligue';
 
   @override
-  String get startChampionshipConfirmTitle => 'Démarrer le championnat ?';
+  String get startChampionshipConfirmTitle => 'Démarrer le ligue ?';
 
   @override
   String get startChampionshipConfirmBody =>
@@ -2585,7 +2585,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String startChampionshipSuccess(int count) {
-    return 'Championnat démarré — $count matchs générés.';
+    return 'Ligue démarré — $count matchs générés.';
   }
 
   @override
@@ -2617,20 +2617,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get editChampionshipButton => 'Modifier les détails';
 
   @override
-  String get editChampionshipTitle => 'Modifier le championnat';
+  String get editChampionshipTitle => 'Modifier le ligue';
 
   @override
   String get editChampionshipChangeDeadline => 'Changer la date limite';
 
   @override
-  String get completeChampionshipConfirmTitle => 'Terminer le championnat ?';
+  String get completeChampionshipConfirmTitle => 'Terminer le ligue ?';
 
   @override
   String get completeChampionshipConfirmBody =>
       'À utiliser uniquement lorsque tous les matchs sont résolus. Irréversible.';
 
   @override
-  String get completeChampionshipSuccess => 'Championnat marqué comme terminé.';
+  String get completeChampionshipSuccess => 'Ligue marqué comme terminé.';
 
   @override
   String get championshipChampionLabel => 'Champion';
@@ -2695,7 +2695,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Sessions créées, annulées, retours';
 
   @override
-  String get notifCategoryChampionships => 'Championnats';
+  String get notifCategoryChampionships => 'Ligues';
 
   @override
   String get notifCategoryChampionshipsSubtitle =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2107,7 +2107,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get next => 'Avanti';
 
   @override
-  String get championshipsTitle => 'Campionati';
+  String get championshipsTitle => 'Leghe';
 
   @override
   String get championshipOpenRegistration => 'Iscrizioni aperte';
@@ -2283,7 +2283,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get championshipMyMatchesEmpty =>
-      'I tuoi match appariranno qui quando il campionato inizierà.';
+      'I tuoi match appariranno qui quando il lega inizierà.';
 
   @override
   String championshipMyMatchesVs(String opponent) {
@@ -2297,11 +2297,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get championshipTabCompleted => 'Completati';
 
   @override
-  String get championshipNoCompletedYet =>
-      'Nessun campionato completato ancora.';
+  String get championshipNoCompletedYet => 'Nessun lega completato ancora.';
 
   @override
-  String get championshipNoResults => 'Nessun campionato al momento.';
+  String get championshipNoResults => 'Nessun lega al momento.';
 
   @override
   String championshipDeadlineCountdown(int days) {
@@ -2331,11 +2330,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get championshipGenderBlockMaleOnly =>
-      'Questo campionato è solo per uomini.';
+      'Questo lega è solo per uomini.';
 
   @override
   String get championshipGenderBlockFemaleOnly =>
-      'Questo campionato è solo per donne.';
+      'Questo lega è solo per donne.';
 
   @override
   String get championshipCreateGenderLabel => 'Categoria di genere (opzionale)';
@@ -2479,7 +2478,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Seleziona un vincitore per il walkover';
 
   @override
-  String get championshipCreate => 'Crea campionato';
+  String get championshipCreate => 'Crea lega';
 
   @override
   String get championshipCreateTitleLabel => 'Titolo';
@@ -2524,10 +2523,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get championshipCreateSubmit => 'Crea campionato';
+  String get championshipCreateSubmit => 'Crea lega';
 
   @override
-  String get championshipCreateSuccess => 'Campionato creato';
+  String get championshipCreateSuccess => 'Lega creato';
 
   @override
   String get championshipCreateStartDateLabel => 'Data di inizio (opzionale)';
@@ -2547,13 +2546,13 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get leaveTeamSuccess => 'Hai abbandonato il campionato.';
+  String get leaveTeamSuccess => 'Hai abbandonato il lega.';
 
   @override
-  String get startChampionshipButton => 'Avvia campionato';
+  String get startChampionshipButton => 'Avvia lega';
 
   @override
-  String get startChampionshipConfirmTitle => 'Avviare il campionato?';
+  String get startChampionshipConfirmTitle => 'Avviare il lega?';
 
   @override
   String get startChampionshipConfirmBody =>
@@ -2561,7 +2560,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String startChampionshipSuccess(int count) {
-    return 'Campionato avviato — $count match generati.';
+    return 'Lega avviato — $count match generati.';
   }
 
   @override
@@ -2593,21 +2592,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get editChampionshipButton => 'Modifica dettagli';
 
   @override
-  String get editChampionshipTitle => 'Modifica campionato';
+  String get editChampionshipTitle => 'Modifica lega';
 
   @override
   String get editChampionshipChangeDeadline => 'Cambia scadenza';
 
   @override
-  String get completeChampionshipConfirmTitle => 'Completare il campionato?';
+  String get completeChampionshipConfirmTitle => 'Completare il lega?';
 
   @override
   String get completeChampionshipConfirmBody =>
       'Usa questa opzione solo quando tutti i match sono stati risolti. L\'operazione è irreversibile.';
 
   @override
-  String get completeChampionshipSuccess =>
-      'Campionato segnato come completato.';
+  String get completeChampionshipSuccess => 'Lega segnato come completato.';
 
   @override
   String get championshipChampionLabel => 'Campione';
@@ -2672,7 +2670,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Sessioni create, cancellate, feedback';
 
   @override
-  String get notifCategoryChampionships => 'Campionati';
+  String get notifCategoryChampionships => 'Leghe';
 
   @override
   String get notifCategoryChampionshipsSubtitle =>

--- a/test/widget/features/championships/championship_list_page_test.dart
+++ b/test/widget/features/championships/championship_list_page_test.dart
@@ -91,7 +91,7 @@ void main() {
       await tester.pumpWidget(_buildTestWidget(bloc));
       await tester.pumpAndSettle();
 
-      expect(find.text('No championships at the moment.'), findsOneWidget);
+      expect(find.text('No leagues at the moment.'), findsOneWidget);
       bloc.close();
     });
 

--- a/test/widget/features/championships/create_championship_page_test.dart
+++ b/test/widget/features/championships/create_championship_page_test.dart
@@ -128,7 +128,7 @@ void main() {
     testWidgets('shows page title and submit button', (tester) async {
       await tester.pumpWidget(_buildTestWidget(bloc));
       await tester.pumpAndSettle();
-      expect(find.text('Create Championship'), findsWidgets);
+      expect(find.text('Create League'), findsWidgets);
     });
 
     testWidgets('shows title field', (tester) async {
@@ -202,7 +202,7 @@ void main() {
       await tester.pumpWidget(_buildTestWidget(bloc));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
-      expect(find.text('Championship created'), findsOneWidget);
+      expect(find.text('League created'), findsOneWidget);
     });
 
     testWidgets('shows error snackbar on error state', (tester) async {

--- a/test/widget/features/notifications/presentation/pages/notification_settings_page_test.dart
+++ b/test/widget/features/notifications/presentation/pages/notification_settings_page_test.dart
@@ -101,7 +101,7 @@ void main() {
       expect(find.text('Social'), findsOneWidget);
       expect(find.text('Games'), findsOneWidget);
       expect(find.text('Training'), findsOneWidget);
-      expect(find.text('Championships'), findsOneWidget);
+      expect(find.text('Leagues'), findsOneWidget);
     });
   });
 
@@ -116,7 +116,7 @@ void main() {
       expect(find.text('Social'), findsOneWidget);
       expect(find.text('Games'), findsOneWidget);
       expect(find.text('Training'), findsOneWidget);
-      expect(find.text('Championships'), findsOneWidget);
+      expect(find.text('Leagues'), findsOneWidget);
     });
 
     testWidgets('displays category subtitles', (tester) async {


### PR DESCRIPTION
Renames the feature from 'Championship' to 'League' in all user-visible strings across EN, FR, DE, ES, IT.

**Approach:** changed ARB string **values** only. ARB keys (`championship`, `createChampionship`, etc.) and all Dart code are untouched — zero code changes required.

| Language | Old | New |
|---|---|---|
| EN | Championship / Championships | League / Leagues |
| FR | Championnat / Championnats | Ligue / Ligues |
| DE | Meisterschaft / Meisterschaften | Liga / Ligen |
| ES | Campeonato / Campeonatos | Liga / Ligas |
| IT | Campionato / Campionati | Lega / Leghe |

17 string values updated per language (85 total).