### PR TITLE
fix(leagues): disable gender check for registration

### DIFF
--- a/lib/features/championships/domain/use_cases/check_championship_eligibility_use_case.dart
+++ b/lib/features/championships/domain/use_cases/check_championship_eligibility_use_case.dart
@@ -107,9 +107,9 @@ class CheckChampionshipEligibilityUseCase
     ChampionshipGenderCategory? category,
     String? userGender,
   ) {
-    if (category == null) return true;
-    if (userGender == null || userGender == 'none') return false;
-    return userGender == category.name;
+    // Gender check temporarily disabled — admins manually remove
+    // teams that don't match the league's gender category.
+    return true;
   }
 
   String? _genderBlockReasonText(
@@ -117,15 +117,7 @@ class CheckChampionshipEligibilityUseCase
     String? userGender,
     bool alreadyRegistered,
   ) {
-    if (category == null || alreadyRegistered) return null;
-    if (userGender == null || userGender == 'none') {
-      return 'Set your gender in profile settings to register for gendered championships.';
-    }
-    if (userGender != category.name) {
-      return category == ChampionshipGenderCategory.male
-          ? 'This is a men\'s championship.'
-          : 'This is a women\'s championship.';
-    }
+    // Gender block disabled — see _isGenderAllowed.
     return null;
   }
 }

--- a/lib/features/championships/domain/use_cases/check_championship_eligibility_use_case.dart
+++ b/lib/features/championships/domain/use_cases/check_championship_eligibility_use_case.dart
@@ -35,8 +35,8 @@ class ChampionshipEligibilityResult {
 }
 
 class CheckChampionshipEligibilityUseCase
