### PR TITLE
fix(championships): consistent leave-team button gating

### DIFF
--- a/lib/features/championships/presentation/pages/championship_detail_page.dart
+++ b/lib/features/championships/presentation/pages/championship_detail_page.dart
@@ -134,7 +134,7 @@ class _ChampionshipDetailView extends StatelessWidget {
                       t.memberIds.contains(currentUserId)).firstOrNull
                   : null,
               onLeaveTeam: alreadyRegistered &&
-                  state.championship.status == ChampionshipStatus.registration
+                  _isRegistrationPhase(state.championship.status)
                   ? () {
                       final myT = state.teams
                           .where((t) => t.memberIds.contains(currentUserId))

--- a/lib/features/championships/presentation/pages/championship_registration_page.dart
+++ b/lib/features/championships/presentation/pages/championship_registration_page.dart
@@ -180,6 +180,10 @@ class _ChampionshipCard extends StatelessWidget {
     required this.onLeave,
   });
 
+  bool get _isRegistrationPhase =>
+      championship.status == ChampionshipStatus.registration ||
+      championship.status == ChampionshipStatus.registrationClosed;
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -208,11 +212,13 @@ class _ChampionshipCard extends StatelessWidget {
                 style: Theme.of(context).textTheme.titleSmall,
               ),
               Text(myTeam!.name),
-              const SizedBox(height: AppSpacing.sm),
-              OutlinedButton(
-                onPressed: () => onLeave(myTeam!.id),
-                child: Text(l10n.leaveTeam),
-              ),
+              if (_isRegistrationPhase) ...[
+                const SizedBox(height: AppSpacing.sm),
+                OutlinedButton(
+                  onPressed: () => onLeave(myTeam!.id),
+                  child: Text(l10n.leaveTeam),
+                ),
+              ],
             ] else if (championship.isOpen) ...[
               FilledButton(
                 onPressed: onRegister,


### PR DESCRIPTION
## Summary
- The championship detail page's Leave Team button was only enabled during `registration` status, while `leaveChampionshipTeamHandler` (Cloud Function) actually permits leaving during both `registration` and `registration_closed`.
- The registration page's Leave Team button had no status gate at all, so it stayed visible/tappable during `active`/`completed` championships and would fail with a backend error when pressed.
- Both pages now consistently show/enable the button only during `registration` and `registration_closed`, matching backend behavior.

## Test plan
- [x] `flutter analyze` on both changed files — no issues
- [x] `flutter test test/widget/features/championships/championship_detail_page_test.dart` — all pass
- [ ] Manual check: verify Leave Team button hides once a championship transitions to `active`