### PR TITLE
Story 35.3c: Profile + Training BlocBuilder/BlocConsumer scoping

### DIFF
--- a/lib/features/profile/presentation/pages/full_elo_history_page.dart
+++ b/lib/features/profile/presentation/pages/full_elo_history_page.dart
@@ -4,7 +4,9 @@ import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/theme/app_colors.dart';
 import 'package:play_with_me/core/theme/play_with_me_app_bar.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/data/models/best_elo_record.dart';
 import 'package:play_with_me/core/data/models/rating_history_entry.dart';
+import 'package:play_with_me/core/domain/entities/time_period.dart';
 import 'package:play_with_me/core/services/service_locator.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/elo_history/elo_history_bloc.dart';
@@ -13,6 +15,15 @@ import 'package:play_with_me/features/profile/presentation/bloc/elo_history/elo_
 import 'package:play_with_me/features/profile/presentation/widgets/best_elo_highlight_card.dart';
 import 'package:play_with_me/features/profile/presentation/widgets/time_period_selector.dart';
 import 'package:intl/intl.dart';
+
+DateTime? _filterStartDateOf(EloHistoryState state) =>
+    state is EloHistoryLoaded ? state.filterStartDate : null;
+
+TimePeriod? _selectedPeriodOf(EloHistoryState state) =>
+    state is EloHistoryLoaded ? state.selectedPeriod : null;
+
+BestEloRecord? _bestEloInPeriodOf(EloHistoryState state) =>
+    state is EloHistoryLoaded ? state.bestEloInPeriod : null;
 
 class FullEloHistoryPage extends StatelessWidget {
   final String userId;
@@ -31,6 +42,9 @@ class FullEloHistoryPage extends StatelessWidget {
           title: 'ELO History',
           extraActions: [
             BlocBuilder<EloHistoryBloc, EloHistoryState>(
+              buildWhen: (previous, current) =>
+                  previous.runtimeType != current.runtimeType ||
+                  _filterStartDateOf(previous) != _filterStartDateOf(current),
               builder: (context, state) {
                 if (state is! EloHistoryLoaded) return const SizedBox.shrink();
 
@@ -208,6 +222,8 @@ class FullEloHistoryPage extends StatelessWidget {
 
         // Time Period Selector (Story 302.3)
         BlocBuilder<EloHistoryBloc, EloHistoryState>(
+          buildWhen: (previous, current) =>
+              _selectedPeriodOf(previous) != _selectedPeriodOf(current),
           builder: (context, state) {
             if (state is! EloHistoryLoaded) return const SizedBox.shrink();
 
@@ -227,6 +243,9 @@ class FullEloHistoryPage extends StatelessWidget {
 
         // Best ELO Highlight Card (Story 302.6)
         BlocBuilder<EloHistoryBloc, EloHistoryState>(
+          buildWhen: (previous, current) =>
+              _bestEloInPeriodOf(previous) != _bestEloInPeriodOf(current) ||
+              _selectedPeriodOf(previous) != _selectedPeriodOf(current),
           builder: (context, state) {
             if (state is! EloHistoryLoaded) return const SizedBox.shrink();
 

--- a/lib/features/profile/presentation/widgets/momentum_consistency_card.dart
+++ b/lib/features/profile/presentation/widgets/momentum_consistency_card.dart
@@ -1,4 +1,5 @@
 // Momentum and consistency card showing streak and monthly improvement.
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:play_with_me/core/theme/app_spacing.dart';
 import 'package:play_with_me/core/theme/app_text_styles.dart';
@@ -108,6 +109,18 @@ class MomentumConsistencyCard extends StatelessWidget {
             ),
             // Period selector + chart + best ELO — white card (Story 302.3/4/6)
             BlocBuilder<EloHistoryBloc, EloHistoryState>(
+              buildWhen: (previous, current) {
+                if (previous is! EloHistoryLoaded ||
+                    current is! EloHistoryLoaded) {
+                  return true;
+                }
+                return previous.selectedPeriod != current.selectedPeriod ||
+                    previous.bestEloInPeriod != current.bestEloInPeriod ||
+                    !listEquals(
+                      previous.filteredHistory,
+                      current.filteredHistory,
+                    );
+              },
               builder: (context, state) {
                 if (state is! EloHistoryLoaded) return const SizedBox.shrink();
 

--- a/lib/features/training/presentation/pages/training_session_creation_page.dart
+++ b/lib/features/training/presentation/pages/training_session_creation_page.dart
@@ -456,14 +456,13 @@ class _TrainingSessionCreationPageState
                   return Center(child: Text(l10n.pleaseLogInToCreateTraining));
                 }
 
-                return BlocBuilder<
+                return BlocSelector<
                   TrainingSessionCreationBloc,
-                  TrainingSessionCreationState
+                  TrainingSessionCreationState,
+                  bool
                 >(
-                  builder: (context, state) {
-                    final isLoading =
-                        state is TrainingSessionCreationSubmitting;
-
+                  selector: (state) => state is TrainingSessionCreationSubmitting,
+                  builder: (context, isLoading) {
                     return SingleChildScrollView(
                       padding: const EdgeInsets.all(16),
                       child: Form(

--- a/lib/features/training/presentation/pages/training_session_details_page.dart
+++ b/lib/features/training/presentation/pages/training_session_details_page.dart
@@ -139,6 +139,9 @@ class _TrainingSessionDetailsPageState
                         Navigator.of(context).pop();
                       }
                     },
+                    buildWhen: (previous, current) =>
+                        (previous is CancellingSession) !=
+                        (current is CancellingSession),
                     builder: (context, state) {
                       final isCancelling = state is CancellingSession;
                       return PopupMenuButton<String>(
@@ -686,6 +689,11 @@ class _TrainingSessionDetailsPageState
             SnackBar(content: Text(state.message), backgroundColor: AppColors.danger),
           );
         }
+      },
+      buildWhen: (previous, current) {
+        bool isLoadingOf(TrainingSessionParticipationState s) =>
+            s is JoiningSession || s is LeavingSession;
+        return isLoadingOf(previous) != isLoadingOf(current);
       },
       builder: (context, state) {
         final l10n = AppLocalizations.of(context)!;


### PR DESCRIPTION
## Summary

Part of Story 35.3 (#880), PR C of 4 (A: `ListView.builder` #898, B: Games+Championships #901, C: this PR, D: Friends+Auth+Invitations+app-root — pending).

Audited all 19 unscoped `BlocBuilder`/`BlocConsumer` sites in `lib/features/profile` and `lib/features/training`, applying the same classification used in PR B: only add `buildWhen`/`BlocSelector` where a builder derives a **narrow subset** of a larger state's fields, ignoring other independently-changing fields on the same state. Page-root builders that switch on the full sealed-state variant (freezed `.when()` or exhaustive `is` checks covering nearly all fields) get zero benefit from `buildWhen` — `flutter_bloc`'s `Equatable`-based `emit()` already dedupes those — and were left unchanged.

**Genuine fixes (7):**
- `full_elo_history_page.dart` — filter icon `buildWhen`, period selector `buildWhen`, best-ELO highlight `buildWhen`
- `momentum_consistency_card.dart` — ELO progress card `buildWhen` on `selectedPeriod`/`bestEloInPeriod`/`filteredHistory`
- `training_session_details_page.dart` — cancel menu button `buildWhen`, join/leave FAB `buildWhen`
- `training_session_creation_page.dart` — form body converted to `BlocSelector<bool>` on submitting state

**Left unchanged (Category 1, 8 sites)** — page-root full-variant switches: `email_verification_page.dart`, `partner_detail_page.dart`, `profile_edit_page.dart` (2 builders), `head_to_head_page.dart`, `avatar_upload_widget.dart`, `training_session_feedback_page.dart`, `exercise_list_widget.dart`, `feedback_display_widget.dart`.

**Bug caught during verification:** the filter-icon `buildWhen` compared a derived value (`filterStartDate`) that resolves to `null` both pre-load and post-load-unfiltered, so the Initial→Loaded transition never triggered a rebuild — the icon stayed permanently hidden. Fixed by OR-ing in a `previous.runtimeType != current.runtimeType` check.

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/unit/ test/widget/` — 3819 passed, 3 skipped, 0 failed
- [x] Verified `full_elo_history_page_test.dart` filter-icon regression fix specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)