### PR TITLE
Story 35.3.1: Convert games_list_page.dart eager list to lazy ListView.builder

### DIFF
--- a/lib/features/games/presentation/pages/games_list_page.dart
+++ b/lib/features/games/presentation/pages/games_list_page.dart
@@ -84,33 +84,33 @@ class _GamesListPageContent extends StatelessWidget {
   }
 
   Widget _buildLoadedState(BuildContext context, GamesListLoaded state) {
+    final items = <Widget>[
+      if (state.upcomingActivities.isNotEmpty) ...[
+        _buildSectionHeader(context, 'Upcoming Activities'),
+        ...state.upcomingActivities.map(
+          (activity) =>
+              _buildActivityItem(context, activity, state.userId, false),
+        ),
+      ],
+      if (state.pastActivities.isNotEmpty) ...[
+        _buildSectionHeader(context, 'Past Activities'),
+        ...state.pastActivities.map(
+          (activity) =>
+              _buildActivityItem(context, activity, state.userId, true),
+        ),
+      ],
+    ];
+
     return RefreshIndicator(
       onRefresh: () async {
         context.read<GamesListBloc>().add(const RefreshGamesList());
         await Future.delayed(const Duration(milliseconds: 500));
       },
-      child: SingleChildScrollView(
+      child: ListView.builder(
         physics: const AlwaysScrollableScrollPhysics(),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (state.upcomingActivities.isNotEmpty) ...[
-              _buildSectionHeader(context, 'Upcoming Activities'),
-              ...state.upcomingActivities.map(
-                (activity) =>
-                    _buildActivityItem(context, activity, state.userId, false),
-              ),
-            ],
-            if (state.pastActivities.isNotEmpty) ...[
-              _buildSectionHeader(context, 'Past Activities'),
-              ...state.pastActivities.map(
-                (activity) =>
-                    _buildActivityItem(context, activity, state.userId, true),
-              ),
-            ],
-            const SizedBox(height: 80), // Space for FAB
-          ],
-        ),
+        padding: const EdgeInsets.only(bottom: 80), // Space for FAB
+        itemCount: items.length,
+        itemBuilder: (context, index) => items[index],
       ),
     );
   }


### PR DESCRIPTION
## Summary

Closes #900. Follow-up from Story #880 (35.3), found while auditing BlocBuilder scoping in the games feature.

- `games_list_page.dart`'s `_buildLoadedState` built `upcomingActivities`/`pastActivities` eagerly via `SingleChildScrollView` + `Column` + `.map()` — same performance concern as the `ListView(children:)` anti-pattern fixed in #880/PR #898, just a different widget shape (not caught by that story's grep scan).
- Converted to a flat `items` list (section headers + activity tiles) rendered via `ListView.builder`, following the same pattern used in PR #898 (`my_games_page.dart`, `friend_requests_list.dart`).
- Replaced the trailing `SizedBox(height: 80)` FAB-spacer with `ListView.builder`'s `padding: EdgeInsets.only(bottom: 80)` — same visual result.

**Note:** a duplicate instance of this same anti-pattern exists in `group_details_page.dart`'s `_buildActivitiesTab` (found during Story 35.3 PR D). It's out of scope for this issue as literally written and was not touched here — worth a separate follow-up if desired.

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/widget/features/games/presentation/pages/games_list_page_test.dart` — all 15 tests pass unchanged
- [x] `flutter test test/unit/ test/widget/` (full suite) — all 3823 tests pass