### PR TITLE
Story 32.4: Breaking-change policy — PR template + function versioning enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+<!-- What does this PR do? -->
+
+## Breaking changes checklist
+<!-- A "breaking change" is any Cloud Function modification that changes the API
+     contract for clients still on the current App Store version. See
+     CLAUDE.md §11.11 (Cloud Function Versioning & Production Safety):
+     https://github.com/Babas10/gatherli/blob/main/CLAUDE.md#1111-cloud-function-versioning--production-safety -->
+- [ ] No Cloud Functions were renamed or removed
+- [ ] No existing function parameters were renamed or made required
+- [ ] No response fields were removed or renamed
+- [ ] No Firestore field names used by the current app were renamed/removed
+- [ ] If any box above is unchecked → a versioned function (V2) has been created
+      and the old function is kept until the old app version is retired
+
+If any box above is unchecked, apply the `breaking-change` label to this PR.
+
+## Data migrations
+- [ ] No existing Firestore documents need to be updated
+- [ ] If documents need updating → a migration script exists in functions/migrations/
+
+## Deployment notes
+<!-- Anything special CI needs to know before deploying? -->

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -1,0 +1,35 @@
+name: Breaking Change Check
+
+# Warns (does not block) when a PR is marked with the `breaking-change` label,
+# reminding reviewers to verify a versioned (V2) Cloud Function exists per
+# CLAUDE.md §11.11 before merging. See .github/pull_request_template.md for
+# the full breaking-change checklist authors fill out.
+on:
+  pull_request:
+    types: [opened, reopened, labeled]
+
+jobs:
+  warn_breaking_change:
+    name: ⚠️ Warn on Breaking Change Label
+    runs-on: ubuntu-latest
+    # Only run when the label is present, and — for the `labeled` event
+    # specifically — only when `breaking-change` is the label that was just
+    # added (avoids re-posting the comment every time an unrelated label is
+    # added to a PR that already has `breaking-change`).
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'breaking-change') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'breaking-change')
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: 💬 Post Breaking Change Warning
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '⚠️ This PR is marked `breaking-change`. Verify a versioned (V2) Cloud Function exists and the old version is kept until the previous app release is retired before merging — see [CLAUDE.md §11.11](https://github.com/Babas10/gatherli/blob/main/CLAUDE.md#1111-cloud-function-versioning--production-safety).'
+            })


### PR DESCRIPTION
## Summary
- Closes #853.
- Adds `.github/pull_request_template.md` with a breaking-change checklist (Cloud Function renames/removals, parameter/response changes, Firestore field renames) and a data-migrations checklist, cross-referencing CLAUDE.md §11.11 (Cloud Function Versioning & Production Safety).
- Creates the `breaking-change` label in the repo.
- Adds `.github/workflows/breaking-change-check.yml`: posts a warning comment on the PR when the `breaking-change` label is present, reminding reviewers to verify a versioned (V2) function exists before merging. Warns only — does not block the merge or the deploy pipeline, per the story's acceptance criteria.

## Out of scope (per issue)
- Automated static analysis of TypeScript to detect breaking changes
- Enforcement via Firestore rules

## Test plan
- [x] Validated both workflow YAML files parse correctly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed `breaking-change` label exists in the repo with a description pointing to CLAUDE.md §11.11
- [ ] Verify the warning comment posts correctly when the label is applied to a real PR