### PR TITLE
Story 35.4: Migrate StreamSubscription BLoCs to BaseBloc

### DIFF
--- a/lib/core/presentation/bloc/deep_link/deep_link_bloc.dart
+++ b/lib/core/presentation/bloc/deep_link/deep_link_bloc.dart
@@ -3,16 +3,16 @@ import 'dart:async';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_event.dart';
 import 'package:play_with_me/core/presentation/bloc/deep_link/deep_link_state.dart';
 import 'package:play_with_me/core/services/deep_link_service.dart';
 import 'package:play_with_me/core/services/pending_invite_storage.dart';
 
-class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
+class DeepLinkBloc extends BaseBloc<DeepLinkEvent, DeepLinkState> {
   final DeepLinkService _deepLinkService;
   final PendingInviteStorage _pendingInviteStorage;
   final FirebaseAnalytics _analytics;
-  StreamSubscription<String?>? _tokenSubscription;
 
   DeepLinkBloc({
     required DeepLinkService deepLinkService,
@@ -60,11 +60,13 @@ class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
 
   void _startLinkListener() {
     // Listen for foreground deep links
-    _tokenSubscription = _deepLinkService.inviteTokenStream.listen((token) {
-      if (token != null) {
-        add(InviteTokenReceived(token));
-      }
-    });
+    trackSubscription(
+      _deepLinkService.inviteTokenStream.listen((token) {
+        if (token != null) {
+          add(InviteTokenReceived(token));
+        }
+      }),
+    );
   }
 
   Future<void> _onInviteTokenReceived(
@@ -91,11 +93,5 @@ class DeepLinkBloc extends Bloc<DeepLinkEvent, DeepLinkState> {
     }
     await _pendingInviteStorage.clear();
     emit(const DeepLinkNoInvite());
-  }
-
-  @override
-  Future<void> close() {
-    _tokenSubscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/features/auth/presentation/bloc/authentication/authentication_bloc.dart
+++ b/lib/features/auth/presentation/bloc/authentication/authentication_bloc.dart
@@ -1,15 +1,13 @@
-import 'dart:async';
-
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/features/auth/domain/repositories/auth_repository.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_event.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 
 class AuthenticationBloc
-    extends Bloc<AuthenticationEvent, AuthenticationState> {
+    extends BaseBloc<AuthenticationEvent, AuthenticationState> {
   final AuthRepository _authRepository;
-  StreamSubscription<dynamic>? _userSubscription;
 
   AuthenticationBloc({required AuthRepository authRepository})
     : _authRepository = authRepository,
@@ -25,17 +23,21 @@ class AuthenticationBloc
   ) {
     debugPrint('🔐 AuthenticationBloc: Starting authentication monitoring');
 
-    _userSubscription = _authRepository.authStateChanges.listen(
-      (user) {
-        debugPrint(
-          '🔐 AuthenticationBloc: Auth state changed - user: ${user?.email ?? 'null'}',
-        );
-        add(AuthenticationUserChanged(user));
-      },
-      onError: (error) {
-        debugPrint('❌ AuthenticationBloc: Error in auth state stream: $error');
-        add(const AuthenticationUserChanged(null));
-      },
+    trackSubscription(
+      _authRepository.authStateChanges.listen(
+        (user) {
+          debugPrint(
+            '🔐 AuthenticationBloc: Auth state changed - user: ${user?.email ?? 'null'}',
+          );
+          add(AuthenticationUserChanged(user));
+        },
+        onError: (error) {
+          debugPrint(
+            '❌ AuthenticationBloc: Error in auth state stream: $error',
+          );
+          add(const AuthenticationUserChanged(null));
+        },
+      ),
     );
   }
 
@@ -67,12 +69,5 @@ class AuthenticationBloc
       // The auth state stream will handle the state change
       // We don't emit error states here as this is a global bloc
     }
-  }
-
-  @override
-  Future<void> close() {
-    _userSubscription?.cancel();
-    debugPrint('🔐 AuthenticationBloc: Closed and subscription cancelled');
-    return super.close();
   }
 }

--- a/lib/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart
+++ b/lib/features/championships/presentation/bloc/championship_detail/championship_detail_bloc.dart
@@ -4,13 +4,14 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
 
 import 'championship_detail_event.dart';
 import 'championship_detail_state.dart';
 
 class ChampionshipDetailBloc
-    extends Bloc<ChampionshipDetailEvent, ChampionshipDetailState> {
+    extends BaseBloc<ChampionshipDetailEvent, ChampionshipDetailState> {
   final ChampionshipRepository _repository;
   final UserRepository _userRepository;
   String? _championshipId;
@@ -64,6 +65,7 @@ class ChampionshipDetailBloc
       (user) => add(ChampionshipDetailUserUpdated(user?.gender?.name)),
       onError: (_) {},
     );
+    trackSubscription(_userSub!);
 
     _champSub = _repository
         .getChampionshipById(event.championshipId)
@@ -76,6 +78,7 @@ class ChampionshipDetailBloc
             add(ChampionshipDetailLoadError(msg));
           },
         );
+    trackSubscription(_champSub!);
 
     _standingsSub = _repository
         .getStandings(event.championshipId)
@@ -83,6 +86,7 @@ class ChampionshipDetailBloc
           (standings) => add(ChampionshipDetailStandingsUpdated(standings)),
           onError: (_) {}, // standings may not exist yet
         );
+    trackSubscription(_standingsSub!);
 
     _teamsSub = _repository
         .getTeams(event.championshipId)
@@ -90,6 +94,7 @@ class ChampionshipDetailBloc
           (teams) => add(ChampionshipDetailTeamsUpdated(teams)),
           onError: (_) {}, // no teams yet is normal
         );
