### PR TITLE
Story 35.3d: Friends + Auth + Invitations + app-root BlocBuilder/Consumer scoping

### DIFF
--- a/lib/app/play_with_me_app.dart
+++ b/lib/app/play_with_me_app.dart
@@ -244,43 +244,42 @@ class PlayWithMeApp extends StatelessWidget {
             },
           ),
         ],
-        child: BlocBuilder<LocalePreferencesBloc, LocalePreferencesState>(
-          builder: (context, localeState) {
-            // Get the current locale from preferences or use default
-            Locale currentLocale = const Locale('en');
-            if (localeState is LocalePreferencesLoaded) {
-              currentLocale = localeState.preferences.locale;
-            }
-
-            return MaterialApp(
-              navigatorKey: PlayWithMeApp.navigatorKey,
-              debugShowCheckedModeBanner: false,
-              title: 'Gatherli${EnvironmentConfig.appSuffix}',
-              theme: AppTheme.light,
-              locale: currentLocale,
-              supportedLocales: LocalePreferencesEntity.supportedLocales,
-              localizationsDelegates: const [
-                AppLocalizations.delegate,
-                GlobalMaterialLocalizations.delegate,
-                GlobalWidgetsLocalizations.delegate,
-                GlobalCupertinoLocalizations.delegate,
-              ],
-              home: BlocBuilder<AuthenticationBloc, AuthenticationState>(
-                buildWhen: (prev, curr) => prev.runtimeType != curr.runtimeType,
-                builder: (context, authState) {
-                  if (authState is AuthenticationAuthenticated) {
-                    return const HomePage();
-                  } else if (authState is AuthenticationUnauthenticated) {
-                    return const LoginPage();
-                  } else {
-                    return const _SplashScreen();
-                  }
-                },
-              ),
-              onGenerateRoute: RouteGenerator.generateRoute,
-            );
-          },
-        ),
+        child:
+            BlocSelector<LocalePreferencesBloc, LocalePreferencesState, Locale>(
+              selector: (localeState) => localeState is LocalePreferencesLoaded
+                  ? localeState.preferences.locale
+                  : const Locale('en'),
+              builder: (context, currentLocale) {
+                return MaterialApp(
+                  navigatorKey: PlayWithMeApp.navigatorKey,
+                  debugShowCheckedModeBanner: false,
+                  title: 'Gatherli${EnvironmentConfig.appSuffix}',
+                  theme: AppTheme.light,
+                  locale: currentLocale,
+                  supportedLocales: LocalePreferencesEntity.supportedLocales,
+                  localizationsDelegates: const [
+                    AppLocalizations.delegate,
+                    GlobalMaterialLocalizations.delegate,
+                    GlobalWidgetsLocalizations.delegate,
+                    GlobalCupertinoLocalizations.delegate,
+                  ],
+                  home: BlocBuilder<AuthenticationBloc, AuthenticationState>(
+                    buildWhen: (prev, curr) =>
+                        prev.runtimeType != curr.runtimeType,
+                    builder: (context, authState) {
+                      if (authState is AuthenticationAuthenticated) {
+                        return const HomePage();
+                      } else if (authState is AuthenticationUnauthenticated) {
+                        return const LoginPage();
+                      } else {
+                        return const _SplashScreen();
+                      }
+                    },
+                  ),
+                  onGenerateRoute: RouteGenerator.generateRoute,
+                );
+              },
+            ),
       ),
     );
   }
@@ -633,11 +632,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
           ],
         ),
         bottomNavigationBar:
