### PR TITLE
Story 35.5: Scope app-root BLoCs to route/page level

### DIFF
--- a/lib/app/play_with_me_app.dart
+++ b/lib/app/play_with_me_app.dart
@@ -26,8 +26,6 @@ import 'package:play_with_me/features/auth/presentation/bloc/authentication/auth
 import 'package:play_with_me/features/auth/presentation/bloc/authentication/authentication_state.dart';
 import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
 import 'package:play_with_me/features/auth/presentation/bloc/login/login_bloc.dart';
-import 'package:play_with_me/features/auth/presentation/bloc/registration/registration_bloc.dart';
-import 'package:play_with_me/features/auth/presentation/bloc/password_reset/password_reset_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/pages/stats_page.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/locale_preferences/locale_preferences_bloc.dart';
 import 'package:play_with_me/features/profile/presentation/bloc/locale_preferences/locale_preferences_event.dart';
@@ -87,22 +85,34 @@ class PlayWithMeApp extends StatelessWidget {
           create: (context) =>
               sl<AuthenticationBloc>()..add(const AuthenticationStarted()),
         ),
+        // InvitationBloc is at app root because the shared PlayWithMeAppBar
+        // (rendered on nearly every authenticated page) reads it directly
+        // for the invitation badge, and the auth listener below loads
+        // pending invitations immediately after login, before any page
+        // exists. Scoping it to a page would break the badge everywhere else.
         BlocProvider<InvitationBloc>(create: (context) => sl<InvitationBloc>()),
-        BlocProvider<LoginBloc>(create: (context) => sl<LoginBloc>()),
-        BlocProvider<RegistrationBloc>(
-          create: (context) => sl<RegistrationBloc>(),
-        ),
-        BlocProvider<PasswordResetBloc>(
-          create: (context) => sl<PasswordResetBloc>(),
-        ),
+        // DeepLinkBloc is at app root because it listens for deep links for
+        // the entire app lifetime (including cold start), and its state is
+        // read by the auth listener below before any page is pushed.
         BlocProvider<DeepLinkBloc>(
           create: (context) =>
               sl<DeepLinkBloc>()..add(const InitializeDeepLinks()),
         ),
+        // InviteJoinBloc is at app root because the auth/deep-link listeners
+        // below fire events into it (ValidateInviteToken/ProcessPendingInvite)
+        // before any page is pushed; pushed pages receive it afterward via
+        // BlocProvider.value.
         BlocProvider<InviteJoinBloc>(create: (context) => sl<InviteJoinBloc>()),
+        // GameInvitationsBloc is at app root because the shared
+        // PlayWithMeAppBar badge and multiple pages (HomePage, MyGamesPage)
+        // read it, and the auth listener below loads invitations
+        // immediately after login.
         BlocProvider<GameInvitationsBloc>(
           create: (context) => sl<GameInvitationsBloc>(),
         ),
