### PR TITLE
Story 0.3.3: Gate app-store deploy jobs on Cloud Functions deploy success

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -118,7 +118,9 @@ jobs:
   # ─── Job 4: Deploy Android ───────────────────────────────────────────────────
   deploy_android:
     name: 🤖 Build & Upload Android (Play Internal)
-    needs: test
+    # Waits on deploy_functions so a failed backend deploy blocks the client
+    # release instead of racing it — see Story 0.3.3.
+    needs: [test, deploy_functions]
     runs-on: ubuntu-latest
 
     steps:
@@ -252,7 +254,9 @@ jobs:
   # ─── Job 5: Deploy iOS ───────────────────────────────────────────────────────
   deploy_ios:
     name: 🍎 Build & Upload iOS (TestFlight)
-    needs: test
+    # Waits on deploy_functions so a failed backend deploy blocks the client
+    # release instead of racing it — see Story 0.3.3.
+    needs: [test, deploy_functions]
     runs-on: macos-latest  # macos-latest must include Xcode 26+ (iOS 26 SDK required from April 28 2026 — ITMS-90725)
 
     steps:

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -171,7 +171,9 @@ jobs:
   # ─── Job 5: Promote Android ──────────────────────────────────────────────────
   promote_android:
     name: 🤖 Promote Android AAB → Play Production
-    needs: [guard, test, find_beta]
+    # Waits on deploy_functions so a failed backend deploy blocks the client
+    # release instead of racing it — see Story 0.3.3.
+    needs: [guard, test, find_beta, deploy_functions]
     runs-on: ubuntu-latest
 
     steps:
@@ -215,7 +217,9 @@ jobs:
   # ─── Job 6: Submit iOS for App Store Review ──────────────────────────────────
   submit_ios:
     name: 🍎 Submit iOS build for App Store review
-    needs: [guard, test, find_beta]
+    # Waits on deploy_functions so a failed backend deploy blocks the client
+    # release instead of racing it — see Story 0.3.3.
+    needs: [guard, test, find_beta, deploy_functions]
     # No Xcode needed — we call the App Store Connect REST API directly.
     # ubuntu-latest is 10× cheaper than macos-latest.
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `cd-beta.yml`: `deploy_android` and `deploy_ios` now `needs: [test, deploy_functions]` instead of just `test`.
- `cd-production.yml`: `promote_android` and `submit_ios` now `needs: [guard, test, find_beta, deploy_functions]` instead of `[guard, test, find_beta]`.

Previously these jobs ran in parallel with `deploy_functions` — if the Cloud Functions/Firestore deploy failed, the mobile release still shipped. This was most severe in production, where `promote_android` uses `status: completed` and would push the Android build live to all users even if the backend deploy failed in the same run.

Closes #888 (filed under Epic 0, #28).

## Test plan
- [x] `yaml.safe_load` on both workflow files — parses cleanly
- [ ] Verify next beta tag push: `deploy_android`/`deploy_ios` wait for `deploy_functions` to succeed before starting
- [ ] Verify next production tag push: `promote_android`/`submit_ios` wait for `deploy_functions` to succeed before starting