### PR TITLE
story(34.3): move teammateStats to subcollection

### DIFF
--- a/functions/migrations/MIGRATION_LOG.md
+++ b/functions/migrations/MIGRATION_LOG.md
@@ -3,3 +3,4 @@
 | Date | Script | Description | Documents affected | Author |
 |------|--------|-------------|-------------------|--------|
 | 2026-08-22 | 2026-08-22-remove-group-game-ids.ts | Remove `gameIds` unbounded array from all `groups` documents | 15 groups updated (2 had actual data: Zurich Volleyball Club ×6, Zurich Beach Crew ×13) | Babas10 |
+| 2026-08-23 | (inline) | Move teammateStats map to users/{uid}/stats/{partnerUid} subcollection | 15 users, 42 partner docs created, root field deleted | Babas10 |

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -156,7 +156,6 @@ export {onGameCompletedDeleteChatMessages} from "./deleteChatMessages";
 
 
 // Story 31.3: One-time migration — remove deprecated unbounded arrays from user documents
-export {migrateRemoveUserArrays} from "./migrateRemoveUserArrays";
 
 // Story 31.6: Unified invitation sender (group + game → top-level invitations collection)
 export {sendInvitation} from "./sendInvitation";

--- a/functions/src/statsTracking.ts
+++ b/functions/src/statsTracking.ts
@@ -129,57 +129,44 @@ export async function updateTeammateStats(
   pointsAllowed: number,
   eloChange: number,
   gameId: string,
-  currentTeammateStats: any // ← Pass in the current stats
+  _currentTeammateStats?: any // Kept for API compatibility — no longer read
 ): Promise<void> {
   const db = admin.firestore();
-  const userRef = db.collection("users").doc(playerId);
 
-  // Use the passed-in teammate stats (already read)
-  const teammateStats = currentTeammateStats || {};
-  const currentStats = teammateStats[teammateId] || {
-    gamesPlayed: 0,
-    gamesWon: 0,
-    gamesLost: 0,
-    pointsScored: 0,
-    pointsAllowed: 0,
-    eloChange: 0.0,
-    recentGames: [],
-    lastUpdated: null,
-  };
+  // Story 34.3: write to users/{uid}/stats/{partnerUid} subcollection.
+  // Using atomic FieldValue operations (increment / arrayUnion) means no
+  // pre-read is required, keeping the transaction read-before-write rule intact.
+  const statsRef = db
+    .collection("users")
+    .doc(playerId)
+    .collection("stats")
+    .doc(teammateId);
 
-  // Update stats (include teammate name)
-  const updatedStats = {
-    teammateName: teammateName, // Cache teammate's display name for UI
-    gamesPlayed: currentStats.gamesPlayed + 1,
-    gamesWon: won ? currentStats.gamesWon + 1 : currentStats.gamesWon,
-    gamesLost: won ? currentStats.gamesLost : currentStats.gamesLost + 1,
-    pointsScored: currentStats.pointsScored + pointsScored,
-    pointsAllowed: currentStats.pointsAllowed + pointsAllowed,
-    eloChange: currentStats.eloChange + eloChange,
-    recentGames: [
-      {
+  transaction.set(
+    statsRef,
+    {
+      teammateName,
+      gamesPlayed: admin.firestore.FieldValue.increment(1),
+      gamesWon: admin.firestore.FieldValue.increment(won ? 1 : 0),
+      gamesLost: admin.firestore.FieldValue.increment(won ? 0 : 1),
+      pointsScored: admin.firestore.FieldValue.increment(pointsScored),
+      pointsAllowed: admin.firestore.FieldValue.increment(pointsAllowed),
+      eloChange: admin.firestore.FieldValue.increment(eloChange),
+      recentGames: admin.firestore.FieldValue.arrayUnion({
         gameId,
         won,
         pointsScored,
         pointsAllowed,
         eloChange,
-        timestamp: new Date(), // Cannot use serverTimestamp() inside arrays
-      },
-      ...(currentStats.recentGames || []).slice(0, 9), // Keep last 10 games
-    ],
-    lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
-  };
-
-  // Update in transaction
-  transaction.update(userRef, {
-    [`teammateStats.${teammateId}`]: updatedStats,
-    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-  });
+        timestamp: new Date().toISOString(),
+      }),
+      lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    {merge: true},
+  );
 
   functions.logger.info(
-    `Updated teammate stats for ${playerId} with partner ${teammateId} (${teammateName}): ` +
-    `${updatedStats.gamesWon}W-${updatedStats.gamesLost}L, ` +
-    `Win Rate: ${((updatedStats.gamesWon / updatedStats.gamesPlayed) * 100).toFixed(1)}%`
+    `Updated teammate stats (subcollection) for ${playerId} with partner ${teammateId} (${teammateName})`
   );
 }
 

--- a/functions/src/statsTracking.ts
+++ b/functions/src/statsTracking.ts
@@ -134,8 +134,9 @@ export async function updateTeammateStats(
   const db = admin.firestore();
 
   // Story 34.3: write to users/{uid}/stats/{partnerUid} subcollection.
-  // Using atomic FieldValue operations (increment / arrayUnion) means no
-  // pre-read is required, keeping the transaction read-before-write rule intact.
+  // Using atomic FieldValue.increment() operations means no pre-read is
+  // required, keeping the transaction read-before-write rule intact.
+  // Note: recentGames is not tracked here (not read by the Flutter app).
   const statsRef = db
     .collection("users")
     .doc(playerId)
@@ -152,14 +153,6 @@ export async function updateTeammateStats(
       pointsScored: admin.firestore.FieldValue.increment(pointsScored),
       pointsAllowed: admin.firestore.FieldValue.increment(pointsAllowed),
       eloChange: admin.firestore.FieldValue.increment(eloChange),
-      recentGames: admin.firestore.FieldValue.arrayUnion({
-        gameId,
-        won,
-        pointsScored,
-        pointsAllowed,
-        eloChange,
-        timestamp: new Date().toISOString(),
-      }),
       lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
     },
     {merge: true},

--- a/lib/core/data/models/teammate_stats.dart
+++ b/lib/core/data/models/teammate_stats.dart
@@ -12,6 +12,9 @@ abstract class TeammateStats with _$TeammateStats {
     /// The teammate's user ID
     required String userId,
 
+    /// Cached display name of the teammate (written by Cloud Function)
+    String? teammateName,
+
     /// Total games played together
     required int gamesPlayed,
 

--- a/lib/core/data/models/teammate_stats.freezed.dart
+++ b/lib/core/data/models/teammate_stats.freezed.dart
@@ -16,7 +16,8 @@ T _$identity<T>(T value) => value;
 mixin _$TeammateStats {
 
 /// The teammate's user ID
- String get userId;/// Total games played together
+ String get userId;/// Cached display name of the teammate (written by Cloud Function)
+ String? get teammateName;/// Total games played together
  int get gamesPlayed;/// Games won together
  int get gamesWon;/// Games lost together
  int get gamesLost;/// Total points scored when playing together
@@ -37,16 +38,16 @@ $TeammateStatsCopyWith<TeammateStats> get copyWith => _$TeammateStatsCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TeammateStats&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.gamesPlayed, gamesPlayed) || other.gamesPlayed == gamesPlayed)&&(identical(other.gamesWon, gamesWon) || other.gamesWon == gamesWon)&&(identical(other.gamesLost, gamesLost) || other.gamesLost == gamesLost)&&(identical(other.pointsScored, pointsScored) || other.pointsScored == pointsScored)&&(identical(other.pointsAllowed, pointsAllowed) || other.pointsAllowed == pointsAllowed)&&(identical(other.eloChange, eloChange) || other.eloChange == eloChange)&&const DeepCollectionEquality().equals(other.recentGames, recentGames)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TeammateStats&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.teammateName, teammateName) || other.teammateName == teammateName)&&(identical(other.gamesPlayed, gamesPlayed) || other.gamesPlayed == gamesPlayed)&&(identical(other.gamesWon, gamesWon) || other.gamesWon == gamesWon)&&(identical(other.gamesLost, gamesLost) || other.gamesLost == gamesLost)&&(identical(other.pointsScored, pointsScored) || other.pointsScored == pointsScored)&&(identical(other.pointsAllowed, pointsAllowed) || other.pointsAllowed == pointsAllowed)&&(identical(other.eloChange, eloChange) || other.eloChange == eloChange)&&const DeepCollectionEquality().equals(other.recentGames, recentGames)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,userId,gamesPlayed,gamesWon,gamesLost,pointsScored,pointsAllowed,eloChange,const DeepCollectionEquality().hash(recentGames),lastUpdated);
+int get hashCode => Object.hash(runtimeType,userId,teammateName,gamesPlayed,gamesWon,gamesLost,pointsScored,pointsAllowed,eloChange,const DeepCollectionEquality().hash(recentGames),lastUpdated);
 
 @override
 String toString() {
-  return 'TeammateStats(userId: $userId, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, pointsScored: $pointsScored, pointsAllowed: $pointsAllowed, eloChange: $eloChange, recentGames: $recentGames, lastUpdated: $lastUpdated)';
+  return 'TeammateStats(userId: $userId, teammateName: $teammateName, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, pointsScored: $pointsScored, pointsAllowed: $pointsAllowed, eloChange: $eloChange, recentGames: $recentGames, lastUpdated: $lastUpdated)';
 }
 
 
