### PR TITLE
Story 0.3.7 & 0.3.8: CD pipeline hygiene cleanup

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -26,8 +26,9 @@ jobs:
       - name: 🛡️ Verify tag is on main branch
         # Prevents accidental beta releases from feature branches reaching
         # TestFlight and the Play Store internal track.
+        # No extra fetch needed — fetch-depth: 0 above already pulled full
+        # history for all branches, including origin/main.
         run: |
-          git fetch origin main --depth=50
           git merge-base --is-ancestor HEAD origin/main \
             || (echo "❌ ERROR: This tag does not point to a commit on main. Beta deploy aborted." && exit 1)
           echo "✅ Tag is on main — proceeding with beta deploy"
@@ -248,6 +249,10 @@ jobs:
       - name: 🧹 Clean up Google Play service account key
         if: always()
         run: rm -f service-account.json
+
+      - name: 🧹 Clean up Android release keystore
+        if: always()
+        run: rm -f android/app/release.jks
 
   # ─── Job 5: Deploy iOS ───────────────────────────────────────────────────────
   deploy_ios:

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -33,8 +33,9 @@ jobs:
         # Prevents accidental production releases from feature or hotfix branches.
         # Play Store production releases go live immediately; App Store submissions
         # enter Apple review — both are hard to reverse once triggered.
+        # No extra fetch needed — fetch-depth: 0 above already pulled full
+        # history for all branches, including origin/main.
         run: |
-          git fetch origin main --depth=50
           git merge-base --is-ancestor HEAD origin/main \
             || (echo "❌ ERROR: This tag does not point to a commit on main. Production deploy aborted." && exit 1)
           echo "✅ Tag is on main — proceeding with production deploy"


### PR DESCRIPTION
## Summary
Two small, low-risk cleanups found during the CD pipeline review:

- **0.3.7**: `deploy_android` in `cd-beta.yml` decodes the signing keystore to `android/app/release.jks` but never removes it, unlike `service-account.json` in the same job which has an explicit `if: always()` cleanup step. Added a matching cleanup step for the keystore.
- **0.3.8**: The `guard` job in both `cd-beta.yml` and `cd-production.yml` checks out with `fetch-depth: 0` (full history for all branches) and then runs a redundant `git fetch origin main --depth=50` before the ancestor check — a no-op since the history is already fully fetched. Removed it from both files.

Closes #892, #893 (filed under Epic 0, #28).

## Test plan
- [x] `yaml.safe_load` on both workflow files — parses cleanly
- [ ] Verify next beta tag push: `deploy_android` still succeeds and the keystore is gone from the job's workspace afterward
- [ ] Verify next beta/production tag push: the branch guard still correctly blocks tags not on `main`