-            BlocBuilder<FriendRequestCountBloc, FriendRequestCountState>(
-              builder: (context, state) {
-                final count = state is FriendRequestCountLoaded
-                    ? state.count
-                    : 0;
+            BlocSelector<FriendRequestCountBloc, FriendRequestCountState, int>(
+              selector: (state) =>
+                  state is FriendRequestCountLoaded ? state.count : 0,
+              builder: (context, count) {
                 return GlobalBottomNavBar(
                   selectedIndex: _selectedIndex,
                   onTabSelected: _onItemTapped,
@@ -683,14 +681,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         onPressed: () async {
           await Navigator.push(
             context,
-            MaterialPageRoute(
-              builder: (_) => const CreateChampionshipPage(),
-            ),
+            MaterialPageRoute(builder: (_) => const CreateChampionshipPage()),
           );
           if (context.mounted) {
-            context
-                .read<ChampionshipListBloc>()
-                .add(const LoadChampionships());
+            context.read<ChampionshipListBloc>().add(const LoadChampionships());
           }
         },
         backgroundColor: AppColors.primary,
@@ -782,128 +776,135 @@ class _HomeTabState extends State<_HomeTab> {
                 child: SingleChildScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.only(top: 30, bottom: 20.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    // Stats section (ELO, Win Rate, Streak, Games Played)
-                    HomeStatsSection(
-                      user: statsState.user,
-                      ratingHistory: statsState.history,
-                    ),
-
-                    const SizedBox(height: 25),
-
-                    // Next Game section title
-                    Padding(
-                      padding: const EdgeInsets.only(left: 20.0, bottom: 15.0),
-                      child: Text(
-                        AppLocalizations.of(context)!.nextGame.toUpperCase(),
-                        style: AppTextStyles.sectionLabel,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Stats section (ELO, Win Rate, Streak, Games Played)
+                      HomeStatsSection(
+                        user: statsState.user,
+                        ratingHistory: statsState.history,
                       ),
-                    ),
 
-                    // Next Game Card
-                    StreamBuilder(
-                      stream: sl<GameRepository>().getNextGameForUser(
-                        authState.user.uid,
+                      const SizedBox(height: 25),
+
+                      // Next Game section title
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: 20.0,
+                          bottom: 15.0,
+                        ),
+                        child: Text(
+                          AppLocalizations.of(context)!.nextGame.toUpperCase(),
+                          style: AppTextStyles.sectionLabel,
+                        ),
                       ),
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState ==
-                                ConnectionState.waiting &&
-                            !snapshot.hasData) {
-                          return const SizedBox.shrink();
-                        }
 
-                        if (snapshot.hasError) {
-                          debugPrint(
-                            'NextGame stream error: ${snapshot.error}',
-                          );
-                        }
+                      // Next Game Card
+                      StreamBuilder(
+                        stream: sl<GameRepository>().getNextGameForUser(
+                          authState.user.uid,
+                        ),
+                        builder: (context, snapshot) {
+                          if (snapshot.connectionState ==
+                                  ConnectionState.waiting &&
+                              !snapshot.hasData) {
+                            return const SizedBox.shrink();
+                          }
 
-                        final nextGame = snapshot.data;
+                          if (snapshot.hasError) {
+                            debugPrint(
+                              'NextGame stream error: ${snapshot.error}',
+                            );
+                          }
 
-                        return NextGameCard(
-                          game: nextGame,
-                          userId: authState.user.uid,
-                          onTap: nextGame != null
-                              ? () {
-                                  final gameRepository = sl<GameRepository>();
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (newContext) =>
-                                          RepositoryProvider.value(
-                                            value: gameRepository,
-                                            child: GameDetailsPage(
-                                              gameId: nextGame.id,
+                          final nextGame = snapshot.data;
+
+                          return NextGameCard(
+                            game: nextGame,
+                            userId: authState.user.uid,
+                            onTap: nextGame != null
+                                ? () {
+                                    final gameRepository = sl<GameRepository>();
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (newContext) =>
+                                            RepositoryProvider.value(
+                                              value: gameRepository,
+                                              child: GameDetailsPage(
+                                                gameId: nextGame.id,
+                                              ),
                                             ),
-                                          ),
-                                    ),
-                                  );
-                                }
-                              : null,
-                        );
-                      },
-                    ),
-
-                    const SizedBox(height: 25),
-
-                    // Next Training Session section title
-                    Padding(
-                      padding: const EdgeInsets.only(left: 20.0, bottom: 15.0),
-                      child: Text(
-                        AppLocalizations.of(
-                          context,
-                        )!.nextTrainingSession.toUpperCase(),
-                        style: AppTextStyles.sectionLabel,
-                      ),
-                    ),
-
-                    // Next Training Session Card
-                    StreamBuilder(
-                      stream: sl<TrainingSessionRepository>()
-                          .getNextTrainingSessionForUser(authState.user.uid),
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState ==
-                                ConnectionState.waiting &&
-                            !snapshot.hasData) {
-                          return const SizedBox.shrink();
-                        }
-
-                        if (snapshot.hasError) {
-                          debugPrint(
-                            'NextTrainingSession stream error: ${snapshot.error}',
+                                      ),
+                                    );
+                                  }
+                                : null,
                           );
-                        }
+                        },
+                      ),
 
-                        final nextSession = snapshot.data;
+                      const SizedBox(height: 25),
 
-                        return NextTrainingSessionCard(
-                          session: nextSession,
-                          userId: authState.user.uid,
-                          onTap: nextSession != null
-                              ? () {
-                                  final trainingSessionRepository =
-                                      sl<TrainingSessionRepository>();
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (newContext) =>
-                                          RepositoryProvider.value(
-                                            value: trainingSessionRepository,
-                                            child: TrainingSessionDetailsPage(
-                                              trainingSessionId: nextSession.id,
+                      // Next Training Session section title
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          left: 20.0,
+                          bottom: 15.0,
+                        ),
+                        child: Text(
+                          AppLocalizations.of(
+                            context,
+                          )!.nextTrainingSession.toUpperCase(),
+                          style: AppTextStyles.sectionLabel,
+                        ),
+                      ),
+
+                      // Next Training Session Card
+                      StreamBuilder(
+                        stream: sl<TrainingSessionRepository>()
+                            .getNextTrainingSessionForUser(authState.user.uid),
+                        builder: (context, snapshot) {
+                          if (snapshot.connectionState ==
+                                  ConnectionState.waiting &&
+                              !snapshot.hasData) {
+                            return const SizedBox.shrink();
+                          }
+
+                          if (snapshot.hasError) {
+                            debugPrint(
+                              'NextTrainingSession stream error: ${snapshot.error}',
+                            );
+                          }
+
+                          final nextSession = snapshot.data;
+
+                          return NextTrainingSessionCard(
+                            session: nextSession,
+                            userId: authState.user.uid,
+                            onTap: nextSession != null
+                                ? () {
+                                    final trainingSessionRepository =
+                                        sl<TrainingSessionRepository>();
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (newContext) =>
+                                            RepositoryProvider.value(
+                                              value: trainingSessionRepository,
+                                              child: TrainingSessionDetailsPage(
+                                                trainingSessionId:
+                                                    nextSession.id,
+                                              ),
                                             ),
-                                          ),
-                                    ),
-                                  );
-                                }
-                              : null,
-                        );
-                      },
-                    ),
-                  ],
+                                      ),
+                                    );
+                                  }
+                                : null,
+                          );
+                        },
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            );
+              );
             }
 
             // Initial state