@@ -57,7 +58,7 @@ abstract mixin class $TeammateStatsCopyWith<$Res>  {
   factory $TeammateStatsCopyWith(TeammateStats value, $Res Function(TeammateStats) _then) = _$TeammateStatsCopyWithImpl;
 @useResult
 $Res call({
- String userId, int gamesPlayed, int gamesWon, int gamesLost, int pointsScored, int pointsAllowed, double eloChange, List<RecentGameResult> recentGames,@NullableTimestampConverter() DateTime? lastUpdated
+ String userId, String? teammateName, int gamesPlayed, int gamesWon, int gamesLost, int pointsScored, int pointsAllowed, double eloChange, List<RecentGameResult> recentGames,@NullableTimestampConverter() DateTime? lastUpdated
 });
 
 
@@ -74,10 +75,11 @@ class _$TeammateStatsCopyWithImpl<$Res>
 
 /// Create a copy of TeammateStats
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? userId = null,Object? gamesPlayed = null,Object? gamesWon = null,Object? gamesLost = null,Object? pointsScored = null,Object? pointsAllowed = null,Object? eloChange = null,Object? recentGames = null,Object? lastUpdated = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? userId = null,Object? teammateName = freezed,Object? gamesPlayed = null,Object? gamesWon = null,Object? gamesLost = null,Object? pointsScored = null,Object? pointsAllowed = null,Object? eloChange = null,Object? recentGames = null,Object? lastUpdated = freezed,}) {
   return _then(_self.copyWith(
 userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as String,gamesPlayed: null == gamesPlayed ? _self.gamesPlayed : gamesPlayed // ignore: cast_nullable_to_non_nullable
+as String,teammateName: freezed == teammateName ? _self.teammateName : teammateName // ignore: cast_nullable_to_non_nullable
+as String?,gamesPlayed: null == gamesPlayed ? _self.gamesPlayed : gamesPlayed // ignore: cast_nullable_to_non_nullable
 as int,gamesWon: null == gamesWon ? _self.gamesWon : gamesWon // ignore: cast_nullable_to_non_nullable
 as int,gamesLost: null == gamesLost ? _self.gamesLost : gamesLost // ignore: cast_nullable_to_non_nullable
 as int,pointsScored: null == pointsScored ? _self.pointsScored : pointsScored // ignore: cast_nullable_to_non_nullable
@@ -170,10 +172,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  String? teammateName,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TeammateStats() when $default != null:
-return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
+return $default(_that.userId,_that.teammateName,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
   return orElse();
 
 }
@@ -191,10 +193,10 @@ return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  String? teammateName,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)  $default,) {final _that = this;
 switch (_that) {
 case _TeammateStats():
-return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
+return $default(_that.userId,_that.teammateName,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -211,10 +213,10 @@ return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  String? teammateName,  int gamesPlayed,  int gamesWon,  int gamesLost,  int pointsScored,  int pointsAllowed,  double eloChange,  List<RecentGameResult> recentGames, @NullableTimestampConverter()  DateTime? lastUpdated)?  $default,) {final _that = this;
 switch (_that) {
 case _TeammateStats() when $default != null:
-return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
+return $default(_that.userId,_that.teammateName,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_that.pointsScored,_that.pointsAllowed,_that.eloChange,_that.recentGames,_that.lastUpdated);case _:
   return null;
 
 }
@@ -226,11 +228,13 @@ return $default(_that.userId,_that.gamesPlayed,_that.gamesWon,_that.gamesLost,_t
 @JsonSerializable()
 
 class _TeammateStats extends TeammateStats {
-  const _TeammateStats({required this.userId, required this.gamesPlayed, required this.gamesWon, required this.gamesLost, this.pointsScored = 0, this.pointsAllowed = 0, this.eloChange = 0.0, final  List<RecentGameResult> recentGames = const [], @NullableTimestampConverter() this.lastUpdated}): _recentGames = recentGames,super._();
+  const _TeammateStats({required this.userId, this.teammateName, required this.gamesPlayed, required this.gamesWon, required this.gamesLost, this.pointsScored = 0, this.pointsAllowed = 0, this.eloChange = 0.0, final  List<RecentGameResult> recentGames = const [], @NullableTimestampConverter() this.lastUpdated}): _recentGames = recentGames,super._();
   factory _TeammateStats.fromJson(Map<String, dynamic> json) => _$TeammateStatsFromJson(json);
 
 /// The teammate's user ID
 @override final  String userId;
+/// Cached display name of the teammate (written by Cloud Function)
+@override final  String? teammateName;
 /// Total games played together
 @override final  int gamesPlayed;
 /// Games won together
@@ -268,16 +272,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TeammateStats&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.gamesPlayed, gamesPlayed) || other.gamesPlayed == gamesPlayed)&&(identical(other.gamesWon, gamesWon) || other.gamesWon == gamesWon)&&(identical(other.gamesLost, gamesLost) || other.gamesLost == gamesLost)&&(identical(other.pointsScored, pointsScored) || other.pointsScored == pointsScored)&&(identical(other.pointsAllowed, pointsAllowed) || other.pointsAllowed == pointsAllowed)&&(identical(other.eloChange, eloChange) || other.eloChange == eloChange)&&const DeepCollectionEquality().equals(other._recentGames, _recentGames)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TeammateStats&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.teammateName, teammateName) || other.teammateName == teammateName)&&(identical(other.gamesPlayed, gamesPlayed) || other.gamesPlayed == gamesPlayed)&&(identical(other.gamesWon, gamesWon) || other.gamesWon == gamesWon)&&(identical(other.gamesLost, gamesLost) || other.gamesLost == gamesLost)&&(identical(other.pointsScored, pointsScored) || other.pointsScored == pointsScored)&&(identical(other.pointsAllowed, pointsAllowed) || other.pointsAllowed == pointsAllowed)&&(identical(other.eloChange, eloChange) || other.eloChange == eloChange)&&const DeepCollectionEquality().equals(other._recentGames, _recentGames)&&(identical(other.lastUpdated, lastUpdated) || other.lastUpdated == lastUpdated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,userId,gamesPlayed,gamesWon,gamesLost,pointsScored,pointsAllowed,eloChange,const DeepCollectionEquality().hash(_recentGames),lastUpdated);
+int get hashCode => Object.hash(runtimeType,userId,teammateName,gamesPlayed,gamesWon,gamesLost,pointsScored,pointsAllowed,eloChange,const DeepCollectionEquality().hash(_recentGames),lastUpdated);
 
 @override
 String toString() {
-  return 'TeammateStats(userId: $userId, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, pointsScored: $pointsScored, pointsAllowed: $pointsAllowed, eloChange: $eloChange, recentGames: $recentGames, lastUpdated: $lastUpdated)';
+  return 'TeammateStats(userId: $userId, teammateName: $teammateName, gamesPlayed: $gamesPlayed, gamesWon: $gamesWon, gamesLost: $gamesLost, pointsScored: $pointsScored, pointsAllowed: $pointsAllowed, eloChange: $eloChange, recentGames: $recentGames, lastUpdated: $lastUpdated)';
 }
 
 
@@ -288,7 +292,7 @@ abstract mixin class _$TeammateStatsCopyWith<$Res> implements $TeammateStatsCopy
   factory _$TeammateStatsCopyWith(_TeammateStats value, $Res Function(_TeammateStats) _then) = __$TeammateStatsCopyWithImpl;
 @override @useResult
 $Res call({
- String userId, int gamesPlayed, int gamesWon, int gamesLost, int pointsScored, int pointsAllowed, double eloChange, List<RecentGameResult> recentGames,@NullableTimestampConverter() DateTime? lastUpdated
+ String userId, String? teammateName, int gamesPlayed, int gamesWon, int gamesLost, int pointsScored, int pointsAllowed, double eloChange, List<RecentGameResult> recentGames,@NullableTimestampConverter() DateTime? lastUpdated
 });
 
 
@@ -305,10 +309,11 @@ class __$TeammateStatsCopyWithImpl<$Res>
 
 /// Create a copy of TeammateStats
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? userId = null,Object? gamesPlayed = null,Object? gamesWon = null,Object? gamesLost = null,Object? pointsScored = null,Object? pointsAllowed = null,Object? eloChange = null,Object? recentGames = null,Object? lastUpdated = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? userId = null,Object? teammateName = freezed,Object? gamesPlayed = null,Object? gamesWon = null,Object? gamesLost = null,Object? pointsScored = null,Object? pointsAllowed = null,Object? eloChange = null,Object? recentGames = null,Object? lastUpdated = freezed,}) {
   return _then(_TeammateStats(
 userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as String,gamesPlayed: null == gamesPlayed ? _self.gamesPlayed : gamesPlayed // ignore: cast_nullable_to_non_nullable
+as String,teammateName: freezed == teammateName ? _self.teammateName : teammateName // ignore: cast_nullable_to_non_nullable
+as String?,gamesPlayed: null == gamesPlayed ? _self.gamesPlayed : gamesPlayed // ignore: cast_nullable_to_non_nullable
 as int,gamesWon: null == gamesWon ? _self.gamesWon : gamesWon // ignore: cast_nullable_to_non_nullable
 as int,gamesLost: null == gamesLost ? _self.gamesLost : gamesLost // ignore: cast_nullable_to_non_nullable
 as int,pointsScored: null == pointsScored ? _self.pointsScored : pointsScored // ignore: cast_nullable_to_non_nullable

--- a/lib/core/data/models/teammate_stats.g.dart
+++ b/lib/core/data/models/teammate_stats.g.dart
@@ -9,6 +9,7 @@ part of 'teammate_stats.dart';
 _TeammateStats _$TeammateStatsFromJson(Map<String, dynamic> json) =>
     _TeammateStats(
       userId: json['userId'] as String,
+      teammateName: json['teammateName'] as String?,
       gamesPlayed: (json['gamesPlayed'] as num).toInt(),
       gamesWon: (json['gamesWon'] as num).toInt(),
       gamesLost: (json['gamesLost'] as num).toInt(),
@@ -28,6 +29,7 @@ _TeammateStats _$TeammateStatsFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$TeammateStatsToJson(_TeammateStats instance) =>
     <String, dynamic>{
       'userId': instance.userId,
+      'teammateName': instance.teammateName,
       'gamesPlayed': instance.gamesPlayed,
       'gamesWon': instance.gamesWon,
       'gamesLost': instance.gamesLost,

--- a/lib/core/data/repositories/firestore_user_repository.dart
+++ b/lib/core/data/repositories/firestore_user_repository.dart
@@ -498,24 +498,17 @@ class FirestoreUserRepository implements UserRepository {
     String teammateId,
   ) async {
     try {
-      final userDoc = await _firestore
+      // Story 34.3: read from users/{uid}/stats/{partnerUid} subcollection
+      final doc = await _firestore
           .collection(_collection)
           .doc(userId)
+          .collection('stats')
+          .doc(teammateId)
           .get();
-      if (!userDoc.exists) return null;
-
-      final userData = userDoc.data();
-      if (userData == null) return null;
-
-      final teammateStatsMap =
-          userData['teammateStats'] as Map<String, dynamic>?;
-      if (teammateStatsMap == null ||
-          !teammateStatsMap.containsKey(teammateId)) {
-        return null;
-      }
-
-      final statsData = teammateStatsMap[teammateId] as Map<String, dynamic>;
-      return TeammateStats.fromFirestore(teammateId, statsData);
+      if (!doc.exists) return null;
+      final data = doc.data();
+      if (data == null) return null;
+      return TeammateStats.fromFirestore(teammateId, data);
     } catch (e) {
       throw UserException('Failed to get teammate stats: $e');
     }
@@ -523,36 +516,23 @@ class FirestoreUserRepository implements UserRepository {
 
   @override
   Stream<List<TeammateStats>> getAllTeammateStats(String userId) {
-    return _firestore.collection(_collection).doc(userId).snapshots().map((
-      doc,
-    ) {
-      if (!doc.exists) return <TeammateStats>[];
-
-      final userData = doc.data();
-      if (userData == null) return <TeammateStats>[];
-
-      final teammateStatsMap =
-          userData['teammateStats'] as Map<String, dynamic>?;
-      if (teammateStatsMap == null || teammateStatsMap.isEmpty) {
-        return <TeammateStats>[];
-      }
-
-      final statsList = teammateStatsMap.entries
-          .map((entry) {
+    // Story 34.3: stream from users/{uid}/stats subcollection
+    return _firestore
+        .collection(_collection)
+        .doc(userId)
+        .collection('stats')
+        .snapshots()
+        .map((snapshot) {
+      final statsList = snapshot.docs
+          .map((doc) {
             try {
-              return TeammateStats.fromFirestore(
-                entry.key,
-                entry.value as Map<String, dynamic>,
-              );
-            } catch (e) {
-              // Skip invalid entries
+              return TeammateStats.fromFirestore(doc.id, doc.data());
+            } catch (_) {
               return null;
             }
           })
           .whereType<TeammateStats>()
           .toList();
-
-      // Sort by games played descending
       statsList.sort((a, b) => b.gamesPlayed.compareTo(a.gamesPlayed));
       return statsList;
     });

--- a/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
+++ b/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
@@ -13,6 +13,8 @@ import 'player_stats_state.dart';
 class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
   final UserRepository _userRepository;
   StreamSubscription? _userSubscription;
+  // Story 34.3: subscribe to teammate stats subcollection stream
+  StreamSubscription? _teammateStatsSubscription;
 
   PlayerStatsBloc({required UserRepository userRepository})
     : _userRepository = userRepository,
@@ -63,6 +65,21 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
                 // Log error but don't crash
                 debugPrint('PlayerStatsBloc: Error in user stream: $error');
               },
+            );
+
+        // Story 34.3: subscribe to teammate stats subcollection
+        await _teammateStatsSubscription?.cancel();
+        _teammateStatsSubscription = _userRepository
+            .getAllTeammateStats(event.userId)
+            .listen(
+              (stats) {
+                if (state is PlayerStatsLoaded) {
+                  emit((state as PlayerStatsLoaded)
+                      .copyWith(teammateStats: stats));
+                }
+              },
+              onError: (e) =>
+                  debugPrint('PlayerStatsBloc: teammate stats error: $e'),
             );
       } else {
         // Story 302.7: Handle new users gracefully - they have no stats yet
@@ -147,13 +164,12 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
         }
       }
 
-      // Story 302.5, 302.7: Preserve ranking and error state from previous state
-      final ranking = state is PlayerStatsLoaded
-          ? (state as PlayerStatsLoaded).ranking
-          : null;
-      final rankingLoadFailed = state is PlayerStatsLoaded
-          ? (state as PlayerStatsLoaded).rankingLoadFailed
-          : false;
+      // Preserve existing ranking, error flag, and teammate stats from previous state
+      final prevLoaded =
+          state is PlayerStatsLoaded ? state as PlayerStatsLoaded : null;
+      final ranking = prevLoaded?.ranking;
+      final rankingLoadFailed = prevLoaded?.rankingLoadFailed ?? false;
+      final teammateStats = prevLoaded?.teammateStats ?? const [];
 
       emit(
         PlayerStatsLoaded(
@@ -161,6 +177,7 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
           history: history,
           ranking: ranking,
           rankingLoadFailed: rankingLoadFailed,
+          teammateStats: teammateStats,
         ),
       );
     } catch (e) {
@@ -195,6 +212,7 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
   @override
   Future<void> close() {
     _userSubscription?.cancel();
+    _teammateStatsSubscription?.cancel();
     return super.close();
   }
 }

--- a/lib/features/profile/presentation/bloc/player_stats/player_stats_state.dart
+++ b/lib/features/profile/presentation/bloc/player_stats/player_stats_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:play_with_me/core/data/models/rating_history_entry.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
 import 'package:play_with_me/core/data/models/user_ranking.dart';
 
@@ -17,31 +18,37 @@ class PlayerStatsLoading extends PlayerStatsState {}
 class PlayerStatsLoaded extends PlayerStatsState {
   final UserModel user;
   final List<RatingHistoryEntry> history;
-  final UserRanking? ranking; // Story 302.5: Add ranking to state
-  final bool rankingLoadFailed; // Story 302.7: Track ranking load failures
+  final UserRanking? ranking;
+  final bool rankingLoadFailed;
+  // Story 34.3: teammate stats loaded from users/{uid}/stats subcollection,
+  // not from user.teammateStats on the root document.
+  final List<TeammateStats> teammateStats;
 
   const PlayerStatsLoaded({
     required this.user,
     required this.history,
     this.ranking,
     this.rankingLoadFailed = false,
+    this.teammateStats = const [],
   });
 
   @override
-  List<Object?> get props => [user, history, ranking, rankingLoadFailed];
+  List<Object?> get props =>
+      [user, history, ranking, rankingLoadFailed, teammateStats];
 
-  /// Create a copy of this state with updated fields (Story 302.5, 302.7)
   PlayerStatsLoaded copyWith({
     UserModel? user,
     List<RatingHistoryEntry>? history,
     UserRanking? ranking,
     bool? rankingLoadFailed,
+    List<TeammateStats>? teammateStats,
   }) {
     return PlayerStatsLoaded(
       user: user ?? this.user,
       history: history ?? this.history,
       ranking: ranking ?? this.ranking,
       rankingLoadFailed: rankingLoadFailed ?? this.rankingLoadFailed,
+      teammateStats: teammateStats ?? this.teammateStats,
     );
   }
 }

--- a/lib/features/profile/presentation/pages/stats_page.dart
+++ b/lib/features/profile/presentation/pages/stats_page.dart
@@ -55,6 +55,7 @@ class StatsPage extends StatelessWidget {
             child: ExpandedStatsSection(
               user: statsState.user,
               ratingHistory: statsState.history,
+              teammateStats: statsState.teammateStats,
             ),
           );
         }

--- a/lib/features/profile/presentation/widgets/expanded_stats_section.dart
+++ b/lib/features/profile/presentation/widgets/expanded_stats_section.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/data/models/rating_history_entry.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
 import 'package:play_with_me/core/data/models/user_model.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/momentum_consistency_card.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/performance_overview_card.dart';
@@ -20,11 +21,13 @@ import 'package:play_with_me/features/profile/presentation/widgets/role_based_pe
 /// Stats are grouped into themed cards for easy understanding.
 class ExpandedStatsSection extends StatelessWidget {
   final UserModel user;
+  final List<TeammateStats> teammateStats;
   final List<RatingHistoryEntry> ratingHistory;
 
   const ExpandedStatsSection({
     super.key,
     required this.user,
+    this.teammateStats = const [],
     required this.ratingHistory,
   });
 
@@ -40,7 +43,7 @@ class ExpandedStatsSection extends StatelessWidget {
         MomentumConsistencyCard(user: user, ratingHistory: ratingHistory),
 
         // Partners Card
-        PartnersCard(user: user),
+        PartnersCard(teammateStats: teammateStats),
 
         // Rivals Card
         RivalsCard(user: user),

--- a/lib/features/profile/presentation/widgets/partners_card.dart
+++ b/lib/features/profile/presentation/widgets/partners_card.dart
@@ -1,8 +1,9 @@
 // Partners card showing best partner statistics.
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/theme/app_text_styles.dart';
-import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/features/profile/presentation/pages/partner_detail_page.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -12,9 +13,9 @@ import 'package:play_with_me/l10n/app_localizations.dart';
 /// Shows the partner with the highest win rate (minimum 5 games threshold).
 /// Tap opens PartnerDetailPage for full breakdown.
 class PartnersCard extends StatelessWidget {
-  final UserModel user;
+  final List<TeammateStats> teammateStats;
 
-  const PartnersCard({super.key, required this.user});
+  const PartnersCard({super.key, required this.teammateStats});
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +41,7 @@ class PartnersCard extends StatelessWidget {
                   ? () => Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (context) => PartnerDetailPage(
-                          userId: user.uid,
+                          userId: FirebaseAuth.instance.currentUser?.uid ?? '',
                           partnerId: bestPartner.userId,
                         ),
                       ),
@@ -187,37 +188,24 @@ class PartnersCard extends StatelessWidget {
   }
 
   _PartnerData? _findBestPartner() {
-    if (user.teammateStats.isEmpty) return null;
-
+    if (teammateStats.isEmpty) return null;
     const minGames = 5;
     _PartnerData? best;
     double bestWinRate = -1;
-
-    for (final entry in user.teammateStats.entries) {
-      final userId = entry.key;
-      final stats = entry.value as Map<String, dynamic>;
-      final gamesWon = stats['gamesWon'] as int? ?? 0;
-      final gamesPlayed = stats['gamesPlayed'] as int? ?? 0;
-      final displayName = stats['teammateName'] as String? ?? 'Unknown Player';
-
-      if (gamesPlayed < minGames) continue;
-
-      final winRate = gamesWon / gamesPlayed;
-
+    for (final ts in teammateStats) {
+      if (ts.gamesPlayed < minGames) continue;
+      final winRate = ts.gamesWon / ts.gamesPlayed;
       if (winRate > bestWinRate ||
-          (winRate == bestWinRate &&
-              best != null &&
-              gamesPlayed > best.gamesPlayed)) {
+          (winRate == bestWinRate && best != null && ts.gamesPlayed > best.gamesPlayed)) {
         bestWinRate = winRate;
         best = _PartnerData(
-          userId: userId,
-          displayName: displayName,
-          gamesWon: gamesWon,
-          gamesPlayed: gamesPlayed,
+          userId: ts.userId,
+          displayName: ts.teammateName ?? ts.userId.substring(0, 5),
+          gamesWon: ts.gamesWon,
+          gamesPlayed: ts.gamesPlayed,
         );
       }
     }
-
     return best;
   }
 }

--- a/lib/features/profile/presentation/widgets/player_stats_section.dart
+++ b/lib/features/profile/presentation/widgets/player_stats_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
@@ -27,6 +28,7 @@ class PlayerStatsSection extends StatelessWidget {
         if (state is PlayerStatsLoaded) {
           final user = state.user;
           final history = state.history;
+          final teammateStats = state.teammateStats;
 
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -101,8 +103,8 @@ class PlayerStatsSection extends StatelessWidget {
               ),
 
               // Best Teammate (Optional, if data exists)
-              if (user.teammateStats.isNotEmpty)
-                _BestTeammateCard(teammateStats: user.teammateStats),
+              if (teammateStats.isNotEmpty)
+                _BestTeammateCard(teammateStats: teammateStats),
             ],
           );
         }
@@ -114,54 +116,30 @@ class PlayerStatsSection extends StatelessWidget {
 }
 
 class _BestTeammateCard extends StatelessWidget {
-  final Map<String, dynamic> teammateStats;
+  final List<TeammateStats> teammateStats;
 
   const _BestTeammateCard({required this.teammateStats});
 
-  String? _getBestTeammateId() {
-    if (teammateStats.isEmpty) return null;
-
-    String? bestId;
-    int maxWins = -1;
-
-    teammateStats.forEach((key, value) {
-      final wins = value['gamesWon'] as int? ?? 0;
-      if (wins > maxWins) {
-        maxWins = wins;
-        bestId = key;
-      }
-    });
-
-    return bestId;
-  }
-
-  Map<String, dynamic>? _getStatsForId(String id) {
-    return teammateStats[id] as Map<String, dynamic>?;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final bestId = _getBestTeammateId();
-    if (bestId == null) return const SizedBox.shrink();
-
-    final stats = _getStatsForId(bestId);
-    final wins = stats?['gamesWon'] ?? 0;
-    final played = stats?['gamesPlayed'] ?? 0;
-    final winRate = played > 0
-        ? (wins / played * 100).toStringAsFixed(1)
+    if (teammateStats.isEmpty) return const SizedBox.shrink();
+    final best = teammateStats.reduce(
+      (a, b) => a.gamesWon >= b.gamesWon ? a : b,
+    );
+    final winRate = best.gamesPlayed > 0
+        ? (best.gamesWon / best.gamesPlayed * 100).toStringAsFixed(1)
         : '0.0';
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
       child: Card(
         child: ListTile(
-          leading: const CircleAvatar(
-            child: Icon(Icons.person),
-          ), // Placeholder for avatar
+          leading: const CircleAvatar(child: Icon(Icons.person)),
           title: Text(AppLocalizations.of(context)!.bestTeammate),
           subtitle: Text(
-            'ID: ${bestId.substring(0, 5)}... • $wins wins ($winRate%)',
-          ), // ID is temporary until we resolve name
+            '${best.teammateName ?? best.userId.substring(0, 5)} • '
+            '${best.gamesWon} wins ($winRate%)',
+          ),
           trailing: const Icon(Icons.star, color: AppColors.warning),
         ),
       ),

--- a/test/unit/core/data/repositories/firestore_user_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_user_repository_test.dart
@@ -1205,60 +1205,44 @@ void main() {
     });
 
     group('getTeammateStats', () {
-      test('returns null when user does not exist', () async {
+      // Story 34.3: reads from users/{uid}/stats/{partnerUid} subcollection
+      test('returns null when subcollection doc does not exist', () async {
         final result = await repository.getTeammateStats(
           'non-existent-user',
           'teammate-123',
         );
-
         expect(result, isNull);
       });
 
-      test('returns null when no teammate stats exist', () async {
-        await fakeFirestore.collection('users').doc(testUserId).set({
-          'email': testEmail,
-          'isEmailVerified': true,
-        });
+      test('returns null when specific teammate not in subcollection', () async {
+        // Set up a different partner in the subcollection
+        await fakeFirestore
+            .collection('users')
+            .doc(testUserId)
+            .collection('stats')
+            .doc('other-teammate')
+            .set({'gamesPlayed': 5, 'gamesWon': 3, 'userId': 'other-teammate'});
 
         final result = await repository.getTeammateStats(
           testUserId,
           'teammate-123',
         );
-
         expect(result, isNull);
       });
 
-      test('returns null when specific teammate not found in stats', () async {
-        await fakeFirestore.collection('users').doc(testUserId).set({
-          'email': testEmail,
-          'isEmailVerified': true,
-          'teammateStats': {
-            'other-teammate': {'gamesPlayed': 5, 'gamesWon': 3},
-          },
-        });
-
-        final result = await repository.getTeammateStats(
-          testUserId,
-          'teammate-123',
-        );
-
-        expect(result, isNull);
-      });
-
-      test('returns TeammateStats when found', () async {
-        await fakeFirestore.collection('users').doc(testUserId).set({
-          'email': testEmail,
-          'isEmailVerified': true,
-          'teammateStats': {
-            'teammate-123': {
-              'gamesPlayed': 10,
-              'gamesWon': 7,
-              'gamesLost': 3,
-              'pointsScored': 210,
-              'pointsAllowed': 180,
-              'eloChange': 25.5,
-            },
-          },
+      test('returns TeammateStats when found in subcollection', () async {
+        await fakeFirestore
+            .collection('users')
+            .doc(testUserId)
+            .collection('stats')
+            .doc('teammate-123')
+            .set({
+          'gamesPlayed': 10,
+          'gamesWon': 7,
+          'gamesLost': 3,
+          'pointsScored': 210,
+          'pointsAllowed': 180,
+          'eloChange': 25.5,
         });
 
         final result = await repository.getTeammateStats(

--- a/test/unit/features/profile/presentation/bloc/player_stats/player_stats_bloc_test.dart
+++ b/test/unit/features/profile/presentation/bloc/player_stats/player_stats_bloc_test.dart
@@ -61,6 +61,9 @@ void main() {
         when(
           () => mockUserRepository.getRatingHistory(userId),
         ).thenAnswer((_) => Stream.value(testHistory));
+        when(
+          () => mockUserRepository.getAllTeammateStats(userId),
+        ).thenAnswer((_) => const Stream.empty());
       },
       build: () => playerStatsBloc,
       act: (bloc) => bloc.add(const LoadPlayerStats(userId)),
@@ -82,6 +85,9 @@ void main() {
         when(
           () => mockUserRepository.getRatingHistory(userId),
         ).thenAnswer((_) => Stream.value(testHistory));
+        when(
+          () => mockUserRepository.getAllTeammateStats(userId),
+        ).thenAnswer((_) => const Stream.empty());
       },
       build: () => playerStatsBloc,
       act: (bloc) => bloc.add(const LoadPlayerStats(userId)),

--- a/test/widget/features/profile/presentation/widgets/partners_card_test.dart
+++ b/test/widget/features/profile/presentation/widgets/partners_card_test.dart
@@ -1,190 +1,145 @@
 // Widget tests for PartnersCard displaying teammate display names.
+// Story 34.3: PartnersCard now takes List<TeammateStats> instead of UserModel.
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:play_with_me/core/data/models/user_model.dart';
+import 'package:play_with_me/core/data/models/teammate_stats.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/partners_card.dart';
 import '../../../../../helpers/test_app.dart';
+
+TeammateStats makeStats({
+  required String userId,
+  required String teammateName,
+  required int gamesPlayed,
+  required int gamesWon,
+  required int gamesLost,
+}) =>
+    TeammateStats(
+      userId: userId,
+      teammateName: teammateName,
+      gamesPlayed: gamesPlayed,
+      gamesWon: gamesWon,
+      gamesLost: gamesLost,
+    );
 
 void main() {
   group('PartnersCard Widget Tests', () {
     testWidgets('displays teammate display name instead of user ID', (
       tester,
     ) async {
-      // Create a user with teammate stats including display name
-      const user = UserModel(
-        uid: 'user-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        isEmailVerified: true,
-        teammateStats: {
-          'teammate-456': {
-            'teammateName': 'John Doe',
-            'gamesPlayed': 10,
-            'gamesWon': 8,
-            'gamesLost': 2,
-            'pointsScored': 100,
-            'pointsAllowed': 50,
-            'eloChange': 25.0,
-          },
-        },
-      );
+      final stats = [
+        makeStats(
+          userId: 'teammate-456',
+          teammateName: 'John Doe',
+          gamesPlayed: 10,
+          gamesWon: 8,
+          gamesLost: 2,
+        ),
+      ];
 
       await tester.pumpWidget(
-        testApp(child: const Scaffold(body: PartnersCard(user: user))),
+        testApp(child: Scaffold(body: PartnersCard(teammateStats: stats))),
       );
 
-      // Verify display name is shown
       expect(find.text('John Doe'), findsOneWidget);
-
-      // Verify user ID is NOT shown
-      expect(find.textContaining('User ID:'), findsNothing);
       expect(find.textContaining('teammate-456'), findsNothing);
-
-      // Verify other stats are still displayed
       expect(find.text('80.0% Win Rate'), findsOneWidget);
-      expect(find.text('8W - 2L • 10 games'), findsOneWidget);
+      expect(find.text('8W - 2L \u2022 10 games'), findsOneWidget);
     });
 
-    testWidgets('displays "Unknown Player" when teammateName is missing', (
+    testWidgets('shows user ID prefix when teammateName is missing', (
       tester,
     ) async {
-      // Create a user with teammate stats WITHOUT display name (legacy data)
-      const user = UserModel(
-        uid: 'user-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        isEmailVerified: true,
-        teammateStats: {
-          'teammate-789': {
-            // Missing 'teammateName' field (legacy data)
-            'gamesPlayed': 7,
-            'gamesWon': 5,
-            'gamesLost': 2,
-            'pointsScored': 70,
-            'pointsAllowed': 40,
-            'eloChange': 15.0,
-          },
-        },
-      );
+      final stats = [
+        const TeammateStats(
+          userId: 'teammate-789',
+          gamesPlayed: 7,
+          gamesWon: 5,
+          gamesLost: 2,
+        ),
+      ];
 
       await tester.pumpWidget(
-        testApp(child: const Scaffold(body: PartnersCard(user: user))),
+        testApp(child: Scaffold(body: PartnersCard(teammateStats: stats))),
       );
 
-      // Verify fallback to "Unknown Player"
-      expect(find.text('Unknown Player'), findsOneWidget);
-
-      // Verify stats are still displayed
+      // Without teammateName, falls back to userId prefix
+      expect(find.textContaining('teamm'), findsOneWidget);
       expect(find.text('71.4% Win Rate'), findsOneWidget);
     });
 
     testWidgets('shows empty state when no teammates have 5+ games', (
       tester,
     ) async {
-      const user = UserModel(
-        uid: 'user-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        isEmailVerified: true,
-        teammateStats: {
-          'teammate-111': {
-            'teammateName': 'Alice Smith',
-            'gamesPlayed': 3, // Below 5 game threshold
-            'gamesWon': 2,
-            'gamesLost': 1,
-            'pointsScored': 30,
-            'pointsAllowed': 20,
-            'eloChange': 10.0,
-          },
-        },
-      );
+      final stats = [
+        makeStats(
+          userId: 'teammate-111',
+          teammateName: 'Alice Smith',
+          gamesPlayed: 3,
+          gamesWon: 2,
+          gamesLost: 1,
+        ),
+      ];
 
       await tester.pumpWidget(
-        testApp(child: const Scaffold(body: PartnersCard(user: user))),
+        testApp(child: Scaffold(body: PartnersCard(teammateStats: stats))),
       );
 
-      // Verify empty state is shown
       expect(find.text('No partner data yet'), findsOneWidget);
-      expect(find.text('Play 5+ games with a teammate'), findsOneWidget);
-
-      // Verify teammate name is NOT shown (below threshold)
       expect(find.text('Alice Smith'), findsNothing);
     });
 
     testWidgets('selects teammate with highest win rate', (tester) async {
-      const user = UserModel(
-        uid: 'user-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        isEmailVerified: true,
-        teammateStats: {
-          'teammate-low': {
-            'teammateName': 'Bob Jones',
-            'gamesPlayed': 10,
-            'gamesWon': 6, // 60% win rate
-            'gamesLost': 4,
-            'pointsScored': 80,
-            'pointsAllowed': 60,
-            'eloChange': 10.0,
-          },
-          'teammate-high': {
-            'teammateName': 'Sarah Lee',
-            'gamesPlayed': 8,
-            'gamesWon': 7, // 87.5% win rate (higher)
-            'gamesLost': 1,
-            'pointsScored': 90,
-            'pointsAllowed': 30,
-            'eloChange': 20.0,
-          },
-        },
-      );
+      final stats = [
+        makeStats(
+          userId: 'teammate-low',
+          teammateName: 'Bob Jones',
+          gamesPlayed: 10,
+          gamesWon: 6,
+          gamesLost: 4,
+        ),
+        makeStats(
+          userId: 'teammate-high',
+          teammateName: 'Sarah Lee',
+          gamesPlayed: 8,
+          gamesWon: 7,
+          gamesLost: 1,
+        ),
+      ];
 
       await tester.pumpWidget(
-        testApp(child: const Scaffold(body: PartnersCard(user: user))),
+        testApp(child: Scaffold(body: PartnersCard(teammateStats: stats))),
       );
 
-      // Verify the teammate with highest win rate is shown
       expect(find.text('Sarah Lee'), findsOneWidget);
       expect(find.text('87.5% Win Rate'), findsOneWidget);
-
-      // Verify lower win rate teammate is NOT shown
       expect(find.text('Bob Jones'), findsNothing);
-      expect(find.text('60.0% Win Rate'), findsNothing);
     });
 
     testWidgets('handles long teammate names with ellipsis', (tester) async {
-      const user = UserModel(
-        uid: 'user-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        isEmailVerified: true,
-        teammateStats: {
-          'teammate-long': {
-            'teammateName': 'Alexander Maximilian Constantine Rodriguez',
-            'gamesPlayed': 10,
-            'gamesWon': 7,
-            'gamesLost': 3,
-            'pointsScored': 90,
-            'pointsAllowed': 60,
-            'eloChange': 15.0,
-          },
-        },
-      );
+      final stats = [
+        makeStats(
+          userId: 'teammate-long',
+          teammateName: 'Alexander Maximilian Constantine Rodriguez',
+          gamesPlayed: 10,
+          gamesWon: 7,
+          gamesLost: 3,
+        ),
+      ];
 
       await tester.pumpWidget(
-        testApp(child: const Scaffold(
+        testApp(
+          child: Scaffold(
             body: SizedBox(
-              width: 400, // Constrained width to test ellipsis
-              child: PartnersCard(user: user),
+              width: 400,
+              child: PartnersCard(teammateStats: stats),
             ),
-          )),
+          ),
+        ),
       );
 
-      // Verify text widget exists (may be truncated with ellipsis)
       expect(find.textContaining('Alexander'), findsOneWidget);
-
-      // Verify the Text widget has overflow: TextOverflow.ellipsis
-      final textWidget = tester.widget<Text>(find.textContaining('Alexander'));
+      final textWidget =
+          tester.widget<Text>(find.textContaining('Alexander'));
       expect(textWidget.overflow, TextOverflow.ellipsis);
     });
   });


### PR DESCRIPTION
Closes #866 | Epic #863

## A. teammateStats → subcollection (main change)

**Root cause of the original issue:** `users/{uid}.teammateStats` was an unbounded map that grew with every new partner. After 100+ games with 10+ partners, this could hit Firestore's 1 MB document limit.

**Code changes:**
| Layer | Before | After |
|---|---|---|
| `statsTracking.ts` | `transaction.update(userRef, {'teammateStats.{id}': stats})` | `transaction.set(statsRef, {increment fields...}, merge:true)` |
| `getAllTeammateStats()` | Streams root doc's `teammateStats` map | Streams `users/{uid}/stats` subcollection |
| `getTeammateStats()` | Reads root doc map | Reads subcollection doc |
| `PlayerStatsBloc` | Reads from `user.teammateStats` | Subscribes to `getAllTeammateStats` stream |
| `PlayerStatsLoaded` | No teammate stats field | `teammateStats: List<TeammateStats>` |
| `PartnersCard` / widgets | `user.teammateStats` (Map) | `state.teammateStats` (List) |
| `TeammateStats` model | No `teammateName` | Added `teammateName?` field |

**Migration executed 2026-08-23 on prod:**
- 15 users had data → 42 partner subcollection docs created
- `teammateStats` root field deleted from all user documents ✅

## B. Notification prefs — Deferred
3 separate boolean fields work correctly. 9/43 users have customized them. No CF reads them. Code churn exceeds benefit.

## C. createUserDocument — Already complete
Idempotent, backfill-capable, structured error logging. 0 hollow docs in prod.