### PR TITLE
Story 0.3.4 / 0.3.9: Fully automate beta and production release rollout

### DIFF
--- a/.github/scripts/asc_submit_for_review.py
+++ b/.github/scripts/asc_submit_for_review.py
@@ -6,6 +6,10 @@ The build is assumed to already be in App Store Connect (uploaded during the
 beta TestFlight pipeline). This script finds it by iOS version string and
 submits it for review — no re-upload required.
 
+The App Store version is set to release automatically the moment Apple
+approves it (releaseType AFTER_APPROVAL) — no manual "Release This Version"
+click needed in App Store Connect.
+
 Required environment variables:
   ASC_KEY_ID       — App Store Connect API key ID
   ASC_ISSUER_ID    — App Store Connect API issuer ID
@@ -87,6 +91,7 @@ def main():
     print(f"Found build: {build_id}")
 
     # 2. Find or create the App Store version entry
+    RELEASE_TYPE = "AFTER_APPROVAL"
     versions = api(
         "GET",
         f"/v1/apps/{app_id}/appStoreVersions"
@@ -106,7 +111,7 @@ def main():
                     "type": "appStoreVersions",
                     "attributes": {
                         "versionString": ios_version,
-                        "releaseType": "MANUAL",
+                        "releaseType": RELEASE_TYPE,
                         "platform": "IOS",
                     },
                     "relationships": {
@@ -117,6 +122,23 @@ def main():
         )
         version_id = new_ver["data"]["id"]
         print(f"Created App Store version: {version_id}")
+
+    # Ensure release type is AFTER_APPROVAL even on the existing-version path
+    # (e.g. a version pre-created manually in App Store Connect would default
+    # to MANUAL) — this is what makes the build go live the moment Apple
+    # approves it, with no manual step required.
+    print(f"Ensuring release type is {RELEASE_TYPE}...")
+    api(
+        "PATCH",
+        f"/v1/appStoreVersions/{version_id}",
+        {
+            "data": {
+                "type": "appStoreVersions",
+                "id": version_id,
+                "attributes": {"releaseType": RELEASE_TYPE},
+            }
+        },
+    )
 
     # 3. Attach the build to the App Store version
     print("Attaching build to App Store version...")

--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -242,7 +242,7 @@ jobs:
           packageName: org.gatherli.app
           releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
           track: internal
-          status: draft
+          status: completed
           releaseName: ${{ env.VERSION_NAME }}
 
       - name: 🧹 Clean up Google Play service account key


### PR DESCRIPTION
## Summary
- Beta (`cd-beta.yml`): Google Play Internal Testing upload now uses `status: completed` instead of `draft`, so internal testers get the build the moment CI finishes — no manual publish step in Play Console.
- Production (`asc_submit_for_review.py`): App Store version now uses `releaseType: AFTER_APPROVAL` instead of `MANUAL`, so the app goes live automatically the moment Apple approves it — no manual "Release This Version" click. Applied on both the create-new-version and existing-version paths for idempotency.
- Android production (`cd-production.yml`) already used `status: completed` — no change needed, it was already fully automated.

Found during a review of the CD pipeline; addresses #889 and #894 (filed under Epic 0, #28). Both issues are left open until verified against a real beta/production run (Play Console rollout confirmation, and Apple review approval respectively) — see the checklists on each issue.

## Test plan
- [x] `python3 -m py_compile asc_submit_for_review.py` — syntax valid
- [x] `yaml.safe_load` on `cd-beta.yml` — parses cleanly
- [ ] Verify next `v*-beta` tag push results in the build being immediately visible to internal testers without a manual Play Console step
- [ ] Verify next production tag results in the app auto-releasing after Apple approval, with no manual click in App Store Connect