### PR TITLE
Story 35.3b: Games + Championships BlocBuilder/BlocConsumer scoping

### DIFF
--- a/lib/features/championships/presentation/pages/championship_detail_page.dart
+++ b/lib/features/championships/presentation/pages/championship_detail_page.dart
@@ -291,19 +291,20 @@ class _ChampionshipDetailView extends StatelessWidget {
               );
             }
           },
-          child: BlocBuilder<TeamRegistrationBloc, TeamRegistrationState>(
-            builder: (builderCtx, state) => AlertDialog(
+          child: BlocSelector<TeamRegistrationBloc, TeamRegistrationState, bool>(
+            selector: (state) => state is TeamRegistrationSubmitting,
+            builder: (builderCtx, isSubmitting) => AlertDialog(
               title: Text(l10n.leaveTeamConfirmTitle),
               content: Text(l10n.leaveTeamConfirmBody),
               actions: [
                 TextButton(
-                  onPressed: state is TeamRegistrationSubmitting
+                  onPressed: isSubmitting
                       ? null
                       : () => Navigator.of(dialogCtx).pop(),
                   child: Text(l10n.cancel),
                 ),
                 TextButton(
-                  onPressed: state is TeamRegistrationSubmitting
+                  onPressed: isSubmitting
                       ? null
                       : () => leaveBloc.add(
                             LeaveTeam(
@@ -313,7 +314,7 @@ class _ChampionshipDetailView extends StatelessWidget {
                           ),
                   style:
                       TextButton.styleFrom(foregroundColor: AppColors.danger),
-                  child: state is TeamRegistrationSubmitting
+                  child: isSubmitting
                       ? const SizedBox(
                           height: 16,
                           width: 16,
@@ -1797,6 +1798,12 @@ class _DecisionSheet extends StatefulWidget {
   State<_DecisionSheet> createState() => _DecisionSheetState();
 }
 
+bool _isDecidingOf(AdminPanelState state) =>
+    state is AdminPanelLoaded && state.isDeciding;
+
+String? _decisionErrorOf(AdminPanelState state) =>
+    state is AdminPanelLoaded ? state.decisionError : null;
+
 class _DecisionSheetState extends State<_DecisionSheet> {
   String _decision = 'cancel';
   String? _winnerId;
@@ -1942,11 +1949,12 @@ class _DecisionSheetState extends State<_DecisionSheet> {
           ],
           const SizedBox(height: AppSpacing.lg),
           BlocBuilder<AdminPanelBloc, AdminPanelState>(
+            buildWhen: (previous, current) =>
+                _isDecidingOf(previous) != _isDecidingOf(current) ||
+                _decisionErrorOf(previous) != _decisionErrorOf(current),
             builder: (context, state) {
-              final isDeciding =
-                  state is AdminPanelLoaded && state.isDeciding;
-              final serverError =
-                  state is AdminPanelLoaded ? state.decisionError : null;
+              final isDeciding = _isDecidingOf(state);
+              final serverError = _decisionErrorOf(state);
 
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/championships/presentation/pages/create_championship_page.dart
+++ b/lib/features/championships/presentation/pages/create_championship_page.dart
@@ -264,9 +264,10 @@ class _CreateChampionshipViewState extends State<_CreateChampionshipView> {
               const SizedBox(height: AppSpacing.xxl),
 
               // Submit
-              BlocBuilder<ChampionshipCreationBloc, ChampionshipCreationState>(
-                builder: (context, state) {
-                  final isSubmitting = state is ChampionshipCreationSubmitting;
+              BlocSelector<ChampionshipCreationBloc, ChampionshipCreationState,
+                  bool>(
+                selector: (state) => state is ChampionshipCreationSubmitting,
+                builder: (context, isSubmitting) {
                   return FilledButton(
                     onPressed: isSubmitting ? null : () => _submit(context),
                     child: isSubmitting

--- a/lib/features/championships/presentation/widgets/create_team_bottom_sheet.dart
+++ b/lib/features/championships/presentation/widgets/create_team_bottom_sheet.dart
@@ -143,10 +143,11 @@ class _CreateTeamBottomSheetState extends State<CreateTeamBottomSheet> {
                 const SizedBox(height: AppSpacing.xxl),
 
                 // Submit button
-                BlocBuilder<PartnerPickerBloc, PartnerPickerState>(
-                  builder: (context, partnerState) {
-                    final hasPartner = partnerState is PartnerPickerLoaded &&
-                        partnerState.selectedPartnerId != null;
+                BlocSelector<PartnerPickerBloc, PartnerPickerState, bool>(
+                  selector: (partnerState) =>
+                      partnerState is PartnerPickerLoaded &&
+                      partnerState.selectedPartnerId != null,
+                  builder: (context, hasPartner) {
                     return FilledButton(
                       onPressed: hasPartner ? _submit : null,
                       child: Text(l10n.registerTeam),

--- a/lib/features/games/presentation/pages/game_details_page.dart
+++ b/lib/features/games/presentation/pages/game_details_page.dart
@@ -1,5 +1,6 @@
 // Game details page displaying game information and allowing RSVP actions.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/presentation/widgets/user_avatar.dart';
@@ -395,13 +396,20 @@ class _PlayersCard extends StatelessWidget {
         ? authState.user.uid
         : null;
 
+    Map<String, dynamic> playersOf(GameDetailsState state) =>
+        (state is GameDetailsLoaded)
+        ? state.players
+        : (state is GameDetailsOperationInProgress)
+        ? state.players
+        : <String, dynamic>{};
+
     return BlocBuilder<GameDetailsBloc, GameDetailsState>(
+      buildWhen: (previous, current) =>
+          !mapEquals(playersOf(previous), playersOf(current)) ||
+          (previous is GameDetailsOperationInProgress) !=
+              (current is GameDetailsOperationInProgress),
       builder: (context, state) {
-        final players = (state is GameDetailsLoaded)
-            ? state.players
-            : (state is GameDetailsOperationInProgress)
-            ? state.players
-            : <String, dynamic>{};
+        final players = playersOf(state);
         final isOperationInProgress = state is GameDetailsOperationInProgress;
 
         final isCreator =


### PR DESCRIPTION
## Summary

Part of Story #880 (35.3: BLoC & widget rebuild scoping), split into 4 PRs by feature area (A merged as #898). This PR covers the **Games + Championships** areas.

Audited all 21 unscoped `BlocBuilder`/`BlocConsumer` sites flagged by the scan in `lib/features/games/` and `lib/features/championships/`, classifying each into one of two buckets:

- **Genuine candidate**: a nested/narrow builder deriving a strict subset of a larger state's fields, ignoring other independently-changing fields on the same state class.
- **Category 1 (left unchanged)**: a page/section-root switch across a sealed state hierarchy (Loading/Loaded/Error/etc.) where every state reaching the builder already carries meaningfully different content. `flutter_bloc`'s `emit()` already skips no-op state transitions via `Equatable`, so `buildWhen` provides no real benefit here — adding it would just be noise.

## Genuine fixes applied (5)

- **`game_details_page.dart`** — `_PlayersCard`'s nested `BlocBuilder<GameDetailsBloc,_>` now has a `buildWhen` comparing the derived `players` map (via `mapEquals`) + `isOperationInProgress`, so it skips rebuilding when only `playerEloUpdates` changes.
- **`championship_detail_page.dart`** — leave-team confirmation dialog: `BlocBuilder` → `BlocSelector<..., bool>` selecting `state is TeamRegistrationSubmitting`.
- **`championship_detail_page.dart`** — `_DecisionSheet` submit button: added `buildWhen` comparing only `isDeciding`/`decisionError`, ignoring 8 other independent fields on `AdminPanelLoaded` (`matches`, `isStarting`, `startError`, `matchesGenerated`, `isCompleting`, `completeError`, `isCompleted`, `isEditing`, `editError`).
- **`create_championship_page.dart`** — submit button: `BlocBuilder` → `BlocSelector<..., bool>` selecting `state is ChampionshipCreationSubmitting`.
- **`create_team_bottom_sheet.dart`** — register button: `BlocBuilder` → `BlocSelector<..., bool>` selecting `hasPartner`, ignoring the `friends` list.

## Sites reviewed and left unchanged (16, Category 1)

`score_entry_page.dart`, `games_list_page.dart`, `game_history_screen.dart`, `record_results_page.dart`, `my_games_page.dart`, `pending_game_invitations_page.dart`, `game_details_page.dart` (outer body builder), `invite_guest_players_sheet.dart`, `game_chat_section.dart`, `match_detail_page.dart`, `championship_detail_page.dart` (AdminPanel `BlocConsumer`), `championship_registration_page.dart`, `match_chat_section.dart`, `create_team_bottom_sheet.dart` (partner-list builder), `match_verification_widget.dart`, `match_result_entry_widget.dart`.

`game_details_page.dart`'s outer `BlocBuilder` in particular would require restructuring `_RsvpButtons`/`_VerificationSection` to independently subscribe to `GameDetailsBloc` for a narrower field — judged too invasive for this PR; flagged as a possible future follow-up, not filed as a story since it's speculative.

## Follow-up filed separately

Story #900 (35.3.1): `games_list_page.dart`'s `_buildLoadedState` uses an eager `SingleChildScrollView` + `Column` + `.map()` for a variable-length activity list — same anti-pattern as this story's `ListView` issue but a different widget shape, not caught by that scan. Not fixed here to avoid scope creep.

## Test plan

- [x] `flutter analyze` — 0 issues (whole project)
- [x] Widget tests for the 3 modified pages (`game_details_page_test.dart`, `championship_detail_page_test.dart`, `create_championship_page_test.dart`) — 37/37 passed
- [x] Full suite `flutter test test/unit/ test/widget/` — 3819 passed, 3 skipped (pre-existing), 0 failed
- [x] No visual/behavioral changes — all edits are rebuild-scoping only