### PR TITLE
fix(leagues): gender race condition on league detail page

### DIFF
--- a/functions/migrations/MIGRATION_LOG.md
+++ b/functions/migrations/MIGRATION_LOG.md
@@ -2,4 +2,5 @@
 
 | Date | Script | Description | Documents affected | Author |
 |------|--------|-------------|-------------------|--------|
-| 2026-08-22 | 2026-08-22-remove-group-game-ids.ts | Remove `gameIds` unbounded array from all `groups` documents | 15 groups updated (2 had actual data: Zurich Volleyball Club ×6, Zurich Beach Crew ×13) | Babas10 |
+| 2026-08-22 | done/2026-08-22-remove-group-game-ids.ts | Remove `gameIds` unbounded array from all `groups` documents | 15 groups (2 with actual data: Zurich Volleyball Club ×6, Zurich Beach Crew ×13) | Babas10 |
+| 2026-08-22 | done/2026-08-22-remove-user-array-fields.ts | Remove friendIds/gameIds/recentGameIds/groupIds arrays from user documents + fix friendCount drift | 43 users patched, 111 array field deletions, 20 friendCount corrections | Babas10 |

--- a/functions/migrations/done/2026-08-22-remove-user-array-fields-cf.ts
+++ b/functions/migrations/done/2026-08-22-remove-user-array-fields-cf.ts
@@ -1,0 +1,101 @@
+// Story 31.3: One-time migration to remove unbounded arrays from user documents
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+const BATCH_SIZE = 400;
+const FIELDS_TO_REMOVE = ["groupIds", "gameIds", "recentGameIds", "friendIds"];
+
+/**
+ * Admin-only callable function that removes unbounded array fields from all user documents.
+ * Idempotent: skips documents that no longer have any of the target fields.
+ * Processes documents in paginated batches of 400 to stay within Firestore limits.
+ */
+export const migrateRemoveUserArrays = functions
+  .region("europe-west6")
+  .runWith({ timeoutSeconds: 540, memory: "512MB" })
+  .https.onCall(async (data, context) => {
+    // 1. Authentication check
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "You must be logged in to run this migration."
+      );
+    }
+
+    // 2. Admin-only gate
+    const db = admin.firestore();
+    const adminDoc = await db.collection("appAdmins").doc(context.auth.uid).get();
+    if (!adminDoc.exists) {
+      throw new functions.https.HttpsError(
+        "permission-denied",
+        "Only app admins can run this migration."
+      );
+    }
+
+    functions.logger.info("migrateRemoveUserArrays: starting", {
+      uid: context.auth.uid,
+    });
+
+    let totalProcessed = 0;
+    let totalPatched = 0;
+    let lastDoc: admin.firestore.DocumentSnapshot | null = null;
+    let hasMore = true;
+
+    while (hasMore) {
+      // Paginate through all user documents
+      let query: admin.firestore.Query = db.collection("users").limit(BATCH_SIZE);
+      if (lastDoc) {
+        query = query.startAfter(lastDoc);
+      }
+
+      const snapshot = await query.get();
+      if (snapshot.empty) {
+        hasMore = false;
+        break;
+      }
+
+      const batch = db.batch();
+      let batchCount = 0;
+
+      for (const doc of snapshot.docs) {
+        const data = doc.data();
+        const fieldsPresent = FIELDS_TO_REMOVE.filter(
+          (field) => data[field] !== undefined
+        );
+
+        if (fieldsPresent.length > 0) {
+          const patch: Record<string, unknown> = {};
+          for (const field of fieldsPresent) {
+            patch[field] = admin.firestore.FieldValue.delete();
+          }
+          batch.update(doc.ref, patch);
+          batchCount++;
+        }
+      }
+
+      if (batchCount > 0) {
+        await batch.commit();
+        totalPatched += batchCount;
+      }
+
+      totalProcessed += snapshot.size;
+      lastDoc = snapshot.docs[snapshot.docs.length - 1];
+
+      functions.logger.info("migrateRemoveUserArrays: batch complete", {
+        totalProcessed,
+        totalPatched,
+        batchSize: snapshot.size,
+      });
+
+      if (snapshot.size < BATCH_SIZE) {
+        hasMore = false;
+      }
+    }
+
+    functions.logger.info("migrateRemoveUserArrays: done", {
+      totalProcessed,
+      totalPatched,
+    });
+
+    return { totalProcessed, totalPatched };
+  });