+    trackSubscription(_teamsSub!);
 
     _allMatchesSub = _repository
         .getAllMatches(event.championshipId)
@@ -97,6 +102,7 @@ class ChampionshipDetailBloc
           (matches) => add(ChampionshipDetailAllMatchesUpdated(matches)),
           onError: (_) {}, // no matches yet is normal before championship starts
         );
+    trackSubscription(_allMatchesSub!);
   }
 
   void _onChampionshipUpdated(
@@ -228,16 +234,6 @@ class ChampionshipDetailBloc
           (matches) => add(ChampionshipDetailMatchesUpdated(matches)),
           onError: (_) {}, // empty rounds are normal before championship starts
         );
-  }
-
-  @override
-  Future<void> close() async {
-    await _champSub?.cancel();
-    await _standingsSub?.cancel();
-    await _teamsSub?.cancel();
-    await _matchesSub?.cancel();
-    await _allMatchesSub?.cancel();
-    await _userSub?.cancel();
-    return super.close();
+    trackSubscription(_matchesSub!);
   }
 }

--- a/lib/features/championships/presentation/bloc/championship_list/championship_list_bloc.dart
+++ b/lib/features/championships/presentation/bloc/championship_list/championship_list_bloc.dart
@@ -2,12 +2,13 @@
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/exceptions/repository_exceptions.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/features/championships/domain/repositories/championship_repository.dart';
 import 'championship_list_event.dart';
 import 'championship_list_state.dart';
 
 class ChampionshipListBloc
-    extends Bloc<ChampionshipListEvent, ChampionshipListState> {
+    extends BaseBloc<ChampionshipListEvent, ChampionshipListState> {
   final ChampionshipRepository _repository;
   StreamSubscription? _subscription;
 
@@ -37,6 +38,7 @@ class ChampionshipListBloc
         add(ChampionshipsLoadFailed(msg));
       },
     );
+    trackSubscription(_subscription!);
   }
 
   void _onUpdated(
@@ -68,11 +70,5 @@ class ChampionshipListBloc
       emit((state as ChampionshipListLoaded)
           .copyWith(activeFilter: event.status));
     }
