### PR TITLE
Story 32.5: Data migration framework — functions/migrations/ scaffold + runbook

### DIFF
--- a/functions/migrations/README.md
+++ b/functions/migrations/README.md
@@ -1,0 +1,127 @@
+# Data Migration Runbook
+
+When a Cloud Function or Flutter model change alters how data is stored in
+Firestore (renames a field, splits a document, adds a required field),
+existing documents keep the old shape until a migration is run. This folder
+is the standard place to write, test, and track those one-time migrations.
+
+## Folder structure
+
+```
+functions/migrations/
+  README.md          ← this file
+  template.ts         ← copy-paste starting point for new migrations
+  tsconfig.json        ← typechecks this folder in isolation (see below)
+  MIGRATION_LOG.md     ← append-only log of migrations run in prod
+  done/                ← completed migration scripts, archived after execution
+```
+
+## 1. Write the migration
+
+1. Copy `template.ts` to a new file named `<date>-<short-description>.ts`
+   (e.g. `2026-09-01-add-championship-tiebreaker-field.ts`). Don't put it in
+   `done/` yet — that's only for scripts that have already run in prod.
+2. Fill in the header comment: what changes, before/after shapes, whether
+   it's safe to re-run, and the story/issue it belongs to.
+3. Write an **idempotency check** — the migration must be safe to run more
+   than once (e.g. after a partial failure) without corrupting data. Skip
+   documents that already have the new shape.
+4. Batch writes in groups of ≤500 (Firestore's batch limit) — see the
+   template for the pattern.
+5. Typecheck it:
+   ```bash
+   cd functions
+   npm run migrate:check
+   ```
+   This only typechecks files directly in `migrations/` (via
+   `migrations/tsconfig.json`), not `done/` — archived scripts are historical
+   records and aren't maintained to keep compiling.
+
+## 2. Test locally against the emulator
+
+Never run an untested migration against prod. Test it against the Firestore
+emulator first:
+
+```bash
+# Terminal 1 — start the emulator with some representative data
+firebase emulators:start --only auth,firestore --project gatherli-dev
+
+# Terminal 2 — point the script at the emulator and run it
+cd functions
+FIRESTORE_EMULATOR_HOST=localhost:8080 npx ts-node migrations/<your-file>.ts
+```
+
+Verify the result in the Emulator UI (http://localhost:4000/firestore) before
+going anywhere near prod.
+
+## 3. Run against `gatherli-prod`
+
+**Do not run standalone scripts directly against prod with a personal service
+account key.** This repo's established pattern (see `done/2026-08-22-remove-user-array-fields-cf.ts`
+and `done/2026-08-22-remove-group-game-ids.ts`) is to temporarily deploy the
+migration as an **admin-only callable Cloud Function** instead:
+
+1. Wrap the same logic from your tested script in a callable function, gated
+   the same way as those two examples:
+   ```typescript
+   export const migrateXyz = functions
+     .region("europe-west6")
+     .runWith({ timeoutSeconds: 540, memory: "512MB" })
+     .https.onCall(async (data, context) => {
+       if (!context.auth) {
+         throw new functions.https.HttpsError("unauthenticated", "...");
+       }
+       const adminDoc = await admin.firestore()
+         .collection("appAdmins").doc(context.auth.uid).get();
+       if (!adminDoc.exists) {
+         throw new functions.https.HttpsError("permission-denied", "Only app admins can run this migration.");
+       }
+       // ... migration logic, with logging and a return summary ...
+     });
+   ```
+2. Export it from `functions/src/index.ts`, deploy it alone:
+   ```bash
+   firebase deploy --only functions:migrateXyz --project gatherli-prod
+   ```
+3. Invoke it once as an app admin (Firebase Console → Functions → test the
+   callable, or trigger it from an authenticated admin client). Confirm the
+   returned summary counts look right.
+4. **Immediately remove the function** from `index.ts` and redeploy, so it
+   can't be triggered again by accident.
+
+This keeps prod credentials out of developer machines and reuses the same
+`context.auth` + `appAdmins` security model as the rest of the app (see
+CLAUDE.md §11.3–§11.4).
+
+**When to run:** always **after** the new function version is deployed, and
+**after** the old app version is retired from the App Store if the migration
+deletes fields the old app still reads (see CLAUDE.md §11.11).
+
+## 4. Log and archive
+
+After a successful prod run:
+
+1. Append a row to `MIGRATION_LOG.md` (never edit past rows — this file is
+   append-only):
+   ```markdown
+   | 2026-09-01 | done/2026-09-01-add-championship-tiebreaker-field.ts | <description> | <N docs> | <author> |
+   ```
+2. Move the script into `done/`.
+3. If you deployed a temporary callable function for step 3, confirm it was
+   removed from `index.ts` and redeployed out.
+
+## Rollback
+
+There is no automated rollback tooling — migrations are one-way by design
+(deleted fields are gone). Before running a destructive migration:
+
+- Confirm the old app version reading the old shape has already been retired,
+  or keep the old fields until it has (see CLAUDE.md §11.11 on function
+  versioning — the same "don't break clients still on the old build" rule
+  applies to data shapes).
+- For non-destructive migrations (adding a field, copying data to a new
+  location without deleting the old one), rollback is simply not reading the
+  new field — no action needed.
+- If a destructive migration must be undone, restore from a Firestore
+  scheduled backup ([console.cloud.google.com](https://console.cloud.google.com)
+  → Firestore → Backups) rather than attempting to reconstruct deleted data.

--- a/functions/migrations/template.ts
+++ b/functions/migrations/template.ts
@@ -1,0 +1,65 @@
+import * as admin from "firebase-admin";
+
+/**
+ * Migration: <short description>
+ *
+ * Date: YYYY-MM-DD
+ * Story: <story number> (#<issue>)
+ *
+ * What it changes:
+ *   Before: <old data shape>
+ *   After:  <new data shape>
+ *
+ * Safe to run multiple times? YES / NO — <explain>
+ * Estimated documents affected: ~N
+ */
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+const db = admin.firestore();
+
+async function migrate(): Promise<void> {
+  let processed = 0;
+  let updated = 0;
+
+  const snapshot = await db.collection("COLLECTION").get();
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const doc of snapshot.docs) {
+    processed++;
+    const data = doc.data();
+
+    // Idempotency check — skip documents that are already migrated. This
+    // makes it safe to re-run the script if it fails partway through.
+    if (data.newField !== undefined) continue;
+
+    batch.update(doc.ref, {
+      newField: data.oldField ?? null,
+      // oldField: admin.firestore.FieldValue.delete(), // only after the old app version is retired
+    });
+    updated++;
+    batchCount++;
+
+    // Firestore batch limit is 500 writes.
+    if (batchCount === 500) {
+      await batch.commit();
+      batch = db.batch();
+      batchCount = 0;
+    }
+  }
+
+  if (batchCount > 0) {
+    await batch.commit();
+  }
+
+  console.log("Migration complete:");
+  console.log(`  Documents processed: ${processed}`);
+  console.log(`  Documents updated:   ${updated}`);
+}
+
+migrate().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/functions/migrations/tsconfig.json
+++ b/functions/migrations/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -20,6 +20,7 @@
         "firebase-functions-test": "^3.1.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -541,6 +542,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1543,6 +1568,34 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2137,6 +2190,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2232,6 +2298,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3071,6 +3144,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3262,6 +3342,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -8643,6 +8733,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -8944,6 +9078,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -9240,6 +9381,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=integration --testPathIgnorePatterns=security-rules",
     "test:integration": "jest --config jest.integration.config.js",
-    "test:all": "npm run test:unit && npm run test:integration"
+    "test:all": "npm run test:unit && npm run test:integration",
+    "migrate:check": "tsc --noEmit -p migrations/tsconfig.json"
   },
   "engines": {
     "node": "22"
@@ -33,6 +34,7 @@
     "firebase-functions-test": "^3.1.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.0"
   },
   "private": true