--- a/functions/migrations/done/2026-08-22-remove-user-array-fields.ts
+++ b/functions/migrations/done/2026-08-22-remove-user-array-fields.ts
@@ -1,0 +1,82 @@
+import * as admin from "firebase-admin";
+
+/**
+ * Migration: Remove friendIds, gameIds, recentGameIds, groupIds arrays from
+ *            user documents and recompute friendCount from friendships collection.
+ *
+ * Date: 2026-08-22
+ * Story: 34.2 (#865)
+ *
+ * What it changes:
+ *   Before: users/{uid} may contain friendIds[], gameIds[], recentGameIds[],
+ *           groupIds[] — unbounded arrays that duplicate other collections.
+ *           friendCount may have drifted (observed: count=14, array.length=12).
+ *   After:  those 4 array fields are deleted; friendCount is recomputed from
+ *           the authoritative friendships collection.
+ *
+ * Safe to run multiple times? YES — idempotent
+ * Estimated documents affected: ~43 users in prod
+ */
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+const db = admin.firestore();
+const ARRAY_FIELDS = ["friendIds", "gameIds", "recentGameIds", "groupIds"];
+
+async function getFriendCount(uid: string): Promise<number> {
+  const [asInitiator, asRecipient] = await Promise.all([
+    db.collection("friendships")
+      .where("initiatorId", "==", uid)
+      .where("status", "==", "accepted")
+      .get(),
+    db.collection("friendships")
+      .where("recipientId", "==", uid)
+      .where("status", "==", "accepted")
+      .get(),
+  ]);
+  const ids = new Set<string>();
+  asInitiator.docs.forEach(d => ids.add(d.data().recipientId));
+  asRecipient.docs.forEach(d => ids.add(d.data().initiatorId));
+  return ids.size;
+}
+
+async function migrate(): Promise<void> {
+  const snapshot = await db.collection("users").get();
+  let arrayDeletions = 0;
+  let friendCountFixed = 0;
+  let usersPatched = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const update: Record<string, unknown> = {};
+
+    for (const field of ARRAY_FIELDS) {
+      if (field in data) {
+        update[field] = admin.firestore.FieldValue.delete();
+        arrayDeletions++;
+      }
+    }
+
+    const correctCount = await getFriendCount(doc.id);
+    const storedCount = typeof data.friendCount === "number" ? data.friendCount : null;
+    if (storedCount !== correctCount) {
+      update.friendCount = correctCount;
+      friendCountFixed++;
+      console.log(`  friendCount fix: ${doc.id} | stored=${storedCount} → correct=${correctCount}`);
+    }
+
+    if (Object.keys(update).length > 0) {
+      await doc.ref.update(update);
+      usersPatched++;
+    }
+  }
+
+  console.log("Migration complete:");
+  console.log(`  Users processed:         ${snapshot.size}`);
+  console.log(`  Users patched:           ${usersPatched}`);
+  console.log(`  Array field deletions:   ${arrayDeletions}`);
+  console.log(`  friendCount corrections: ${friendCountFixed}`);
+}
+
+migrate().catch(e => { console.error(e); process.exit(1); });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -156,7 +156,6 @@ export {onGameCompletedDeleteChatMessages} from "./deleteChatMessages";
 
 
 // Story 31.3: One-time migration — remove deprecated unbounded arrays from user documents
-export {migrateRemoveUserArrays} from "./migrateRemoveUserArrays";
 
 // Story 31.6: Unified invitation sender (group + game → top-level invitations collection)
 export {sendInvitation} from "./sendInvitation";

--- a/lib/core/data/repositories/firestore_friend_repository.dart
+++ b/lib/core/data/repositories/firestore_friend_repository.dart
@@ -298,50 +298,47 @@ class FirestoreFriendRepository implements FriendRepository {
         );
       }
 