-  }
-
-  @override
-  Future<void> close() async {
-    await _subscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/features/friends/presentation/bloc/friend_request_count_bloc.dart
+++ b/lib/features/friends/presentation/bloc/friend_request_count_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/repositories/friend_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'friend_request_count_event.dart';
 import 'friend_request_count_state.dart';
 
@@ -8,7 +9,7 @@ import 'friend_request_count_state.dart';
 /// This is a dedicated BLoC that only handles the real-time count of pending friend requests
 /// Separated from FriendBloc to avoid state conflicts and enable independent updates
 class FriendRequestCountBloc
-    extends Bloc<FriendRequestCountEvent, FriendRequestCountState> {
+    extends BaseBloc<FriendRequestCountEvent, FriendRequestCountState> {
   final FriendRepository _friendRepository;
   StreamSubscription<int>? _countSubscription;
 
@@ -56,11 +57,5 @@ class FriendRequestCountBloc
     await _countSubscription?.cancel();
     _countSubscription = null;
     emit(const FriendRequestCountState.initial());
-  }
-
-  @override
-  Future<void> close() {
-    _countSubscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/features/profile/presentation/bloc/email_verification/email_verification_bloc.dart
+++ b/lib/features/profile/presentation/bloc/email_verification/email_verification_bloc.dart
@@ -1,14 +1,13 @@
-import 'dart:async';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/features/auth/domain/repositories/auth_repository.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_event.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/email_verification/email_verification_state.dart';
 
 /// BLoC for managing email verification flow
 class EmailVerificationBloc
-    extends Bloc<EmailVerificationEvent, EmailVerificationState> {
+    extends BaseBloc<EmailVerificationEvent, EmailVerificationState> {
   final AuthRepository _authRepository;
   final UserRepository _userRepository;
 
@@ -17,9 +16,6 @@ class EmailVerificationBloc
 
   /// Track last sent time for cooldown
   DateTime? _lastSentAt;
-
-  /// Subscription to auth state changes
-  StreamSubscription<dynamic>? _authStateSubscription;
 
   EmailVerificationBloc({
     required AuthRepository authRepository,
@@ -34,16 +30,18 @@ class EmailVerificationBloc
     on<EmailVerificationAuthStateChanged>(_onAuthStateChanged);
 
     // Listen to auth state changes for real-time verification updates
-    _authStateSubscription = _authRepository.authStateChanges.listen((user) {
-      if (user != null && user.isEmailVerified) {
-        add(
-          EmailVerificationEvent.authStateChanged(
-            isVerified: true,
-            verifiedAt: user.lastSignInAt,
-          ),
-        );
-      }
-    });
+    trackSubscription(
+      _authRepository.authStateChanges.listen((user) {
+        if (user != null && user.isEmailVerified) {
+          add(
+            EmailVerificationEvent.authStateChanged(
+              isVerified: true,
+              verifiedAt: user.lastSignInAt,
+            ),
+          );
+        }
+      }),
+    );
   }
 
   Future<void> _onCheckStatus(
@@ -261,11 +259,5 @@ class EmailVerificationBloc
     final remaining = resendCooldownSeconds - elapsed;
 
     return remaining > 0 ? remaining : 0;
-  }
-
-  @override
-  Future<void> close() {
-    _authStateSubscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
+++ b/lib/features/profile/presentation/bloc/player_stats/player_stats_bloc.dart
@@ -5,12 +5,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:play_with_me/core/data/models/rating_history_entry.dart';
 import 'package:play_with_me/core/data/models/user_model.dart'; // Story 302.7
 import 'package:play_with_me/core/domain/repositories/user_repository.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/core/utils/performance_tracer.dart';
 
 import 'player_stats_event.dart';
 import 'player_stats_state.dart';
 
-class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
+class PlayerStatsBloc extends BaseBloc<PlayerStatsEvent, PlayerStatsState> {
   final UserRepository _userRepository;
   StreamSubscription? _userSubscription;
   // Story 34.3: subscribe to teammate stats subcollection stream
@@ -66,6 +67,7 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
                 debugPrint('PlayerStatsBloc: Error in user stream: $error');
               },
             );
+        trackSubscription(_userSubscription!);
 
         // Story 34.3: subscribe to teammate stats subcollection
         await _teammateStatsSubscription?.cancel();
@@ -81,6 +83,7 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
               onError: (e) =>
                   debugPrint('PlayerStatsBloc: teammate stats error: $e'),
             );
+        trackSubscription(_teammateStatsSubscription!);
       } else {
         // Story 302.7: Handle new users gracefully - they have no stats yet
         // Get current auth user data to create a minimal UserModel
@@ -117,6 +120,7 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
                 debugPrint('PlayerStatsBloc: Error in user stream: $error');
               },
             );
+        trackSubscription(_userSubscription!);
       }
     } catch (e) {
       emit(PlayerStatsError('Failed to load player stats: ${e.toString()}'));
@@ -207,12 +211,5 @@ class PlayerStatsBloc extends Bloc<PlayerStatsEvent, PlayerStatsState> {
       debugPrint('PlayerStatsBloc: Failed to load ranking: $e');
       emit(currentState.copyWith(rankingLoadFailed: true));
     }
-  }
-
-  @override
-  Future<void> close() {
-    _userSubscription?.cancel();
-    _teammateStatsSubscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/features/training/presentation/bloc/feedback/training_feedback_bloc.dart
+++ b/lib/features/training/presentation/bloc/feedback/training_feedback_bloc.dart
@@ -5,13 +5,14 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 
 import '../../../../../core/domain/repositories/training_feedback_repository.dart';
 import 'training_feedback_event.dart';
 import 'training_feedback_state.dart';
 
 class TrainingFeedbackBloc
-    extends Bloc<TrainingFeedbackEvent, TrainingFeedbackState> {
+    extends BaseBloc<TrainingFeedbackEvent, TrainingFeedbackState> {
   final TrainingFeedbackRepository _feedbackRepository;
   StreamSubscription? _aggregatedFeedbackSubscription;
 
@@ -106,6 +107,7 @@ class TrainingFeedbackBloc
               }
             },
           );
+      trackSubscription(_aggregatedFeedbackSubscription!);
     } catch (e) {
       emit(
         FeedbackError(
@@ -221,11 +223,6 @@ class TrainingFeedbackBloc
     }
   }
 
-  @override
-  Future<void> close() {
-    _aggregatedFeedbackSubscription?.cancel();
-    return super.close();
-  }
 }
 
 /// Internal event for aggregated feedback updates from stream

