### PR TITLE
Story 35.1: Add .limit()/pagination to unbounded Firestore queries

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -283,6 +283,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "trainingSessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "groupId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/core/data/repositories/firestore_exercise_repository.dart
+++ b/lib/core/data/repositories/firestore_exercise_repository.dart
@@ -21,6 +21,10 @@ class FirestoreExerciseRepository implements ExerciseRepository {
   static const String _trainingSessions = 'trainingSessions';
   static const String _exercises = 'exercises';
 
+  // Caps the exercise list per training session so a single session can't
+  // grow unbounded (no natural limit otherwise exists on exercise count).
+  static const int _exercisesLimit = 200;
+
   FirestoreExerciseRepository({
     FirebaseFirestore? firestore,
     required TrainingSessionRepository trainingSessionRepository,
@@ -95,6 +99,7 @@ class FirestoreExerciseRepository implements ExerciseRepository {
     try {
       return _getExercisesCollection(trainingSessionId)
           .orderBy('createdAt', descending: false)
+          .limit(_exercisesLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs

--- a/lib/core/data/repositories/firestore_invitation_repository.dart
+++ b/lib/core/data/repositories/firestore_invitation_repository.dart
@@ -16,6 +16,10 @@ class FirestoreInvitationRepository implements InvitationRepository {
 
   static const String _invitationsCollection = 'invitations';
 
+  // Caps invitation list queries so they don't grow unbounded as a user
+  // accumulates invitation history over time.
+  static const int _invitationsLimit = 50;
+
   FirestoreInvitationRepository({
     FirebaseFirestore? firestore,
     FirebaseFunctions? functions,
@@ -141,6 +145,7 @@ class FirestoreInvitationRepository implements InvitationRepository {
         .where('invitedUserId', isEqualTo: userId)
         .where('status', isEqualTo: 'pending')
         .orderBy('createdAt', descending: true)
+        .limit(_invitationsLimit)
         .snapshots()
         .map(
           (snapshot) => snapshot.docs
@@ -157,6 +162,7 @@ class FirestoreInvitationRepository implements InvitationRepository {
           .collection(_invitationsCollection)
           .where('invitedUserId', isEqualTo: userId)
           .orderBy('createdAt', descending: true)
+          .limit(_invitationsLimit)
           .get();
       return snapshot.docs
           .where((doc) => doc.exists)

--- a/lib/core/data/repositories/firestore_message_repository.dart
+++ b/lib/core/data/repositories/firestore_message_repository.dart
@@ -6,6 +6,12 @@ import 'package:play_with_me/core/domain/repositories/message_repository.dart';
 class FirestoreMessageRepository implements MessageRepository {
   final FirebaseFirestore _firestore;
 
+  // Caps chat history to the most recent N messages per context. Without a
+  // limit, this streams the entire chat history (unbounded growth) on every
+  // load. Messages are fetched newest-first then reversed so callers keep
+  // seeing ascending (oldest → newest) order.
+  static const int _messagesLimit = 100;
+
   FirestoreMessageRepository({FirebaseFirestore? firestore})
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
@@ -15,11 +21,14 @@ class FirestoreMessageRepository implements MessageRepository {
       return _firestore
           .doc(contextPath)
           .collection('messages')
-          .orderBy('sentAt', descending: false)
+          .orderBy('sentAt', descending: true)
+          .limit(_messagesLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
                 .map((doc) => ChatMessageModel.fromFirestore(doc))
+                .toList()
+                .reversed
                 .toList(),
           )
           .handleError((error) {

--- a/lib/core/data/repositories/firestore_training_session_repository.dart
+++ b/lib/core/data/repositories/firestore_training_session_repository.dart
@@ -24,6 +24,10 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
 
   static const String _collection = 'trainingSessions';
 
+  // Caps list/stream queries that have no other natural bound (e.g. no date
+  // filter) so they don't grow unbounded as session history accumulates.
+  static const int _sessionsListLimit = 100;
+
   FirestoreTrainingSessionRepository({
     FirebaseFirestore? firestore,
     FirebaseFunctions? functions,
@@ -92,6 +96,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .collection(_collection)
           .where('groupId', isEqualTo: groupId)
           .orderBy('startTime', descending: false)
+          .limit(_sessionsListLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
@@ -131,6 +136,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .where('startTime', isGreaterThan: now)
           .where('status', isEqualTo: 'scheduled')
           .orderBy('startTime', descending: false)
+          .limit(_sessionsListLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
@@ -204,6 +210,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .where('groupId', isEqualTo: groupId)
           .where('startTime', isGreaterThan: cutoff)
           .orderBy('startTime', descending: false)
+          .limit(_sessionsListLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
@@ -240,19 +247,20 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
       final cutoff = Timestamp.fromDate(
         DateTime.now().subtract(Duration(days: pastDays)),
       );
+      // Ordered descending + limited so the query returns the most recent
+      // older sessions first, capped instead of fetching the entire history.
       final query = await _firestore
           .collection(_collection)
           .where('groupId', isEqualTo: groupId)
           .where('startTime', isLessThanOrEqualTo: cutoff)
-          .orderBy('startTime', descending: false)
+          .orderBy('startTime', descending: true)
+          .limit(_sessionsListLimit)
           .get();
 
       final sessions = query.docs
           .where((doc) => doc.exists)
           .map((doc) => TrainingSessionModel.fromFirestore(doc))
           .toList();
-      // Sort descending (most recent first) in Dart to avoid a new index
-      sessions.sort((a, b) => b.startTime.compareTo(a.startTime));
       return sessions;
     } on FirebaseException catch (e) {
       throw TrainingSessionException(
@@ -274,6 +282,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .collection(_collection)
           .where('participantIds', arrayContains: userId)
           .orderBy('startTime', descending: false)
+          .limit(_sessionsListLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
@@ -327,6 +336,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
                 .where('status', isEqualTo: 'scheduled')
                 .where('startTime', isGreaterThan: Timestamp.now())
                 .orderBy('startTime')
+                .limit(1)
                 .snapshots()
                 .listen(
                   (sessionsSnapshot) {
@@ -1047,6 +1057,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .collection(_collection)
           .where('parentSessionId', isEqualTo: parentSessionId)
           .orderBy('startTime', descending: false)
+          .limit(_sessionsListLimit)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs
@@ -1086,6 +1097,7 @@ class FirestoreTrainingSessionRepository implements TrainingSessionRepository {
           .where('startTime', isGreaterThan: now)
           .where('status', isEqualTo: 'scheduled')
           .orderBy('startTime', descending: false)
+          .limit(50)
           .snapshots()
           .map(
             (snapshot) => snapshot.docs

--- a/lib/core/data/repositories/firestore_user_repository.dart
+++ b/lib/core/data/repositories/firestore_user_repository.dart
@@ -22,6 +22,10 @@ class FirestoreUserRepository implements UserRepository {
 
   static const String _collection = 'users';
 
+  // Caps subcollection list/stream queries that have no other natural bound.
+  static const int _ratingHistoryByPeriodLimit = 500;
+  static const int _headToHeadStatsLimit = 50;
+
   /// In-memory cache: uid → (user, fetchedAt). TTL: 10 minutes.
   final Map<String, ({UserModel user, DateTime fetchedAt})> _userCache = {};
   static const Duration _userCacheTtl = Duration(minutes: 10);
@@ -450,6 +454,7 @@ class FirestoreUserRepository implements UserRepository {
           isGreaterThanOrEqualTo: Timestamp.fromDate(startDate),
         )
         .orderBy('timestamp', descending: true)
+        .limit(_ratingHistoryByPeriodLimit)
         .snapshots()
         .map(
           (snapshot) => snapshot.docs
@@ -597,6 +602,7 @@ class FirestoreUserRepository implements UserRepository {
         .doc(userId)
         .collection('headToHead')
         .orderBy('gamesPlayed', descending: true)
+        .limit(_headToHeadStatsLimit)
         .snapshots()
         .map(
           (snapshot) => snapshot.docs

--- a/test/unit/core/data/repositories/firestore_message_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_message_repository_test.dart
@@ -1,0 +1,89 @@
+// Tests FirestoreMessageRepository — message list capping and ordering.
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:play_with_me/core/data/repositories/firestore_message_repository.dart';
+
+void main() {
+  group('FirestoreMessageRepository', () {
+    late FakeFirebaseFirestore fakeFirestore;
+    late FirestoreMessageRepository repository;
+
+    const contextPath = 'games/game-123';
+
+    Future<void> addTestMessage({
+      required String text,
+      required DateTime sentAt,
+    }) async {
+      await fakeFirestore.doc(contextPath).collection('messages').add({
+        'senderId': 'user-1',
+        'senderDisplayName': 'User One',
+        'text': text,
+        'sentAt': Timestamp.fromDate(sentAt),
+      });
+    }
+
+    setUp(() {
+      fakeFirestore = FakeFirebaseFirestore();
+      repository = FirestoreMessageRepository(firestore: fakeFirestore);
+    });
+
+    group('sendMessage', () {
+      test('adds a message document under the context path', () async {
+        await repository.sendMessage(
+          contextPath: contextPath,
+          senderId: 'user-1',
+          senderDisplayName: 'User One',
+          text: 'Hello',
+        );
+
+        final snapshot = await fakeFirestore
+            .doc(contextPath)
+            .collection('messages')
+            .get();
+
+        expect(snapshot.docs, hasLength(1));
+        expect(snapshot.docs.first.data()['text'], 'Hello');
+      });
+    });
+
+    group('getMessages', () {
+      test('returns messages in ascending (oldest → newest) order', () async {
+        final now = DateTime.now();
+        await addTestMessage(text: 'first', sentAt: now.subtract(const Duration(minutes: 2)));
+        await addTestMessage(text: 'second', sentAt: now.subtract(const Duration(minutes: 1)));
+        await addTestMessage(text: 'third', sentAt: now);
+
+        final messages = await repository
+            .getMessages(contextPath: contextPath)
+            .first;
+
+        expect(messages.map((m) => m.text).toList(), ['first', 'second', 'third']);
+      });
+
+      test('caps to the most recent 100 messages, still ascending', () async {
+        final now = DateTime.now();
+        const totalMessages = 105;
+        for (var i = 0; i < totalMessages; i++) {
+          await addTestMessage(
+            text: 'message-$i',
+            sentAt: now.subtract(Duration(minutes: totalMessages - i)),
+          );
+        }
+
+        final messages = await repository
+            .getMessages(contextPath: contextPath)
+            .first;
+
+        // Capped to 100 instead of all 105.
+        expect(messages, hasLength(100));
+
+        // The oldest 5 messages (message-0..message-4) are dropped; the
+        // most recent 100 remain, still in ascending order.
+        expect(messages.first.text, 'message-5');
+        expect(messages.last.text, 'message-104');
+      });
+    });
+  });
+}

--- a/test/unit/core/data/repositories/firestore_training_session_repository_test.dart
+++ b/test/unit/core/data/repositories/firestore_training_session_repository_test.dart
@@ -605,5 +605,56 @@ void main() {
         expect(sessionIds, contains('session-3'));
       });
     });
+
+    group('getOlderTrainingSessionsForGroup', () {
+      test(
+        'caps results to the most recent sessions before the cutoff, '
+        'ordered descending by startTime',
+        () async {
+          const groupId = 'group-older-sessions';
+          final cutoff = DateTime.now().subtract(const Duration(days: 90));
+
+          // Add 105 sessions older than the cutoff, each one day further in
+          // the past than the last, so startTime values are all distinct.
+          const totalOlderSessions = 105;
+          for (var i = 0; i < totalOlderSessions; i++) {
+            await addTestSessionToFirestore(
+              createTestSession(
+                groupId: groupId,
+                startTime: cutoff.subtract(Duration(days: i + 1)),
+                endTime: cutoff.subtract(Duration(days: i + 1, hours: -2)),
+              ),
+            );
+          }
+
+          final result = await repository.getOlderTrainingSessionsForGroup(
+            groupId,
+            pastDays: 90,
+          );
+
+          // Capped to the shared list limit instead of returning all 105.
+          expect(result, hasLength(100));
+
+          // Ordered descending — most recent (closest to cutoff) first.
+          for (var i = 0; i < result.length - 1; i++) {
+            expect(
+              result[i].startTime.isAfter(result[i + 1].startTime) ||
+                  result[i].startTime.isAtSameMomentAs(result[i + 1].startTime),
+              isTrue,
+            );
+          }
+
+          // The oldest 5 sessions (beyond the 100 cap) must be excluded.
+          final oldestIncludedStartTime = result.last.startTime;
+          final oldestOverallStartTime = cutoff.subtract(
+            const Duration(days: totalOlderSessions),
+          );
+          expect(
+            oldestIncludedStartTime.isAfter(oldestOverallStartTime),
+            isTrue,
+          );
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Closes #878 (Epic #877).

Adds `.limit()` to Firestore queries that previously fetched entire collections/subcollections with no page size, so load time and cost no longer grow unbounded as users accumulate messages, invitations, training sessions, exercises, and stats.

## Code scan results

| Repository | Method | Before | After |
|---|---|---|---|
| `FirestoreMessageRepository` | `getMessages` | Ascending, **no limit** — full chat history on every load | Descending + `.limit(100)` + reversed (preserves ascending output order) |
| `FirestoreInvitationRepository` | `getPendingInvitations`, `getInvitations` | No limit | `.limit(50)` |
| `FirestoreTrainingSessionRepository` | `getTrainingSessionsForGroup`, `getUpcomingTrainingSessionsForGroup`, `getRecentTrainingSessionsForGroup`, `getTrainingSessionsForUser`, `getRecurringSessionInstances` | No limit | `.limit(100)` |
| | `getUpcomingRecurringSessionInstances` | No limit | `.limit(50)` |
| | `getNextTrainingSessionForUser` | No limit (only `.first` ever used) | `.limit(1)` |
| | `getOlderTrainingSessionsForGroup` | Ascending fetch-all + client-side descending sort | Firestore-level `orderBy(descending: true)` + `.limit(100)` — returns the 100 most recent sessions before the cutoff instead of the entire history |
| `FirestoreExerciseRepository` | `getExercisesForTrainingSession` | No limit | `.limit(200)` |
| `FirestoreUserRepository` | `getRatingHistoryByPeriod` | No limit | `.limit(500)` |
| | `getAllHeadToHeadStats` | No limit | `.limit(50)` |

None of the above changed sort direction except `getOlderTrainingSessionsForGroup`, which now requires a new composite index — added to `firestore.indexes.json`: `trainingSessions {groupId ASC, startTime DESC}`. **This index must be deployed before/with this change to `gatherli-prod`** (`firebase deploy --only firestore:indexes`), otherwise the query will throw `FAILED_PRECONDITION`.

## Deliberately left unchanged (documented, not silently skipped)

- **`getPendingFriendRequestCount`, `getExerciseCount`, `getUpcomingTrainingSessionsCount`** (`Stream<int>` via `.snapshots().map(docs.length)`): the story suggested converting these to Firestore aggregate `.count()` queries. Verified directly in the `cloud_firestore` 5.6.12 package source that `AggregateQuery` only exposes `Future<AggregateQuerySnapshot> get()` — **no `.snapshots()` method exists**, so aggregate counts cannot back a real-time `Stream<int>`. Recommend a denormalized counter maintained by a Cloud Function trigger as a follow-up story.
- **`getAllTeammateStats`**: sorts client-side (no Firestore `orderBy`) after fetching the full `stats` subcollection. Adding `.limit()` before an in-memory sort would return an arbitrary N docs rather than the true top-N by `gamesPlayed`. Fixing this properly needs a Firestore index + `orderBy` — a bigger change, flagged as a follow-up rather than forced into this story.
- **`firestore_game_repository.dart`'s `getOlderGamesForGroup`/`getRecentGamesForGroup`**: have the identical unbounded/client-sort pattern as the training session methods (used together in the same activity feed), but the games repository was not listed in issue #878's scope. Flagging as a follow-up rather than scope-creeping into this story.

## Test plan

- [x] New regression test for `getOlderTrainingSessionsForGroup` — asserts the 100-item cap and descending order are enforced (105 seeded docs → 100 returned, most recent first)
- [x] New test file for `firestore_message_repository.dart` (previously untested) — asserts ascending output order and the 100-message cap (105 seeded docs → 100 returned, oldest 5 dropped)
- [x] `flutter test test/unit/` — 2873 passing, 0 failures
- [x] `flutter analyze` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)