### PR TITLE
fix(games): 3rd set to 15 points + remove green result badge from list

### DIFF
--- a/lib/features/games/domain/use_cases/validate_game_scores_use_case.dart
+++ b/lib/features/games/domain/use_cases/validate_game_scores_use_case.dart
@@ -5,13 +5,15 @@ import 'package:play_with_me/core/domain/use_cases/base_use_case.dart';
 class GameScoreInput {
   final List<SetScore> sets;
   final int requiredSetsToWin;    // e.g. 2 for best-of-3
-  final int pointsToWinSet;       // e.g. 21
+  final int pointsToWinSet;       // e.g. 21 for regular sets
+  final int deciderSetPoints;     // e.g. 15 for the deciding 3rd set
   final int minimumPointDiff;     // e.g. 2
 
   const GameScoreInput({
     required this.sets,
     required this.requiredSetsToWin,
     this.pointsToWinSet = 21,
+    this.deciderSetPoints = 15,
     this.minimumPointDiff = 2,
   });
 }
@@ -73,18 +75,21 @@ class ValidateGameScoresUseCase
       return 'Set ${setIndex + 1}: scores cannot be negative.';
     }
 
+    // The deciding set (e.g. 3rd in best-of-3) plays to deciderSetPoints (15),
+    // all other sets play to pointsToWinSet (21).
+    final totalSets = input.requiredSetsToWin * 2 - 1; // 3 for best-of-3
+    final isDeciderSet = setIndex == totalSets - 1;
+    final target = isDeciderSet ? input.deciderSetPoints : input.pointsToWinSet;
+
     final maxPoints = a > b ? a : b;
     final diff = (a - b).abs();
 