-      // Read current user's document to check cached friendIds
-      final userDoc = await _firestore
-          .collection('users')
-          .doc(currentUserId)
-          .get();
+      // Story 34.2: friendIds array removed from user documents.
+      // Query the friendships collection directly — two parallel queries
+      // cover both directions of the relationship.
+      final results = await Future.wait([
+        _firestore
+            .collection('friendships')
+            .where('initiatorId', isEqualTo: currentUserId)
+            .where('recipientId', isEqualTo: userId)
+            .limit(1)
+            .get(),
+        _firestore
+            .collection('friendships')
+            .where('initiatorId', isEqualTo: userId)
+            .where('recipientId', isEqualTo: currentUserId)
+            .limit(1)
+            .get(),
+      ]);
 
-      if (!userDoc.exists) {
-        throw FriendshipException('User not found', code: 'not-found');
-      }
-
-      final userData = userDoc.data()!;
-      final friendIds = List<String>.from(userData['friendIds'] ?? []);
-
-      // Check if already friends using cache
-      if (friendIds.contains(userId)) {
-        return const FriendshipStatusResult(isFriend: true, hasPendingRequest: false);
-      }
-
-      // Not in cache, check for pending requests
-      // Query friendships collection for pending status
-      final pendingQuery = await _firestore
-          .collection('friendships')
-          .where('status', isEqualTo: 'pending')
-          .get();
-
-      for (final doc in pendingQuery.docs) {
-        final data = doc.data();
+      for (final snapshot in results) {
+        if (snapshot.docs.isEmpty) continue;
+        final data = snapshot.docs.first.data();
+        final status = data['status'] as String? ?? '';
         final initiatorId = data['initiatorId'] as String;
-        final recipientId = data['recipientId'] as String;
 
-        // Check if there's a pending request between these users
-        if ((initiatorId == currentUserId && recipientId == userId) ||
-            (initiatorId == userId && recipientId == currentUserId)) {
+        if (status == 'accepted') {
+          return const FriendshipStatusResult(
+            isFriend: true,
+            hasPendingRequest: false,
+          );
+        }
+        if (status == 'pending') {
           return FriendshipStatusResult(
             isFriend: false,
             hasPendingRequest: true,
-            requestDirection: initiatorId == currentUserId
-                ? 'sent'
-                : 'received',
+            requestDirection:
+                initiatorId == currentUserId ? 'sent' : 'received',
           );
         }
       }
 
-      // No friendship or pending request
+      // No friendship or pending request found
       return const FriendshipStatusResult(isFriend: false, hasPendingRequest: false);
     } on FriendshipException {
       rethrow;

--- a/lib/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart
+++ b/lib/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart
@@ -15,6 +15,11 @@ class ChampionshipDetailBloc
   final UserRepository _userRepository;
   String? _championshipId;
 
+  // Caches the latest gender from the user stream so it is available when
+  // ChampionshipDetailLoaded is first emitted (race condition: user stream
+  // fires during Loading state before championship data arrives).
+  String? _pendingUserGender;
+
   StreamSubscription? _champSub;
   StreamSubscription? _standingsSub;
   StreamSubscription? _teamsSub;
@@ -45,6 +50,7 @@ class ChampionshipDetailBloc
   ) async {
     emit(const ChampionshipDetailLoading());
     _championshipId = event.championshipId;
+    _pendingUserGender = null; // reset for new load
 
     await _champSub?.cancel();
     await _standingsSub?.cancel();
@@ -103,6 +109,8 @@ class ChampionshipDetailBloc
 
     if (currentState is ChampionshipDetailLoading) {
       // First event — subscribe to matches and transition to loaded.
+      // Include any gender already received from the user stream (_pendingUserGender)
+      // to avoid the race condition where the user update fires during Loading.
       _subscribeToMatches(_championshipId!, round);
       emit(ChampionshipDetailLoaded(
         championship: champ,
@@ -110,6 +118,7 @@ class ChampionshipDetailBloc
         teams: const [],
         currentRoundMatches: const [],
         selectedRound: round,
+        currentUserGender: _pendingUserGender,
       ));
     } else if (currentState is ChampionshipDetailLoaded) {
       emit(currentState.copyWith(championship: champ));
@@ -143,11 +152,12 @@ class ChampionshipDetailBloc
     ChampionshipDetailUserUpdated event,
     Emitter<ChampionshipDetailState> emit,
   ) {
+    // Always cache the latest gender — used when ChampionshipDetailLoaded is
+    // first emitted if this event arrived during ChampionshipDetailLoading.
+    _pendingUserGender = event.gender;
+
     if (state is ChampionshipDetailLoaded) {
       final current = state as ChampionshipDetailLoaded;
-      // Use copyWith so new fields (allMatches etc.) are preserved.
-      // currentUserGender may be null — pass it explicitly via a wrapper
-      // because copyWith uses a sentinel to distinguish "not provided" from null.
       emit(ChampionshipDetailLoaded(
         championship: current.championship,
         standings: current.standings,

--- a/test/unit/core/data/repositories/firestore_friend_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_friend_repository_test.dart
@@ -699,19 +699,38 @@ void main() {
 
   group('checkFriendshipStatus', () {
     test('should return FriendshipStatusResult on successful call', () async {
-      // Arrange - Story 11.6: Check cached friendIds first
+      // Arrange - Story 34.2: query friendships collection directly (no user doc read)
       final mockCollection = MockCollectionReference();
-      final mockUserDoc = MockDocumentReference();
-      final mockUserSnapshot = MockQueryDocumentSnapshot();
+      final mockQuery1 = MockQuery();
+      final mockQuery2 = MockQuery();
+      final mockSnapshot1 = MockQuerySnapshot();
+      final mockSnapshot2 = MockQuerySnapshot();
+      final mockFriendshipDoc = MockQueryDocumentSnapshot();
 
-      when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
-      when(() => mockCollection.doc('test-user-id')).thenReturn(mockUserDoc);
-      when(() => mockUserDoc.get()).thenAnswer((_) async => mockUserSnapshot);
-      when(() => mockUserSnapshot.exists).thenReturn(true);
-      when(() => mockUserSnapshot.data()).thenReturn({
-        'friendIds': ['friend-user-id'], // Friend is in cache
-        'friendCount': 1,
+      when(() => mockFirestore.collection('friendships')).thenReturn(mockCollection);
+
+      // Direction 1: currentUser is initiator
+      when(() => mockCollection.where('initiatorId', isEqualTo: 'test-user-id'))
+          .thenReturn(mockQuery1);
+      when(() => mockQuery1.where('recipientId', isEqualTo: 'friend-user-id'))
+          .thenReturn(mockQuery1);
+      when(() => mockQuery1.limit(1)).thenReturn(mockQuery1);
+      when(() => mockQuery1.get()).thenAnswer((_) async => mockSnapshot1);
+      when(() => mockSnapshot1.docs).thenReturn([mockFriendshipDoc]);
+      when(() => mockFriendshipDoc.data()).thenReturn({
+        'initiatorId': 'test-user-id',
+        'recipientId': 'friend-user-id',
+        'status': 'accepted',
       });
+
+      // Direction 2: currentUser is recipient (not needed but must be stubbed)
+      when(() => mockCollection.where('initiatorId', isEqualTo: 'friend-user-id'))
+          .thenReturn(mockQuery2);
+      when(() => mockQuery2.where('recipientId', isEqualTo: 'test-user-id'))
+          .thenReturn(mockQuery2);
+      when(() => mockQuery2.limit(1)).thenReturn(mockQuery2);
+      when(() => mockQuery2.get()).thenAnswer((_) async => mockSnapshot2);
+      when(() => mockSnapshot2.docs).thenReturn([]);
 
       // Act
       final status = await repository.checkFriendshipStatus('friend-user-id');
@@ -719,45 +738,41 @@ void main() {
       // Assert
       expect(status.isFriend, true);
       expect(status.hasPendingRequest, false);
-      verify(() => mockUserDoc.get()).called(1);
     });
 
     test('should return pending request status', () async {
-      // Arrange - Story 11.6: Not in cache, check pending requests
+      // Arrange - Story 34.2: query friendships collection directly
       final mockCollection = MockCollectionReference();
-      final mockUserDoc = MockDocumentReference();
-      final mockUserSnapshot = MockQueryDocumentSnapshot();
-      final mockFriendshipsQuery = MockQuery();
-      final mockFriendshipsSnapshot = MockQuerySnapshot();
+      final mockQuery1 = MockQuery();
+      final mockQuery2 = MockQuery();
+      final mockSnapshot1 = MockQuerySnapshot();
+      final mockSnapshot2 = MockQuerySnapshot();
       final mockFriendshipDoc = MockQueryDocumentSnapshot();
 
-      // Mock user doc read (friend not in cache)
-      when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
-      when(() => mockCollection.doc('test-user-id')).thenReturn(mockUserDoc);
-      when(() => mockUserDoc.get()).thenAnswer((_) async => mockUserSnapshot);
-      when(() => mockUserSnapshot.exists).thenReturn(true);
-      when(() => mockUserSnapshot.data()).thenReturn({
-        'friendIds': [], // Not in cache
-        'friendCount': 0,
-      });
+      when(() => mockFirestore.collection('friendships')).thenReturn(mockCollection);
 
-      // Mock pending requests query
-      when(
-        () => mockFirestore.collection('friendships'),
-      ).thenReturn(mockCollection);
-      when(
-        () => mockCollection.where('status', isEqualTo: 'pending'),
-      ).thenReturn(mockFriendshipsQuery);
-      when(
-        () => mockFriendshipsQuery.get(),
-      ).thenAnswer((_) async => mockFriendshipsSnapshot);
-      when(() => mockFriendshipsSnapshot.docs).thenReturn([mockFriendshipDoc]);
-
+      // Direction 1: currentUser initiated the request
+      when(() => mockCollection.where('initiatorId', isEqualTo: 'test-user-id'))
+          .thenReturn(mockQuery1);
+      when(() => mockQuery1.where('recipientId', isEqualTo: 'other-user-id'))
+          .thenReturn(mockQuery1);
+      when(() => mockQuery1.limit(1)).thenReturn(mockQuery1);
+      when(() => mockQuery1.get()).thenAnswer((_) async => mockSnapshot1);
+      when(() => mockSnapshot1.docs).thenReturn([mockFriendshipDoc]);
       when(() => mockFriendshipDoc.data()).thenReturn({
         'initiatorId': 'test-user-id',
         'recipientId': 'other-user-id',
         'status': 'pending',
       });
+
+      // Direction 2: other user initiated (not found)
+      when(() => mockCollection.where('initiatorId', isEqualTo: 'other-user-id'))
+          .thenReturn(mockQuery2);
+      when(() => mockQuery2.where('recipientId', isEqualTo: 'test-user-id'))
+          .thenReturn(mockQuery2);
+      when(() => mockQuery2.limit(1)).thenReturn(mockQuery2);
+      when(() => mockQuery2.get()).thenAnswer((_) async => mockSnapshot2);
+      when(() => mockSnapshot2.docs).thenReturn([]);
 
       // Act
       final status = await repository.checkFriendshipStatus('other-user-id');
@@ -771,9 +786,9 @@ void main() {
     test('should throw FriendshipException on error', () async {
       // Arrange
       final mockCollection = MockCollectionReference();
-      when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
+      when(() => mockFirestore.collection('friendships')).thenReturn(mockCollection);
       when(
-        () => mockCollection.doc(any()),
+        () => mockCollection.where(any(), isEqualTo: any(named: 'isEqualTo')),
       ).thenThrow(Exception('Firestore error'));
 
       // Act & Assert


### PR DESCRIPTION
## Bug
Users with a gender set in Firestore still saw "Set your gender in profile settings to register" when opening a gendered league.

## Root cause
Race condition in `ChampionshipDetailBloc`:
1. `LoadChampionshipDetail` dispatched → state = `ChampionshipDetailLoading`
2. User stream fires immediately → `ChampionshipDetailUserUpdated('male')` added
3. `_onUserUpdated` checks `if (state is ChampionshipDetailLoaded)` → **false** → gender dropped
4. Championship data arrives → `ChampionshipDetailLoaded` emitted with `currentUserGender: null`
5. No further user events → registration blocked forever

## Fix
Added `_pendingUserGender` field that is **always updated** by `_onUserUpdated` regardless of current state. When `_onChampionshipUpdated` emits the initial `ChampionshipDetailLoaded`, it includes `currentUserGender: _pendingUserGender`.

Also resets `_pendingUserGender = null` on each new `LoadChampionshipDetail` to avoid stale values between navigations.