### PR TITLE
Story 35.2: Repository stream/query cleanup — parallelize batched ID lookups

### DIFF
--- a/lib/core/data/repositories/firebase_image_storage_repository.dart
+++ b/lib/core/data/repositories/firebase_image_storage_repository.dart
@@ -69,10 +69,9 @@ class FirebaseImageStorageRepository implements ImageStorageRepository {
       final ref = _storage.ref().child('avatars/$userId');
       final listResult = await ref.listAll();
 
-      // Delete all files in the folder
-      for (final item in listResult.items) {
-        await item.delete();
-      }
+      // Delete all files in the folder in parallel — deletions are
+      // independent of each other.
+      await Future.wait(listResult.items.map((item) => item.delete()));
     } on FirebaseException catch (e) {
       // Ignore if folder doesn't exist
       if (e.code != 'object-not-found') {

--- a/lib/core/data/repositories/firestore_game_repository.dart
+++ b/lib/core/data/repositories/firestore_game_repository.dart
@@ -64,23 +64,27 @@ class FirestoreGameRepository implements GameRepository {
     if (gameIds.isEmpty) return [];
 
     try {
-      final List<GameModel> games = [];
-
-      // Firestore 'in' queries are limited to 10 items
+      // Firestore 'in' queries are limited to 10 items, so chunk into
+      // batches. Batches are independent — run them in parallel instead of
+      // awaiting one at a time.
       const int batchSize = 10;
+      final futures = <Future<QuerySnapshot<Map<String, dynamic>>>>[];
       for (int i = 0; i < gameIds.length; i += batchSize) {
         final batch = gameIds.skip(i).take(batchSize).toList();
-        final query = await _firestore
-            .collection(_collection)
-            .where(FieldPath.documentId, whereIn: batch)
-            .get();
-
-        for (final doc in query.docs) {
-          if (doc.exists) {
-            games.add(GameModel.fromFirestore(doc));
-          }
-        }
+        futures.add(
+          _firestore
+              .collection(_collection)
+              .where(FieldPath.documentId, whereIn: batch)
+              .get(),
+        );
       }
+
+      final results = await Future.wait(futures);
+      final games = <GameModel>[
+        for (final query in results)
+          for (final doc in query.docs)
+            if (doc.exists) GameModel.fromFirestore(doc),
+      ];
 
       return games;
     } on FirebaseException catch (e) {

--- a/lib/core/data/repositories/firestore_group_repository.dart
+++ b/lib/core/data/repositories/firestore_group_repository.dart
@@ -72,23 +72,27 @@ class FirestoreGroupRepository implements GroupRepository {
     if (groupIds.isEmpty) return [];
 
     try {
-      final List<GroupModel> groups = [];
-
-      // Firestore 'in' queries are limited to 10 items
+      // Firestore 'in' queries are limited to 10 items, so chunk into
+      // batches. Batches are independent — run them in parallel instead of
+      // awaiting one at a time.
       const int batchSize = 10;
+      final futures = <Future<QuerySnapshot<Map<String, dynamic>>>>[];
       for (int i = 0; i < groupIds.length; i += batchSize) {
         final batch = groupIds.skip(i).take(batchSize).toList();
-        final query = await _firestore
-            .collection(_collection)
-            .where(FieldPath.documentId, whereIn: batch)
-            .get();
-
-        for (final doc in query.docs) {
-          if (doc.exists) {
-            groups.add(GroupModel.fromFirestore(doc));
-          }
-        }
+        futures.add(
+          _firestore
+              .collection(_collection)
+              .where(FieldPath.documentId, whereIn: batch)
+              .get(),
+        );
       }
+
+      final results = await Future.wait(futures);
+      final groups = <GroupModel>[
+        for (final query in results)
+          for (final doc in query.docs)
+            if (doc.exists) GroupModel.fromFirestore(doc),
+      ];
 
       return groups;
     } catch (e) {


### PR DESCRIPTION
## Summary

Closes #879.

Fixes the sequential-await-in-loop anti-pattern for batched Firestore/Storage ID lookups, and documents the nested-subscription pattern review from the issue's acceptance criteria.

## Code scan results

| File / method | Finding | Action |
|---|---|---|
| `FirestoreGroupRepository.getGroupsByIds` | Sequential `await` per 10-item batch | Fixed — `Future.wait()` |
| `FirestoreGameRepository.getGamesByIds` | Byte-for-byte duplicate of the same bug (not named in the issue, found via full scan) | Fixed — `Future.wait()` |
| `FirebaseImageStorageRepository.deleteAvatar` | Sequential `await item.delete()` over independent Storage files (not named in the issue, found via full scan) | Fixed — `Future.wait()` |
| `FirestoreTrainingFeedbackRepository.deleteFeedbackForSession` | `for` loop with `batch.delete()` + periodic `await batch.commit()` | **Not a bug** — required chunking at Firestore's 500-writes-per-batch limit |
| `FirestoreExerciseRepository.deleteAllExercisesForSession` | Same batch-write pattern as above | **Not a bug** — same reasoning |
| `FirestoreUserRepository.getUsersByIds` | Named in the issue | **No change needed** — already does a single batched Cloud Function call with in-memory caching, no sequential Firestore reads |
| `FirestoreFriendRepository` (all batch methods) | Named in the issue | **No change needed** — `checkFriendshipStatus` already uses `Future.wait()` (Story 34.2), `batchCheckFriendship`/`batchCheckFriendRequestStatus` already use single Cloud Function calls. Issue text is outdated for this file. |

## Nested subscription pattern (`FirestoreGameRepository`)

Per the issue's acceptance criteria, reviewed `getGroupGamesForUser` and `getNextGameForUser` for simplification via rxdart's `switchMap`/`combineLatest`. **Kept as manual `StreamController`/`StreamSubscription` implementations**, for two reasons:

1. `rxdart` is declared as a `dev_dependency` in `pubspec.yaml`, not a production dependency. The only existing `lib/` usage (`firestore_training_feedback_repository.dart`) requires an `// ignore: depend_on_referenced_packages` lint suppression and is actually dead/unused code — not an established production pattern to build on. Promoting it to a real dependency is outside this story's scope.
2. Even setting aside the dependency issue, `getNextGameForUser`'s dual-source merge (group games + player-id games) has behavior that `Rx.combineLatest2` would change: the current code emits as soon as either source has data (treating the other as an empty list until it arrives), while `combineLatest2` would delay the first emission until both sources have emitted. It also has an intentional asymmetry — group-games stream errors are fatal (`controller.addError`), player-games stream errors are non-fatal and only logged — which isn't free with `combineLatest2`.

Both nested-subscription implementations are functionally correct as-is (proper cancel-on-resubscribe via `?.cancel()`, proper cleanup in `controller.onCancel`) — this is a structural verbosity concern, not a functional bug.

## Test plan

- [x] Existing tests for `getGroupsByIds` and `getGamesByIds` already cover the >10 IDs (multi-batch) case and pass against the parallelized implementation
- [x] Existing `deleteAvatar` test covers multi-item deletion and passes against the parallelized implementation
- [x] `flutter test test/unit/` — 2869 passed, 0 failed
- [x] `flutter analyze` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)