### PR DESCRIPTION
## Summary
- Closes #854.
- Adds `functions/migrations/README.md`: full runbook covering write (with idempotency check) → test locally against the Firestore emulator → run in prod → log → archive.
- **Deviation from the issue's proposed prod-run method, based on real precedent already in this repo:** the issue suggested running `npx ts-node migrations/<file>.ts` directly against `gatherli-prod`, which would require a personal service-account key with prod write access on a developer machine. This repo already has two real migrations (`done/2026-08-22-remove-user-array-fields-cf.ts`, `done/2026-08-22-remove-group-game-ids.ts`) that instead deployed the migration as a temporary admin-only callable Cloud Function, invoked once, then removed. The README documents that as the required production path (keeps prod credentials off developer machines, reuses the existing `context.auth` + `appAdmins` security model — CLAUDE.md §11.3–§11.4). The `ts-node`/emulator workflow is kept for local iteration and dry-runs.
- Adds `functions/migrations/template.ts`: copy-paste starting point (standard metadata header, idempotency check, batched writes at the 500-doc Firestore limit).
- Adds `functions/migrations/tsconfig.json` (scoped to `*.ts` directly in `migrations/`, excluding `done/`) + `npm run migrate:check` script so the template can be typechecked without pulling in the already-archived `done/` scripts (one of which has a stale relative import from when it was still deployed).
- Adds `ts-node` as a devDependency to support the documented local workflow.
- `functions/migrations/MIGRATION_LOG.md` already existed with 3 real entries from prior migrations — untouched.
- `RELEASE_CHECKLIST.md` already references the migration log as a post-release step (added in Story 32.3) — satisfies that acceptance criterion with no further change needed.

## Out of scope (per issue)
- Automated migration runs in CI
- Rollback tooling (documented approach instead, in the README's Rollback section)

## Test plan
- [x] `cd functions && npm run migrate:check` — passes, typechecks `template.ts` cleanly
- [x] `cd functions && npm run build` — main functions build still passes after the tsconfig/template additions