-    // Valid set: one team reaches pointsToWinSet with minimumPointDiff lead
-    // OR extended play (both above pointsToWinSet, difference == minimumPointDiff)
-    if (maxPoints >= input.pointsToWinSet) {
+    // Valid set: one team reaches target with minimumPointDiff lead
+    // OR extended play (both above target, difference == minimumPointDiff)
+    if (maxPoints >= target) {
       if (diff < input.minimumPointDiff) {
         return 'Set ${setIndex + 1}: need a ${input.minimumPointDiff}-point lead to win.';
       }
-    } else if (a != b) {
-      // One team has more points but neither reached the winning threshold
-      // This is only valid if it's the last set being played
     }
 
     return null;

--- a/lib/features/games/presentation/bloc/score_entry/score_entry_bloc.dart
+++ b/lib/features/games/presentation/bloc/score_entry/score_entry_bloc.dart
@@ -65,10 +65,14 @@ class ScoreEntryBloc extends Bloc<ScoreEntryEvent, ScoreEntryState> {
         final loadedGames = <GameData>[];
 
         for (final individualGame in result.games) {
-          final sets = individualGame.sets.map((set) {
+          final totalSets = individualGame.sets.length;
+          final sets = individualGame.sets.asMap().entries.map((entry) {
+            final i = entry.key;
+            final set = entry.value;
             return SetScoreData(
               teamAPoints: set.teamAPoints,
               teamBPoints: set.teamBPoints,
+              isDeciderSet: totalSets > 1 && i == totalSets - 1,
             );
           }).toList();
 
@@ -138,12 +142,15 @@ class ScoreEntryBloc extends Bloc<ScoreEntryEvent, ScoreEntryState> {
     final currentGame = updatedGames[event.gameIndex];
 
     // Update the game with new number of sets
+    // The last set of a best-of-N format (index == numberOfSets - 1 && numberOfSets > 1)
+    // is the deciding set and plays to 15 points instead of 21.
     final newSets = List.generate(event.numberOfSets, (index) {
-      // Keep existing set data if it exists
+      final isDecider = event.numberOfSets > 1 && index == event.numberOfSets - 1;
       if (index < currentGame.sets.length) {
-        return currentGame.sets[index];
+        // Preserve existing score data but update isDeciderSet flag
+        return currentGame.sets[index].copyWith(isDeciderSet: isDecider);
       }
-      return const SetScoreData();
+      return SetScoreData(isDeciderSet: isDecider);
     });
 
     updatedGames[event.gameIndex] = currentGame.copyWith(
@@ -173,9 +180,9 @@ class ScoreEntryBloc extends Bloc<ScoreEntryEvent, ScoreEntryState> {
       return;
     }
 
-    // Update the specific set score with both values
+    // Update the specific set score with both values (preserve isDeciderSet flag)
     final updatedSets = List<SetScoreData>.from(currentGame.sets);
-    updatedSets[event.setIndex] = SetScoreData(
+    updatedSets[event.setIndex] = currentGame.sets[event.setIndex].copyWith(
       teamAPoints: event.teamAPoints,
       teamBPoints: event.teamBPoints,
     );

--- a/lib/features/games/presentation/bloc/score_entry/score_entry_state.dart
+++ b/lib/features/games/presentation/bloc/score_entry/score_entry_state.dart
@@ -24,51 +24,58 @@ class ScoreEntryLoading extends ScoreEntryState {
 class SetScoreData {
   final int? teamAPoints;
   final int? teamBPoints;
+  // True for the deciding 3rd set in best-of-3 — plays to 15 points instead of 21
+  final bool isDeciderSet;
 
-  const SetScoreData({this.teamAPoints, this.teamBPoints});
+  const SetScoreData({this.teamAPoints, this.teamBPoints, this.isDeciderSet = false});
 
   SetScoreData copyWith({
     int? teamAPoints,
     int? teamBPoints,
+    bool? isDeciderSet,
     bool clearTeamA = false,
     bool clearTeamB = false,
   }) {
     return SetScoreData(
       teamAPoints: clearTeamA ? null : (teamAPoints ?? this.teamAPoints),
       teamBPoints: clearTeamB ? null : (teamBPoints ?? this.teamBPoints),
+      isDeciderSet: isDeciderSet ?? this.isDeciderSet,
     );
   }
 
   bool get isComplete => teamAPoints != null && teamBPoints != null;
 
+  int get _targetPoints => isDeciderSet ? 15 : 21;
+
   bool get isValid {
     if (!isComplete) return false;
+    final target = _targetPoints;
     final maxPoints = teamAPoints! > teamBPoints! ? teamAPoints! : teamBPoints!;
     final minPoints = teamAPoints! < teamBPoints! ? teamAPoints! : teamBPoints!;
 
-    if (maxPoints < 21) return false;
-    if (maxPoints == 21) return minPoints <= 19;
+    if (maxPoints < target) return false;
+    if (maxPoints == target) return minPoints <= target - 2;
     return (maxPoints - minPoints) == 2;
   }
 
   /// Get a user-friendly error message if the score is invalid
   String? get validationError {
     if (!isComplete) return null;
-
+    final target = _targetPoints;
     final maxPoints = teamAPoints! > teamBPoints! ? teamAPoints! : teamBPoints!;
     final minPoints = teamAPoints! < teamBPoints! ? teamAPoints! : teamBPoints!;
 
-    if (maxPoints < 21) {
-      return 'Winning team must reach at least 21 points';
+    if (maxPoints < target) {
+      return 'Winning team must reach at least $target points';
     }
 
-    if (maxPoints == 21) {
-      if (minPoints > 19) {
-        return 'Must win by at least 2 points (e.g., 21-19)';
+    if (maxPoints == target) {
+      if (minPoints > target - 2) {
+        return 'Must win by at least 2 points (e.g., $target-${target - 2})';
       }
     }
 
-    if (maxPoints > 21) {
+    if (maxPoints > target) {
       if ((maxPoints - minPoints) != 2) {
         return 'In extra points, must win by exactly 2 points';
       }
@@ -88,10 +95,11 @@ class SetScoreData {
       other is SetScoreData &&
           runtimeType == other.runtimeType &&
           teamAPoints == other.teamAPoints &&
-          teamBPoints == other.teamBPoints;
+          teamBPoints == other.teamBPoints &&
+          isDeciderSet == other.isDeciderSet;
 
   @override
-  int get hashCode => teamAPoints.hashCode ^ teamBPoints.hashCode;
+  int get hashCode => teamAPoints.hashCode ^ teamBPoints.hashCode ^ isDeciderSet.hashCode;
 }
 
 /// Helper class to store data for a single game

--- a/lib/features/games/presentation/widgets/game_list_item.dart
+++ b/lib/features/games/presentation/widgets/game_list_item.dart
@@ -6,7 +6,6 @@ import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:play_with_me/core/data/models/game_model.dart';
-import 'game_result_badge.dart';
 import 'set_scores_display.dart';
 
 class GameListItem extends StatelessWidget {
@@ -70,9 +69,7 @@ class GameListItem extends StatelessWidget {
                     const MixGameBadge(),
                     const SizedBox(width: 6),
                   ],
-                  if (isCompletedWithResult)
-                    GameResultBadge(result: game.result!, teams: game.teams)
-                  else if (isVerification)
+                  if (isVerification)
                     _buildVerificationBadge(context)
                   else if (isCancelled)
                     _buildCancelledBadge(context)

--- a/test/widget/features/games/presentation/widgets/game_list_item_test.dart
+++ b/test/widget/features/games/presentation/widgets/game_list_item_test.dart
@@ -4,7 +4,6 @@ import 'package:play_with_me/core/data/models/game_model.dart';
 import 'package:play_with_me/core/presentation/widgets/mix_game_badge.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/features/games/presentation/widgets/game_list_item.dart';
-import 'package:play_with_me/features/games/presentation/widgets/game_result_badge.dart';
 import 'package:play_with_me/features/games/presentation/widgets/set_scores_display.dart';
 import '../../../../../helpers/test_app.dart';
 
@@ -96,7 +95,7 @@ void main() {
       expect(title.style?.decoration, TextDecoration.lineThrough);
     });
 
-    testWidgets('displays result badge and scores when completed with result', (
+    testWidgets('displays scores (no badge) when completed with result', (
       tester,
     ) async {
       const result = GameResult(
@@ -117,7 +116,6 @@ void main() {
           )),
       );
 
-      expect(find.byType(GameResultBadge), findsOneWidget);
       expect(find.byType(SetScoresDisplay), findsOneWidget);
       expect(find.text('21-19'), findsOneWidget);
     });


### PR DESCRIPTION
## Bug 1 — 3rd set score limit

In best-of-3, the deciding (3rd) set must be played to **15 points** (not 21), always with a 2-point lead.

**Root cause:** `SetScoreData.isValid` hardcoded `maxPoints >= 21` for every set.

**Fix:** Added `isDeciderSet: bool` to `SetScoreData`. When the score_entry BLoC creates sets for a best-of format (`numberOfSets > 1`), the last set gets `isDeciderSet: true`. Validation then uses 15 as the target instead of 21.

## Bug 2 — Solid green rectangle on completed game cards

**Root cause:** `GameResultBadge` used `AppColors.success` (#27AE60 green) as **both** the container background AND the text/icon colour → green-on-green = invisible content, showing only a solid green block.

**Fix:** Removed `GameResultBadge` from the game list card entirely. The set scores are already displayed clearly below the card title via `SetScoresDisplay` — the badge is redundant.