--- a/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart
+++ b/lib/features/training/presentation/bloc/training_session_participation/training_session_participation_bloc.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/presentation/bloc/base_bloc.dart';
 import 'package:play_with_me/core/utils/performance_tracer.dart';
 
 import '../../../../../core/data/models/training_session_participant_model.dart';
@@ -15,7 +16,7 @@ import 'training_session_participation_state.dart';
 
 class TrainingSessionParticipationBloc
     extends
-        Bloc<
+        BaseBloc<
           TrainingSessionParticipationEvent,
           TrainingSessionParticipationState
         > {
@@ -75,6 +76,7 @@ class TrainingSessionParticipationBloc
                   }
                 },
               );
+          trackSubscription(_participantsSubscription!);
         },
       );
     } catch (e) {
@@ -299,11 +301,6 @@ class TrainingSessionParticipationBloc
     return null;
   }
 
-  @override
-  Future<void> close() {
-    _participantsSubscription?.cancel();
-    return super.close();
-  }
 }
 
 // Internal events for stream handling


### PR DESCRIPTION
## Summary

Migrates the 9 BLoCs identified in #881 to extend `BaseBloc` instead of `Bloc`, so their `StreamSubscription`s are tracked via `trackSubscription()` and auto-cancelled on `close()`, eliminating hand-written `close()` overrides and reducing leak risk.

**BLoCs migrated:**
- `AuthenticationBloc`, `DeepLinkBloc` — simple 1:1 pattern (single subscription, assigned once)
- `PlayerStatsBloc`, `TrainingFeedbackBloc`, `TrainingSessionParticipationBloc`, `ChampionshipListBloc` — cancel-before-reassign pattern; kept the nullable subscription field(s) for that in-flight-replacement logic, with `trackSubscription()` layered on top as a close()-time safety net (double-cancelling an already-cancelled `StreamSubscription` is a no-op, so this is safe)
- `ChampionshipDetailBloc` — most complex: 6 independently-managed subscriptions (`_champSub`, `_standingsSub`, `_teamsSub`, `_matchesSub`, `_allMatchesSub`, `_userSub`)
- `EmailVerificationBloc` — single one-time constructor subscription; field removed entirely since there's no reassignment logic to preserve

**Notable finding (flagged, not fixed — out of scope for this story):** `FriendRequestCountBloc`'s `_countSubscription` field was already dead code before this change — it's declared and cancelled in `close()`/`_onStopListening()`, but never actually assigned, since the BLoC uses `emit.forEach` internally rather than manual `.listen()`. Left untouched to avoid unrelated cleanup; only the `BaseBloc` extension and no-op `close()` override removal were applied here.

## Test plan
- [x] `flutter analyze` — 0 issues (full project)
- [x] `flutter test test/unit/ test/widget/` — all 3823 tests pass, 0 failures
- [x] Ran each migrated BLoC's dedicated unit test file individually to confirm behavior is unchanged