--- a/lib/core/theme/play_with_me_app_bar.dart
+++ b/lib/core/theme/play_with_me_app_bar.dart
@@ -42,7 +42,11 @@ class PlayWithMeAppBar {
       title: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.sports_volleyball, color: AppColors.secondary, size: 22),
+          const Icon(
+            Icons.sports_volleyball,
+            color: AppColors.secondary,
+            size: 22,
+          ),
           const SizedBox(width: 6),
           Flexible(
             child: Text(
@@ -80,13 +84,10 @@ class PlayWithMeAppBar {
 
     return [
       // Invitation badge (group invitations)
-      BlocBuilder<InvitationBloc, InvitationState>(
-        builder: (context, state) {
-          int pendingCount = 0;
-          if (state is InvitationsLoaded) {
-            pendingCount = state.invitations.length;
-          }
-
+      BlocSelector<InvitationBloc, InvitationState, int>(
+        selector: (state) =>
+            state is InvitationsLoaded ? state.invitations.length : 0,
+        builder: (context, pendingCount) {
           return Badge(
             isLabelVisible: pendingCount > 0,
             label: Text(pendingCount > 9 ? '9+' : '$pendingCount'),
@@ -121,20 +122,21 @@ class PlayWithMeAppBar {
           } catch (_) {}
           if (gameInvBloc == null) return const SizedBox.shrink();
 
-          return BlocBuilder<GameInvitationsBloc, GameInvitationsState>(
+          return BlocSelector<GameInvitationsBloc, GameInvitationsState, int>(
             bloc: gameInvBloc,
-            builder: (context, state) {
-              int pendingCount = 0;
+            selector: (state) {
               if (state is GameInvitationsLoaded) {
-                pendingCount = state.invitations.length;
+                return state.invitations.length;
               } else if (state is GameInvitationActionInFlight) {
-                pendingCount = state.invitations.length;
+                return state.invitations.length;
               } else if (state is GameInvitationActionSuccess) {
-                pendingCount = state.invitations.length;
+                return state.invitations.length;
               } else if (state is GameInvitationActionError) {
-                pendingCount = state.invitations.length;
+                return state.invitations.length;
               }
-
+              return 0;
+            },
+            builder: (context, pendingCount) {
               return Badge(
                 isLabelVisible: pendingCount > 0,
                 label: Text(pendingCount > 9 ? '9+' : '$pendingCount'),
@@ -145,10 +147,7 @@ class PlayWithMeAppBar {
                   color: Colors.white,
                 ),
                 child: IconButton(
-                  icon: const Icon(
-                    Icons.sports_volleyball_outlined,
-                    size: 22,
-                  ),
+                  icon: const Icon(Icons.sports_volleyball_outlined, size: 22),
                   visualDensity: VisualDensity.compact,
                   tooltip: l10n.gameInvitations,
                   onPressed: () async {

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -130,11 +130,12 @@ class _LoginPageState extends State<LoginPage> {
                     onFieldSubmitted: (_) => _submitLogin(),
                   ),
                   const SizedBox(height: AppSpacing.xl),
-                  BlocBuilder<LoginBloc, LoginState>(
-                    builder: (context, state) {
+                  BlocSelector<LoginBloc, LoginState, bool>(
+                    selector: (state) => state is LoginLoading,
+                    builder: (context, isLoading) {
                       return AuthButton(
                         text: l10n.login,
-                        isLoading: state is LoginLoading,
+                        isLoading: isLoading,
                         onPressed: _submitLogin,
                       );
                     },

--- a/lib/features/auth/presentation/pages/password_reset_page.dart
+++ b/lib/features/auth/presentation/pages/password_reset_page.dart
@@ -101,11 +101,12 @@ class _PasswordResetPageState extends State<PasswordResetPage> {
                   onFieldSubmitted: (_) => _submitPasswordReset(),
                 ),
                 const SizedBox(height: AppSpacing.xl),
-                BlocBuilder<PasswordResetBloc, PasswordResetState>(
-                  builder: (context, state) {
+                BlocSelector<PasswordResetBloc, PasswordResetState, bool>(
+                  selector: (state) => state is PasswordResetLoading,
+                  builder: (context, isLoading) {
                     return AuthButton(
                       text: l10n.sendResetEmail,
-                      isLoading: state is PasswordResetLoading,
+                      isLoading: isLoading,
                       onPressed: _submitPasswordReset,
                     );
                   },
@@ -140,7 +141,11 @@ class _PasswordResetPageState extends State<PasswordResetPage> {
       barrierDismissible: false,
       builder: (BuildContext dialogContext) {
         return AlertDialog(
-          icon: const Icon(Icons.check_circle, color: AppColors.success, size: 48),
+          icon: const Icon(
+            Icons.check_circle,
+            color: AppColors.success,
+            size: 48,
+          ),
           title: Text(l10n.emailSent),
           content: Column(
             mainAxisSize: MainAxisSize.min,

--- a/lib/features/auth/presentation/pages/registration_page.dart
+++ b/lib/features/auth/presentation/pages/registration_page.dart
@@ -318,11 +318,12 @@ class _RegistrationPageState extends State<RegistrationPage> {
                   onFieldSubmitted: (_) => _submitRegistration(),
                 ),
                 const SizedBox(height: AppSpacing.xl),
-                BlocBuilder<RegistrationBloc, RegistrationState>(
-                  builder: (context, state) {
+                BlocSelector<RegistrationBloc, RegistrationState, bool>(
+                  selector: (state) => state is RegistrationLoading,
+                  builder: (context, isLoading) {
                     return AuthButton(
                       text: l10n.createAccount,
-                      isLoading: state is RegistrationLoading,
+                      isLoading: isLoading,
                       onPressed: _submitRegistration,
                     );
                   },

--- a/lib/features/friends/presentation/pages/add_friend_page.dart
+++ b/lib/features/friends/presentation/pages/add_friend_page.dart
@@ -90,10 +90,9 @@ class _AddFriendPageState extends State<AddFriendPage> {
 
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: BlocBuilder<FriendBloc, FriendState>(
-        builder: (context, state) {
-          final isSearching = state is FriendSearchLoading;
-
+      child: BlocSelector<FriendBloc, FriendState, bool>(
+        selector: (state) => state is FriendSearchLoading,
+        builder: (context, isSearching) {
           return Row(
             children: [
               Expanded(
@@ -162,7 +161,10 @@ class _AddFriendPageState extends State<AddFriendPage> {
         state.whenOrNull(
           error: (message) {
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(message), backgroundColor: AppColors.danger),
+              SnackBar(
+                content: Text(message),
+                backgroundColor: AppColors.danger,
+              ),
             );
           },
           actionSuccess: (_) {

--- a/lib/features/friends/presentation/pages/my_community_page.dart
+++ b/lib/features/friends/presentation/pages/my_community_page.dart
@@ -92,11 +92,14 @@ class _MyCommunityPageContentState extends State<_MyCommunityPageContent>
                 unselectedLabelColor: AppColors.secondary,
                 tabs: [
                   Tab(height: 40, text: l10n.friends),
-                  BlocBuilder<FriendRequestCountBloc, FriendRequestCountState>(
-                    builder: (context, state) {
-                      final count = state is FriendRequestCountLoaded
-                          ? state.count
-                          : 0;
+                  BlocSelector<
+                    FriendRequestCountBloc,
+                    FriendRequestCountState,
+                    int
+                  >(
+                    selector: (state) =>
+                        state is FriendRequestCountLoaded ? state.count : 0,
+                    builder: (context, count) {
                       return Tab(
                         height: 40,
                         child: Row(

--- a/lib/features/friends/presentation/widgets/friend_search_bar.dart
+++ b/lib/features/friends/presentation/widgets/friend_search_bar.dart
@@ -55,10 +55,9 @@ class _FriendSearchBarState extends State<FriendSearchBar> {
 
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: BlocBuilder<FriendBloc, FriendState>(
-        builder: (context, state) {
-          final isSearching = state is FriendSearchLoading;
-
+      child: BlocSelector<FriendBloc, FriendState, bool>(
+        selector: (state) => state is FriendSearchLoading,
+        builder: (context, isSearching) {
           return Row(
             children: [
               Expanded(

--- a/lib/features/groups/presentation/pages/group_details_page.dart
+++ b/lib/features/groups/presentation/pages/group_details_page.dart
@@ -70,9 +70,9 @@ class GroupDetailsPage extends StatelessWidget {
         BlocProvider(create: (context) => sl<GroupInviteLinkBloc>()),
         BlocProvider(create: (context) => sl<GamesListBloc>()),
         BlocProvider(
-          create: (context) => NotificationBloc(
-            repository: sl<NotificationRepository>(),
-          )..add(const NotificationEvent.loadPreferences()),
+          create: (context) =>
+              NotificationBloc(repository: sl<NotificationRepository>())
+                ..add(const NotificationEvent.loadPreferences()),
         ),
       ],
       child: _GroupDetailsPageContent(
@@ -412,25 +412,25 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                       if (value == 'leave') {
                         _handleLeaveGroup(context, authState.user.uid);
                       } else if (value == 'mute' || value == 'unmute') {
-                        final notifState =
-                            context.read<NotificationBloc>().state;
+                        final notifState = context
+                            .read<NotificationBloc>()
+                            .state;
                         final isMuted = notifState.maybeWhen(
                           loaded: (prefs) =>
                               prefs.groupSpecific[widget.groupId] == false,
                           orElse: () => false,
                         );
                         context.read<NotificationBloc>().add(
-                              NotificationEvent.toggleGroupSpecific(
-                                groupId: widget.groupId,
-                                // If currently muted (enabled=false), unmute (enabled=true)
-                                enabled: isMuted,
-                              ),
-                            );
+                          NotificationEvent.toggleGroupSpecific(
+                            groupId: widget.groupId,
+                            // If currently muted (enabled=false), unmute (enabled=true)
+                            enabled: isMuted,
+                          ),
+                        );
                       }
                     },
                     itemBuilder: (context) {
-                      final notifState =
-                          context.read<NotificationBloc>().state;
+                      final notifState = context.read<NotificationBloc>().state;
                       final isMuted = notifState.maybeWhen(
                         loaded: (prefs) =>
                             prefs.groupSpecific[widget.groupId] == false,
@@ -471,7 +471,9 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                               Flexible(
                                 child: Text(
                                   l10n.leaveGroup,
-                                  style: const TextStyle(color: AppColors.danger),
+                                  style: const TextStyle(
+                                    color: AppColors.danger,
+                                  ),
                                 ),
                               ),
                             ],
@@ -587,6 +589,11 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
             _showErrorMessage(state.message);
           }
         },
+        // Only the "isGenerating" flag is used below (deep in itemBuilder),
+        // so ignore unrelated field changes on Generated/Error variants.
+        buildWhen: (previous, current) =>
+            (previous is GroupInviteLinkLoading) !=
+            (current is GroupInviteLinkLoading),
         builder: (context, inviteLinkState) {
           return BlocBuilder<GroupMemberBloc, GroupMemberState>(
             buildWhen: (prev, curr) => prev.runtimeType != curr.runtimeType,
@@ -613,17 +620,30 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                     if (index == 1) {
                       final l10n = AppLocalizations.of(context)!;
                       return AccentCard(
-                        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+                        margin: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 5,
+                        ),
                         onTap: () => _navigateToInvitePage(context),
                         child: Row(
                           children: [
                             CircleAvatar(
-                              backgroundColor: AppColors.secondary.withValues(alpha: 0.1),
-                              child: const Icon(Icons.person_add, color: AppColors.secondary),
+                              backgroundColor: AppColors.secondary.withValues(
+                                alpha: 0.1,
+                              ),
+                              child: const Icon(
+                                Icons.person_add,
+                                color: AppColors.secondary,
+                              ),
                             ),
                             const SizedBox(width: AppSpacing.md),
-                            Text(l10n.inviteMember,
-                              style: const TextStyle(color: AppColors.secondary, fontWeight: FontWeight.w500)),
+                            Text(
+                              l10n.inviteMember,
+                              style: const TextStyle(
+                                color: AppColors.secondary,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
                           ],
                         ),
                       );
@@ -633,19 +653,42 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                       final isGenerating =
                           inviteLinkState is GroupInviteLinkLoading;
                       return AccentCard(
-                        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
-                        onTap: isGenerating ? null : () => context.read<GroupInviteLinkBloc>().add(GenerateInvite(groupId: widget.groupId)),
+                        margin: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 5,
+                        ),
+                        onTap: isGenerating
+                            ? null
+                            : () => context.read<GroupInviteLinkBloc>().add(
+                                GenerateInvite(groupId: widget.groupId),
+                              ),
                         child: Row(
                           children: [
                             CircleAvatar(
-                              backgroundColor: AppColors.secondary.withValues(alpha: 0.1),
+                              backgroundColor: AppColors.secondary.withValues(
+                                alpha: 0.1,
+                              ),
                               child: isGenerating
-                                  ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
-                                  : const Icon(Icons.link, color: AppColors.secondary),
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(
+                                      Icons.link,
+                                      color: AppColors.secondary,
+                                    ),
                             ),
                             const SizedBox(width: AppSpacing.md),
-                            Text(l10n.inviteWithLink,
-                              style: const TextStyle(color: AppColors.secondary, fontWeight: FontWeight.w500)),
+                            Text(
+                              l10n.inviteWithLink,
+                              style: const TextStyle(
+                                color: AppColors.secondary,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
                           ],
                         ),
                       );
@@ -754,10 +797,11 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                             label: Text(l10n.createGame),
                           ),
                         ),
-                      const SizedBox(width: AppSpacing.md),
+                        const SizedBox(width: AppSpacing.md),
                         Expanded(
                           child: OutlinedButton.icon(
-                            onPressed: () => _navigateToTrainingCreation(context),
+                            onPressed: () =>
+                                _navigateToTrainingCreation(context),
                             icon: const Icon(Icons.fitness_center),
                             label: Text(l10n.createTraining),
                           ),
@@ -869,7 +913,9 @@ class _GroupDetailsPageContentState extends State<_GroupDetailsPageContent>
                                   .add(const LoadOlderActivities()),
                               style: OutlinedButton.styleFrom(
                                 foregroundColor: AppColors.secondary,
-                                side: const BorderSide(color: AppColors.secondary),
+                                side: const BorderSide(
+                                  color: AppColors.secondary,
+                                ),
                                 minimumSize: const Size(double.infinity, 44),
                               ),
                               child: Text(l10n.loadOlderActivities),

--- a/lib/features/invitations/presentation/pages/invite_registration_page.dart
+++ b/lib/features/invitations/presentation/pages/invite_registration_page.dart
@@ -361,15 +361,24 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
     );
   }
 
+  // Maps the submit-button-relevant states to a comparable key so buildWhen
+  // can ignore unrelated state changes that don't affect this button.
+  int _buttonStateKey(InviteRegistrationState state) {
+    if (state is InviteRegistrationJoiningGroup) return 2;
+    if (state is InviteRegistrationCreatingAccount) return 1;
+    return 0;
+  }
+
   Widget _buildSubmitButton(BuildContext blocContext, AppLocalizations l10n) {
     return BlocBuilder<InviteRegistrationBloc, InviteRegistrationState>(
+      buildWhen: (previous, current) =>
+          _buttonStateKey(previous) != _buttonStateKey(current),
       builder: (context, state) {
-        final isLoading =
-            state is InviteRegistrationCreatingAccount ||
-            state is InviteRegistrationJoiningGroup;
-        final buttonText = state is InviteRegistrationJoiningGroup
+        final buttonKey = _buttonStateKey(state);
+        final isLoading = buttonKey != 0;
+        final buttonText = buttonKey == 2
             ? l10n.accountCreatedJoiningGroup
-            : state is InviteRegistrationCreatingAccount
+            : buttonKey == 1
             ? l10n.creatingAccount
             : l10n.createAccountAndJoin;
 
@@ -411,17 +420,17 @@ class _InviteRegistrationPageState extends State<InviteRegistrationPage> {
     }
   }
 
-  void _onStateChange(
-    BuildContext context,
-    InviteRegistrationState state,
-  ) {
+  void _onStateChange(BuildContext context, InviteRegistrationState state) {
     final l10n = AppLocalizations.of(context)!;
 
     if (state is InviteRegistrationFailure) {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..showSnackBar(
-          SnackBar(content: Text(state.message), backgroundColor: AppColors.danger),
+          SnackBar(
+            content: Text(state.message),
+            backgroundColor: AppColors.danger,
+          ),
         );
     } else if (state is InviteRegistrationSuccess) {
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary

Part of Epic #877 (Performance Optimization), Story #880 (35.3), final PR (D of 4: A #898, B #901, C #904).

Converts `BlocBuilder`/`BlocConsumer` to `BlocSelector` or adds `buildWhen` for narrow-field derivations across Friends, Auth, Invitations, and app-root that were previously rebuilding on unrelated state changes:

- **`add_friend_page.dart` / `friend_search_bar.dart`**: search bar `isLoading` → `BlocSelector<bool>`
- **`my_community_page.dart`**: Requests tab badge count → `BlocSelector<int>`
- **`password_reset_page.dart` / `login_page.dart` / `registration_page.dart`**: submit button `isLoading` → `BlocSelector<bool>`
- **`invite_registration_page.dart`**: submit button derives both `isLoading` and `buttonText` from the same 2 variants — added `buildWhen` keyed by a `_buttonStateKey()` helper
- **`play_with_me_app.dart`**:
  - **Highest-impact fix in this story**: app-root `LocalePreferencesBloc` `BlocBuilder` wrapping the entire `MaterialApp` → `BlocSelector<Locale>`. Previously, toggling `hasUnsavedChanges` (used in profile locale editing) rebuilt the whole app tree.
  - Bottom-nav `FriendRequestCountBloc` badge → `BlocSelector<int>`
- **`play_with_me_app_bar.dart`**:
  - `InvitationBloc` mail badge → `BlocSelector<int>`
  - `GameInvitationsBloc` badge → `BlocSelector<int>` — this state class is **not Equatable-based**, so every emit was previously treated as different by `flutter_bloc`'s dedup; this fix has outsized value here
- **`group_details_page.dart`**: `GroupInviteLinkBloc` `BlocConsumer` (listener untouched) — added `buildWhen` scoped to `is GroupInviteLinkLoading`, matching the sole derived field (`isGenerating`) used in `itemBuilder`

Category 1 sites (full sealed-state-variant switches, e.g. `add_friend_page.dart`'s search-results `BlocConsumer`, `invite_onboarding_page.dart`, `pending_invitations_page.dart`, `join_group_confirmation_page.dart`, `play_with_me_app.dart`'s `AccountStatusBloc`, `group_details_page.dart`'s `GamesListBloc` activities builder) were reviewed and left unchanged per the Story 35.3 classification methodology established in PRs B/C — they get zero benefit since every state reaching the builder already renders a meaningfully different subtree.

Every new `buildWhen`/`BlocSelector` was checked against the PR C-discovered "runtimeType-transition" correctness bug (a derived value's unloaded-default coinciding with its loaded-default can silently suppress a necessary rebuild). All sites here are either plain booleans (state-identity comparisons, always safe) or integer-keyed helpers with a distinct default — none are affected.

**Flagged out-of-scope finding (not fixed here):** `group_details_page.dart`'s `_buildActivitiesTab` uses the same `SingleChildScrollView`+`Column`+`.map()` anti-pattern for a variable-length list that's already tracked as follow-up Story 35.3.1 (#900), currently scoped only to `games_list_page.dart`. This is a duplicate instance in a different file — recommend adding it to #900's scope.

## Test plan
- [x] `flutter analyze` — 0 issues on all 10 modified files
- [x] `flutter test test/unit/ test/widget/` — all 3823 tests pass