-    extends UseCase<ChampionshipEligibilityInput, ChampionshipEligibilityResult> {
-
+    extends
+        UseCase<ChampionshipEligibilityInput, ChampionshipEligibilityResult> {
   const CheckChampionshipEligibilityUseCase();
 
   @override
@@ -47,15 +47,16 @@ class CheckChampionshipEligibilityUseCase
     final championship = input.championship;
     final teams = input.teams;
 
-    final isAlreadyRegistered = userId != null &&
-        teams.any((t) => t.memberIds.contains(userId));
+    final isAlreadyRegistered =
+        userId != null && teams.any((t) => t.memberIds.contains(userId));
 
     final isGenderAllowed = _isGenderAllowed(
       championship.genderCategory,
       input.userGender,
     );
 
-    final canRegister = userId != null &&
+    final canRegister =
+        userId != null &&
         !isAlreadyRegistered &&
         isGenderAllowed &&
         championship.status == ChampionshipStatus.registration &&
@@ -63,9 +64,9 @@ class CheckChampionshipEligibilityUseCase
 
     final myTeamId = userId != null
         ? teams
-            .where((t) => t.memberIds.contains(userId))
-            .map((t) => t.id)
-            .firstOrNull
+              .where((t) => t.memberIds.contains(userId))
+              .map((t) => t.id)
+              .firstOrNull
         : null;
 
     return ChampionshipEligibilityResult(
@@ -83,22 +84,39 @@ class CheckChampionshipEligibilityUseCase
 
   /// Synchronous version — safe because this use case has no I/O.
   /// Use from widget build() methods instead of execute().
-  ChampionshipEligibilityResult executeSync(ChampionshipEligibilityInput input) {
+  ChampionshipEligibilityResult executeSync(
+    ChampionshipEligibilityInput input,
+  ) {
     final userId = input.userId;
     final championship = input.championship;
     final teams = input.teams;
-    final isAlreadyRegistered = userId != null && teams.any((t) => t.memberIds.contains(userId));
-    final isGenderAllowed = _isGenderAllowed(championship.genderCategory, input.userGender);
-    final canRegister = userId != null && !isAlreadyRegistered && isGenderAllowed &&
-        championship.status == ChampionshipStatus.registration && championship.isOpen;
+    final isAlreadyRegistered =
+        userId != null && teams.any((t) => t.memberIds.contains(userId));
+    final isGenderAllowed = _isGenderAllowed(
+      championship.genderCategory,
+      input.userGender,
+    );
+    final canRegister =
+        userId != null &&
+        !isAlreadyRegistered &&
+        isGenderAllowed &&
+        championship.status == ChampionshipStatus.registration &&
+        championship.isOpen;
     final myTeamId = userId != null
-        ? teams.where((t) => t.memberIds.contains(userId)).map((t) => t.id).firstOrNull
+        ? teams
+              .where((t) => t.memberIds.contains(userId))
+              .map((t) => t.id)
+              .firstOrNull
         : null;
     return ChampionshipEligibilityResult(
       isAlreadyRegistered: isAlreadyRegistered,
       isGenderAllowed: isGenderAllowed,
       canRegister: canRegister,
-      genderBlockReason: _genderBlockReasonText(championship.genderCategory, input.userGender, isAlreadyRegistered),
+      genderBlockReason: _genderBlockReasonText(
+        championship.genderCategory,
+        input.userGender,
+        isAlreadyRegistered,
+      ),
       myTeamId: myTeamId,
     );
   }

--- a/test/unit/property_based/championship_model_property_test.dart
+++ b/test/unit/property_based/championship_model_property_test.dart
@@ -124,16 +124,17 @@ void main() {
       }
     });
 
-    test('correct gender always allowed, wrong gender always blocked', () async {
+    test('gender check disabled — all users allowed regardless of category', () async {
+      // Gender check temporarily disabled — admin manages team eligibility.
       final testCases = [
-        (ChampionshipGenderCategory.male, 'male', true),
-        (ChampionshipGenderCategory.male, 'female', false),
-        (ChampionshipGenderCategory.female, 'female', true),
-        (ChampionshipGenderCategory.female, 'male', false),
-        (ChampionshipGenderCategory.male, 'none', false),
-        (ChampionshipGenderCategory.female, 'none', false),
+        (ChampionshipGenderCategory.male, 'male'),
+        (ChampionshipGenderCategory.male, 'female'),
+        (ChampionshipGenderCategory.female, 'female'),
+        (ChampionshipGenderCategory.female, 'male'),
+        (ChampionshipGenderCategory.male, 'none'),
+        (ChampionshipGenderCategory.female, 'none'),
       ];
-      for (final (cat, gender, expected) in testCases) {
+      for (final (cat, gender) in testCases) {
         final result = await useCase(ChampionshipEligibilityInput(
           championship: generateChampionship(gender: cat),
           teams: [],
@@ -142,8 +143,8 @@ void main() {
         ));
         expect(
           result.isGenderAllowed,
-          equals(expected),
-          reason: 'category=$cat userGender=$gender expected=$expected',
+          isTrue,
+          reason: 'category=$cat userGender=$gender should be allowed (gender check disabled)',
         );
       }
     });

--- a/test/unit/use_cases/check_championship_eligibility_use_case_test.dart
+++ b/test/unit/use_cases/check_championship_eligibility_use_case_test.dart
@@ -84,25 +84,27 @@ void main() {
       expect(result.isGenderAllowed, isTrue);
     });
 
-    test('blocks male user from female championship', () async {
+    test('gender check disabled — male user allowed into female league', () async {
       final result = await useCase(ChampionshipEligibilityInput(
         championship: makeChampionship(gender: ChampionshipGenderCategory.female),
         teams: [],
         userId: 'user1',
         userGender: 'male',
       ));
-      expect(result.isGenderAllowed, isFalse);
-      expect(result.genderBlockReason, isNotNull);
+      // Gender check temporarily disabled — admin manages team eligibility
+      expect(result.isGenderAllowed, isTrue);
+      expect(result.genderBlockReason, isNull);
     });
 
-    test('blocks user with no gender set', () async {
+    test('gender check disabled — user with no gender allowed', () async {
       final result = await useCase(ChampionshipEligibilityInput(
         championship: makeChampionship(gender: ChampionshipGenderCategory.male),
         teams: [],
         userId: 'user1',
         userGender: 'none',
       ));
-      expect(result.isGenderAllowed, isFalse);
+      // Gender check temporarily disabled — admin manages team eligibility
+      expect(result.isGenderAllowed, isTrue);
     });
 
     test('allows female user into female championship', () async {


### PR DESCRIPTION
## Problem
The gender race condition in `ChampionshipDetailBloc` causes `userGender` to be null when the page first opens, blocking registration even when the user has a gender set in Firestore.

## Fix
Temporarily disable the gender gate client-side:
- `_isGenderAllowed` always returns `true`
- `_genderBlockReason` always returns `null`

Admins manually remove teams that don't match the league's gender category.

## Follow-up
The root race condition fix is in PR #869. Once that is validated and the admin tooling for manual team removal is confirmed, the gender check can be re-enabled.