### PR TITLE
Story 0.3.6: Migrate TestFlight upload from altool --upload-app to --upload-package

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -4,6 +4,9 @@ name: CD — Beta (TestFlight + Play Internal Track)
 # Builds and uploads the prod flavor to:
 #   - Google Play Internal Testing track (Android)
 #   - TestFlight via App Store Connect (iOS)
+#
+# Required secret (Story 0.3.6): ASC_APPLE_APP_ID — numeric app ID from App
+# Store Connect, needed by `altool --upload-package` (also used by cd-production.yml).
 on:
   push:
     tags:
@@ -423,6 +426,7 @@ jobs:
         run: |
           # Strip beta suffix for iOS: 0.4.0-beta12 → 0.4.0 (CFBundleShortVersionString must be numeric X.Y.Z)
           IOS_VERSION=$(echo "${{ env.VERSION_NAME }}" | sed 's/-beta[0-9]*//')
+          echo "IOS_VERSION=$IOS_VERSION" >> $GITHUB_ENV
           flutter build ipa --release --flavor prod \
             -t lib/main_prod.dart \
             --build-name=$IOS_VERSION \
@@ -430,10 +434,19 @@ jobs:
             --export-options-plist=ios/ExportOptions.plist
 
       - name: 🚀 Upload IPA to TestFlight
+        # --upload-app is deprecated by Apple in favor of --upload-package (Story
+        # 0.3.6) — Apple's own altool man page marks --upload-app as
+        # "[DEPRECATED use --upload-package instead]", and Xcode 26 has had
+        # bugs mis-selecting the target app under --upload-app for accounts
+        # with multiple similar bundle IDs. --upload-package requires the
+        # app/build identifiers explicitly instead of inferring them.
         run: |
-          xcrun altool --upload-app \
+          xcrun altool --upload-package "$(find build/ios/ipa -name '*.ipa' | head -1)" \
             --type ios \
-            -f "$(find build/ios/ipa -name '*.ipa' | head -1)" \
+            --apple-id "${{ secrets.ASC_APPLE_APP_ID }}" \
+            --bundle-id org.gatherli.app \
+            --bundle-version "${{ env.BUILD_NUMBER }}" \
+            --bundle-short-version-string "${{ env.IOS_VERSION }}" \
             --apiKey "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}" \
             --apiIssuer "${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}"
 


### PR DESCRIPTION
## Summary
Apple's own `altool` man page marks `--upload-app` as `[DEPRECATED use --upload-package instead]`. There are also active, reported bugs in Xcode 26 where `--upload-app` mis-selects the target app for accounts with multiple similar bundle IDs — relevant here since `deploy_ios` in `cd-beta.yml` pins `xcode-version: 'latest-stable'`, which now resolves to Xcode 26.

Changes:
- `deploy_ios` in `cd-beta.yml` now uses `xcrun altool --upload-package` with the required app/build identifiers (`--apple-id`, `--bundle-id`, `--bundle-version`, `--bundle-short-version-string`) instead of letting `--upload-app` infer them.
- Exports `IOS_VERSION` via `$GITHUB_ENV` in the build step so it's available in the separate upload step.
- Keeps the existing `--apiKey`/`--apiIssuer` auth unchanged.
- Adds the `ASC_APPLE_APP_ID` secret requirement (already used by `cd-production.yml`'s App Store submission script) — documented in the workflow header.
- Omits `--asc-public-id`: Apple's docs tie it specifically to username/password auth for multi-provider accounts, which doesn't apply here (this pipeline uses API key auth).

Closes #891 (filed under Epic 0, #28).

## ⚠️ Cannot be fully verified from this environment
I don't have access to real Apple Developer credentials or App Store Connect to test an actual upload. The parameter set follows Apple's documented `--upload-package` syntax, but there's inherent risk that a subtly wrong parameter (e.g. if `--asc-public-id` turns out to be required after all) could break the entire iOS beta pipeline. **Recommend watching the very next beta tag push closely** and being ready to revert if the upload step fails.

## Test plan
- [x] `yaml.safe_load` on `cd-beta.yml` — parses cleanly
- [x] Researched current Apple documentation (altool man page, App Store Connect help) confirming `--upload-app` deprecation and `--upload-package` required parameters
- [ ] Verify the next beta tag push actually uploads successfully to TestFlight
- [ ] Confirm `ASC_APPLE_APP_ID` secret is set and accessible to `cd-beta.yml` (same secrets store as `cd-production.yml`, not environment-scoped, but worth a final check)