+        // LocalePreferencesBloc is at app root because it drives
+        // MaterialApp.locale directly via the BlocSelector wrapping
+        // MaterialApp below.
         BlocProvider<LocalePreferencesBloc>(
           create: (context) => LocalePreferencesBloc(
             repository: sl<LocalePreferencesRepository>(),
@@ -270,7 +280,10 @@ class PlayWithMeApp extends StatelessWidget {
                       if (authState is AuthenticationAuthenticated) {
                         return const HomePage();
                       } else if (authState is AuthenticationUnauthenticated) {
-                        return const LoginPage();
+                        return BlocProvider<LoginBloc>(
+                          create: (_) => sl<LoginBloc>(),
+                          child: const LoginPage(),
+                        );
                       } else {
                         return const _SplashScreen();
                       }

--- a/lib/app/route_generator.dart
+++ b/lib/app/route_generator.dart
@@ -1,5 +1,10 @@
 // Generates routes for the app, including deep link handling for /invite/{token}.
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:play_with_me/core/services/service_locator.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/login/login_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/password_reset/password_reset_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/registration/registration_bloc.dart';
 import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
 import 'package:play_with_me/features/auth/presentation/pages/registration_page.dart';
 import 'package:play_with_me/features/auth/presentation/pages/password_reset_page.dart';
@@ -18,17 +23,29 @@ class RouteGenerator {
       // Deep link invite route — no dedicated page yet.
       // The DeepLinkBloc handles token extraction and storage.
       // For now, redirect to login page so auth flow can proceed.
-      return _buildRoute(const LoginPage(), settings);
+      return _buildRoute(_buildLoginPage(), settings);
     }
 
     // Standard named routes
     switch (routeName) {
       case '/login':
-        return _buildRoute(const LoginPage(), settings);
+        return _buildRoute(_buildLoginPage(), settings);
       case '/register':
-        return _buildRoute(const RegistrationPage(), settings);
+        return _buildRoute(
+          BlocProvider<RegistrationBloc>(
+            create: (_) => sl<RegistrationBloc>(),
+            child: const RegistrationPage(),
+          ),
+          settings,
+        );
       case '/forgot-password':
-        return _buildRoute(const PasswordResetPage(), settings);
+        return _buildRoute(
+          BlocProvider<PasswordResetBloc>(
+            create: (_) => sl<PasswordResetBloc>(),
+            child: const PasswordResetPage(),
+          ),
+          settings,
+        );
       case '/my-community':
         return _buildRoute(const MyCommunityPage(), settings);
       default:
@@ -41,6 +58,13 @@ class RouteGenerator {
     RouteSettings settings,
   ) {
     return MaterialPageRoute(builder: (_) => page, settings: settings);
+  }
+
+  static Widget _buildLoginPage() {
+    return BlocProvider<LoginBloc>(
+      create: (_) => sl<LoginBloc>(),
+      child: const LoginPage(),
+    );
   }
 }
 

--- a/test/unit/app/route_generator_test.dart
+++ b/test/unit/app/route_generator_test.dart
@@ -1,10 +1,11 @@
 // Validates RouteGenerator generates correct routes for standard and deep link paths.
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:play_with_me/app/route_generator.dart';
-import 'package:play_with_me/features/auth/presentation/pages/login_page.dart';
-import 'package:play_with_me/features/auth/presentation/pages/registration_page.dart';
-import 'package:play_with_me/features/auth/presentation/pages/password_reset_page.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/login/login_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/password_reset/password_reset_bloc.dart';
+import 'package:play_with_me/features/auth/presentation/bloc/registration/registration_bloc.dart';
 import 'package:play_with_me/features/friends/presentation/pages/my_community_page.dart';
 
 void main() {
@@ -17,7 +18,12 @@ void main() {
 
         expect(route, isA<MaterialPageRoute>());
         final pageRoute = route as MaterialPageRoute;
-        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+        // LoginPage is now wrapped in its own page-scoped BlocProvider
+        // (Story 35.5) instead of relying on an app-root LoginBloc.
+        expect(
+          pageRoute.builder(MockBuildContext()),
+          isA<BlocProvider<LoginBloc>>(),
+        );
       });
 
       test('generates RegistrationPage for /register', () {
@@ -27,7 +33,10 @@ void main() {
 
         expect(route, isA<MaterialPageRoute>());
         final pageRoute = route as MaterialPageRoute;
-        expect(pageRoute.builder(MockBuildContext()), isA<RegistrationPage>());
+        expect(
+          pageRoute.builder(MockBuildContext()),
+          isA<BlocProvider<RegistrationBloc>>(),
+        );
       });
 
       test('generates PasswordResetPage for /forgot-password', () {
@@ -37,7 +46,10 @@ void main() {
 
         expect(route, isA<MaterialPageRoute>());
         final pageRoute = route as MaterialPageRoute;
-        expect(pageRoute.builder(MockBuildContext()), isA<PasswordResetPage>());
+        expect(
+          pageRoute.builder(MockBuildContext()),
+          isA<BlocProvider<PasswordResetBloc>>(),
+        );
       });
 
       test('generates MyCommunityPage for /my-community', () {
@@ -59,7 +71,10 @@ void main() {
 
         expect(route, isA<MaterialPageRoute>());
         final pageRoute = route as MaterialPageRoute;
-        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+        expect(
+          pageRoute.builder(MockBuildContext()),
+          isA<BlocProvider<LoginBloc>>(),
+        );
       });
 
       test('generates LoginPage for invite deep link with complex token', () {
@@ -69,7 +84,10 @@ void main() {
 
         expect(route, isA<MaterialPageRoute>());
         final pageRoute = route as MaterialPageRoute;
-        expect(pageRoute.builder(MockBuildContext()), isA<LoginPage>());
+        expect(
+          pageRoute.builder(MockBuildContext()),
+          isA<BlocProvider<LoginBloc>>(),
+        );
       });
     });
 


### PR DESCRIPTION
## Summary

Implements Story 35.5 (issue #882) of Epic 35 (Performance Optimization).

- Moves `LoginBloc`, `RegistrationBloc`, and `PasswordResetBloc` from the app-root `MultiBlocProvider` to page/route-scoped `BlocProvider`s, created in `RouteGenerator` (and in `play_with_me_app.dart`'s `home:` builder for the unauthenticated case). Each BLoC is now created when its page is pushed and disposed when popped, per CLAUDE.md §9c.
- Adds one-line justification comments (matching the existing `ChampionshipListBloc` pattern) for the BLoCs that remain at app root: `InvitationBloc`, `DeepLinkBloc`, `InviteJoinBloc`, `GameInvitationsBloc`, `LocalePreferencesBloc`.

### Deviation from the literal issue spec

The issue named 6 BLoCs to move: `InvitationBloc`, `LoginBloc`, `RegistrationBloc`, `PasswordResetBloc`, `InviteJoinBloc`, `GameInvitationsBloc`. Only 3 of these (`LoginBloc`, `RegistrationBloc`, `PasswordResetBloc`) were moved. The other 3 were kept at root because they are genuinely cross-cutting/session-scoped:

- **`InvitationBloc`** — read unconditionally (no try/catch) by the shared `PlayWithMeAppBar`, rendered on nearly every authenticated page, for the invitation badge. Scoping it to one page would break the badge everywhere else.
- **`GameInvitationsBloc`** — also read by the shared app bar (with graceful degradation) plus multiple pages (`HomePage`, `MyGamesPage`); loaded immediately after login by the root auth listener.
- **`InviteJoinBloc`** — fired into by root auth/deep-link listeners *before* any page exists (`ValidateInviteToken`/`ProcessPendingInvite`), then handed to pushed pages via `BlocProvider.value`.

Moving these would violate the issue's own "no navigation flow breaks" acceptance criterion (invitation badge disappearing on non-owning pages, invite deep links failing before a page exists). This was discussed and explicitly approved before implementation.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/unit/ test/widget/` — 3823 passed, 0 failed (3 pre-existing unrelated skips)
- [x] `dart format --set-exit-if-changed` on all edited files — 0 changes needed
- [x] Manually traced login, registration, password-reset, invite-join, and game-invitations flows through the updated provider wiring